### PR TITLE
ARIA2 Remove "when there is a visual cue to this effect." from objective.

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA2.xml
+++ b/wcag20/sources/techniques/aria/ARIA2.xml
@@ -18,7 +18,7 @@
       </ua-issue>
    </ua-issues>
    <description>
-      <p>The objective of this technique is to indicate in a programmatically determined way that the completion of a user input field is mandatory for successful submission of a form when there is a visual cue to this effect.</p>
+      <p>The objective of this technique is to indicate in a programmatically determined way that the completion of a user input field is mandatory for successful submission of a form.</p>
       <p>The fact that the element is required is often visually presented (via a text or non-text symbol, or text indicating input is required or color / styling) but this is not programmatically determinable as part of the field's name.</p>
       <p>The WAI-ARIA <prop>aria-required</prop> property indicates that user input is required before submission. The <prop>aria-required</prop> property can have values of <attval>true</attval> or <attval>false</attval>. For example, if a user must fill in an address field, then <att>aria-required</att> is set to <attval>true</attval>.</p>
       <note>
@@ -35,19 +35,19 @@
             <p>The <prop>required</prop> property is indicated by an asterisk placed next to the label element:</p>
             <codeblock xml:space="preserve"><![CDATA[
 <form action="#" method="post"  id="login1" onsubmit="return errorCheck1()">
-  <p>Note: [*]denotes mandatory field</p> 
+  <p>Note: [*]denotes mandatory field</p>
   <p>
-    <label for="usrname">Login name: </label> 
+    <label for="usrname">Login name: </label>
     <input type="text" name="usrname" id="usrname" aria-required="true"/>[*]
   </p>
   <p>
-    <label for="pwd">Password</label> 
+    <label for="pwd">Password</label>
     <input type="password" name="pwd" id="pwd" size="12" aria-required="true" />[*]
-  </p> 
+  </p>
   <p>
     <input type="submit" value="Login" id="next_btn" name="next_btn"/>
   </p>
- 
+
 </form>		]]></codeblock>
          </description>
       </eg-group>
@@ -58,26 +58,26 @@
             <codeblock xml:space="preserve"><![CDATA[<head>
 <form action="#" method="post" id="step1" onsubmit="return errorCheck2()">
   <p>
-    <label for="fname">First name: </label> 
+    <label for="fname">First name: </label>
     <input type="text" id="fname" aria-required="true" />
     [required]
   </p>
   <p>
-    <label for="mname">Middle name: </label> 
+    <label for="mname">Middle name: </label>
     <input type="text" id="mname" />
   </p>
   <p>
-    <label for="lname">Last name: </label> 
+    <label for="lname">Last name: </label>
     <input type="text" id="lname" aria-required="true" />
     [required]
   </p>
   <p>
-    <label for="email">Email address: </label> 
+    <label for="email">Email address: </label>
     <input type="text" id="email" aria-required="true" />
     [required]
   </p>
   <p>
-    <label for="zip_post">Zip / Postal code: </label> 
+    <label for="zip_post">Zip / Postal code: </label>
     <input type="text" id="zip_post" size="6" aria-required="true" />
     [required]
   </p>
@@ -99,17 +99,17 @@
       aria-required="true" name="acctnum" />
 
  <p id="radio_label">Please send an alert when balance exceeds $3,000.</p>
- 
+
  <ul  id="rg" role="radiogroup" aria-labelledby="radio_label">
     <li id="rb1" role="radio" aria-required="true">Yes</li>
     <li id="rb2" role="radio" aria-required="true">No</li>
- </ul>	
-</form> 
+ </ul>
+</form>
  ]]></codeblock>
             <codeblock xml:space="preserve"><![CDATA[<head>
 [aria-required=true] {
   border: red thin solid;
-} 
+}
 [aria-required=true]:before {
   content: url('/iconStar.gif');
 }
@@ -127,10 +127,10 @@
          </description>
          <code xml:space="preserve"><![CDATA[
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1
     For Accessible Adaptable Applications//EN"
   "http://www.w3.org/WAI/ARIA/schemata/xhtml-aria-1.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" 
+<html xmlns="http://www.w3.org/1999/xhtml"
           xml:lang="en">
   <head>
     <title>Required Input</title>
@@ -163,11 +163,11 @@
          <code xml:space="preserve"><![CDATA[<head>
  <script type="text/javascript">
  //<![CDATA[
- 
+
  // array or ids on the required fields on this page
  var requiredIds = new Array( "firstName", "lastName");
- 
- // function that is run after the page has loaded to set the aria-required property on each of the 
+
+ // function that is run after the page has loaded to set the aria-required property on each of the
  //elements in requiredIds array of id values
  function setRequired(){
  	if (requiredIds){
@@ -183,13 +183,13 @@
  </script>
  </head>
  <body>
- <p>Please enter the following data.  Required fields have been programmatically identified 
+ <p>Please enter the following data.  Required fields have been programmatically identified
  as required and  marked with an asterisk (*) following the field label.</p>
  <form action="submit.php">
  <p>
- <label for="firstName">First Name *: </label><input type="text" name="firstName" 
+ <label for="firstName">First Name *: </label><input type="text" name="firstName"
     id="firstName" value="" />
- <label for="lastName">Last Name *: </label><input type="text" name="lastName" 
+ <label for="lastName">Last Name *: </label><input type="text" name="lastName"
     id="lastName"  value="" />
  </p>
  </form>
@@ -209,11 +209,11 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/wai-aria-practices/">WAI-ARIA 1.0 Authoring Practices</loc> 
+                       href="http://www.w3.org/TR/wai-aria-practices/">WAI-ARIA 1.0 Authoring Practices</loc>
                </p>
             </item>
             <item>
-               <p> 
+               <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
                        href="http://www.deque.com/blog/aria-requiredtrue-wcag-2-compliance-practice/">Aria-required=true: WCAG 2 Compliance versus Best Practice</loc>
                </p>


### PR DESCRIPTION
The application of ARIA2 should not be limited whether "there is a visual cue to this effect." Because there could be audio or other sensory cues if authors use CSS or JavaScript. Also, the "Tests" procedures don't check whether "there is a visual cue to this effect."

We should remove "there is a visual cue to this effect." from the objective.
