### PR TITLE
Technique SCR30 uses outdated JavaScript, doesn’t work in browsers

### DIFF
--- a/wcag20/sources/script-tech-src.xml
+++ b/wcag20/sources/script-tech-src.xml
@@ -1695,7 +1695,7 @@ var linkContext = {
 function doExpand() {
 	var links = document.links;
 	
-	for each (link in links) {
+	for (link of links) {
 		var cn = link.className;
 		if (linkContext[cn]) {
 			span = link.appendChild(document.createElement("span"));


### PR DESCRIPTION
I got an email in German about an issue with SCR30: The example isn’t working as the JavaScript has an error.

Using the `for each (… in …)` is [deprecated in JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FStatements%2Ffor_each...in), and it looks like browsers have problems interpreting it. If we switch to `for (… of …)` it works like a charm in my browser (Firefox).
