### PR TITLE
ARIA1 Fix typos and indentation issues

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA1.xml
+++ b/wcag20/sources/techniques/aria/ARIA1.xml
@@ -163,7 +163,7 @@ Customize </button></span></p>
          </description>
          <code xml:space="preserve"><![CDATA[<html lang="en-us">
 <head>
-<meta http-equiv="content-type" content="text/xhtml; charset=utf-8" />
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>Demonstration of aria-describedby property</title>
 <style type="text/css">
 div.form p { clear:left; margin: 0.3em 0;}


### PR DESCRIPTION
This pull request includes typo and indentation issues fixes.
- Removed trailing spaces
- Fixed typos
  - s/&lt;html lang="en-us"">/&lt;html lang="en-us">/
  - s/application:xhtml+xml/application\/xhtml+xml/
- Fixed XHTML 1.1 + ARIA DOCTYPE in example 5 as per http://www.w3.org/TR/2014/REC-wai-aria-20140320/appendices#xhtml_dtd
- Fixed indentation of examples
