### PR TITLE
Using aria-labelledby for unconcatenated labels

### DIFF
--- a/wcag20/sources/ARIA-tech-src.xml
+++ b/wcag20/sources/ARIA-tech-src.xml
@@ -1473,7 +1473,7 @@ return you back to the main page</div>
  					<eg-group>
 						<head>A financial journal entry</head>
 						<description>
-							<p>A financial journal entry table combining concatenated and non-concatenated input labels.</p>
+							<p>A financial journal entry table combining concatenated and unconcatenated input labels.</p>
 						<codeblock xml:space="preserve"><![CDATA[<h1>New Journal Entry</h1>
 <div><label for="date">Date </label><input type="text" id="date" aria-describedby="format" /></div>
 <span id="format">Format dd/mm/yyyy</span>


### PR DESCRIPTION
When remediating form based systems I often come across input fields that developers have dumped into data tables without labels. The concatenated label examples in ARIA9 are fantastic but developers are sometimes looking for simpler examples.
