### PR TITLE
ARIA7 Remove Example 1

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA7.xml
+++ b/wcag20/sources/techniques/aria/ARIA7.xml
@@ -57,23 +57,16 @@
          </ulist>
          <p>
             <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                 href="http://3needs.org/en/testing/code/aria-labelledby-for-link-purpose.html">See full testing results for Example 1</loc>
-         </p>
-         <p>
-            <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                 href="http://3needs.org/en/testing/code/aria-labelledby-filetype.html">See full testing results for Example 2</loc>
+                 href="http://3needs.org/en/testing/code/aria-labelledby-filetype.html">See full testing results for Example 1</loc>
          </p>
          <p>David <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                 href="http://davidmacd.com/test/labelledby-on-a-link.html">tested</loc> on Aug 25, 2013... Example 2 and 3 are still not sufficiently supported.</p>
+                 href="http://davidmacd.com/test/labelledby-on-a-link.html">tested</loc> on Aug 25, 2013... Example 1 and 2 are still not sufficiently supported.</p>
          <ulist>
             <item>
-               <p>Example 1 ok on JAWS, VoiceOver. NVDA ignores labelledby on an anchor</p>
+               <p>Example 1: JAWS 14 in FF, IE 10 read the entire paragraph for each link which is confusing and chatty. VoiceOver for Mountain Lion in Safari 6 same as JAWS. NVDA ignores labelledby on an anchor (unsuccessful implementation)</p>
             </item>
             <item>
-               <p>Example 2: JAWS 14 in FF, IE 10 read the entire paragraph for each link which is confusing and chatty. VoiceOver for Mountain Lion in Safari 6 same as JAWS. NVDA ignores labelledby on an anchor (unsuccessful implementation)</p>
-            </item>
-            <item>
-               <p>Example 3: JAWS 14 in FF, IE 10 read the entire paragraph for each link which is confusing and chatty, VoiceOver for Mountain Lion in Safari 6 OK. NVDA ignores labelledby on an anchor (unsuccessful implementation)</p>
+               <p>Example 2: JAWS 14 in FF, IE 10 read the entire paragraph for each link which is confusing and chatty, VoiceOver for Mountain Lion in Safari 6 OK. NVDA ignores labelledby on an anchor (unsuccessful implementation)</p>
             </item>
          </ulist>
       </ua-issue>
@@ -89,16 +82,6 @@
               href="http://www.w3.org/TR/html-aapi/#a-element">accessible name and description calculation for links</loc> in the HTML to Platform Accessibility APIs Implementation Guide.</p>
    </description>
    <examples>
-      <eg-group>
-         <head>Providing additional information for links</head>
-         <description>
-            <p>This example should replace the "read more" link text at the end of the teaser text with the content of the <el>h2</el> heading referenced by <att>aria-labelledby</att>.</p>
-            <codeblock xml:space="preserve"><![CDATA[<h2 id="headline">Storms hit east coast</h2>
-
-<p>Torrential rain and gale force winds have struck the east coast, causing flooding in many coastal towns.
-   <a href="news.html" aria-labelledby="headline">Read more...</a></p>]]></codeblock>
-         </description>
-      </eg-group>
       <eg-group>
          <head>Concatenating link text from multiple sources</head>
          <description>
@@ -118,7 +101,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/html-aapi/#accessible-name-and-description-calculation">HTML to Platform Accessibility APIs Implementation Guide: Accessible Name and Description Calculation</loc> 
+                       href="http://www.w3.org/TR/html-aapi/#accessible-name-and-description-calculation">HTML to Platform Accessibility APIs Implementation Guide: Accessible Name and Description Calculation</loc>
                </p>
             </item>
          </ulist>


### PR DESCRIPTION
Changing accessible name from rendered/visible text  generally causes accessibility issues. Especially, changing accessible name completely different one from rendered/visible text causes serious accessibility issues.

ARIA 1.0 Recommendation provides some examples of similar issues. In a note of |aria-hidden| 
http://www.w3.org/TR/2014/REC-wai-aria-20140320/states_and_properties#aria-hidden

> Note: Authors are advised to use extreme caution and consider a wide range of disabilities when hiding visibly rendered content from assistive technologies. For example, a sighted, dexterity-impaired individual may use voice-controlled assistive technologies to access a visual interface. If an author hides visible link text "Go to checkout" and exposes similar, yet non-identical link text "Check out now" to the accessibility API, the user may be unable to access the interface they perceive using voice control. Similar problems may also arise for screen reader users. For example, a sighted telephone support technician may attempt to have the blind screen reader user click the "Go to checkout" link, which they may be unable to find using a type-ahead item search ("Go to…").

As Example 1 of ARIA7 changes accessible name from "Read more..." to "Storms hit east coast", people who use voice control or who are blind and communicating with sighted person may face issues.

Thus we should get rid of Example 1 of ARIA7.
