### PR TITLE
Remove layout table section from H39 and H73

### DIFF
--- a/wcag20/sources/techniques/html/H39.xml
+++ b/wcag20/sources/techniques/html/H39.xml
@@ -23,13 +23,15 @@
             whereas the <att>summary</att> attribute gives an overview of the purpose or explains
             how to navigate the table. If both are used, the <el>caption</el> should not duplicate
             information in the <att>summary</att>.</p>
-      <p>Although WCAG 2.0 does not prohibit the use of layout tables, CSS-based layouts are
-            recommended in order to retain the defined semantic meaning of the HTML and XHTML
-            <el>table</el> elements and to conform to the coding practice of separating
-            presentation from content. If a table is used for layout, the <el>caption</el> element
-            is not used. The purpose of a layout table is simply to control the placement of
-            content; the table itself is “transparent" to the user. A <el>caption</el> would "break"
-            this transparency by calling attention to the table. </p>
+      <note>
+         <p>Although WCAG 2.0 does not prohibit the use of layout tables, CSS-based layouts are
+               recommended in order to retain the defined semantic meaning of the HTML and XHTML
+               <el>table</el> elements and to conform to the coding practice of separating
+               presentation from content. If a table is used for layout, the <el>caption</el> element
+               is not used. The purpose of a layout table is simply to control the placement of
+               content; the table itself is “transparent" to the user. A <el>caption</el> would "break"
+               this transparency by calling attention to the table. See <specref ref="F46" /> for details..</p>
+      </note>
    </description>
    <examples>
       <eg-group>
@@ -52,36 +54,21 @@
       </see-also>
    </resources>
    <related-techniques>
-      <relatedtech idref="H43"/>
-      <relatedtech idref="H63"/>
+      <relatedtech idref="H51"/>
       <relatedtech idref="H73"/>
+      <relatedtech idref="F46"/>
    </related-techniques>
    <tests>
       <procedure>
+         <p>For each data table: </p>
          <olist>
             <item>
-               <p>Check for layout tables: determine whether the content has a relationship with
-                  other content in both its column and its row. </p>
-               <olist>
-                  <item>
-                     <p>If “no," the table is a layout table.</p>
-                  </item>
-                  <item>
-                     <p>If “yes," the table is a data table.</p>
-                  </item>
-               </olist>
-            </item>
-            <item>
-               <p>If the table is a layout table, check that the table does not include a
-                    <el>caption</el> element.</p>
-            </item>
-            <item>
-               <p>If the table is a data table and it includes a <el>caption</el> element, check
+               <p>If the table includes a <el>caption</el> element, check
                   that the <el>caption</el> identifies the table</p>
             </item>
             <item>
                <p>If both a <att>summary</att> attribute and a <el>caption</el> element are present
-                  for this data table, check that the <att>summary</att> does not duplicate the
+                  for the table, check that the <att>summary</att> does not duplicate the
                     <el>caption</el>.</p>
             </item>
          </olist>
@@ -89,10 +76,7 @@
       <expected-results>
          <ulist>
             <item>
-               <p>For layout tables, #2 is true.</p>
-            </item>
-            <item>
-               <p>For data tables, #3 and #4 are true.</p>
+               <p>#1 and #2 are true.</p>
             </item>
          </ulist>
       </expected-results>

--- a/wcag20/sources/techniques/html/H73.xml
+++ b/wcag20/sources/techniques/html/H73.xml
@@ -20,20 +20,20 @@
       <p>The <att>summary</att> attribute may be used whether or not the table includes a
               <el>caption</el> element. If both are used, the <att>summary</att> should not
             duplicate the <el>caption</el>.</p>
-      <p> Although WCAG 2 does not prohibit the use of layout tables, CSS-based layouts are
-            recommended in order to retain the defined semantic meaning of the HTML <el>table</el>
-            elements and to conform to the coding practice of separating presentation from content.
-            However, if a layout table is used, then the <att>summary</att> attribute is not used or
-            is null. The purpose of a layout table is simply to control the placement of content;
-            the table itself is “transparent" to the user. A <att>summary</att> would “break" this
-            transparency by calling attention to the table. A null <att>summary</att>
-              (<code><![CDATA[
-							]]><att>summary</att><![CDATA[=""]]></code>) on layout tables is acceptable.</p>
+      <note>
+         <p> Although WCAG 2 does not prohibit the use of layout tables, CSS-based layouts are
+               recommended in order to retain the defined semantic meaning of the HTML <el>table</el>
+               elements and to conform to the coding practice of separating presentation from content.
+               However, if a layout table is used, then the <att>summary</att> attribute is not used or
+               is null. The purpose of a layout table is simply to control the placement of content;
+               the table itself is “transparent" to the user. A <att>summary</att> would “break" this
+               transparency by calling attention to the table. A null <att>summary</att>
+                 (<code><att>summary</att><![CDATA[=""]]></code>) on layout tables is acceptable. See <specref ref="F46" /> for details.</p>
+      </note>
    </description>
    <examples>
       <eg-group>
-         <head>A data table with a <att>summary</att> but no <el>caption</el>
-						   </head>
+         <head>A data table with a <att>summary</att> but no <el>caption</el></head>
          <description>
             <p>This example shows a bus schedule. The route number and direction are included in
                 the <att>summary</att> along with information on how to use the schedule.</p>
@@ -91,45 +91,28 @@ Service begins at 4:00 AM and ends at midnight.">
    <related-techniques>
       <relatedtech idref="H39"/>
       <relatedtech idref="H51"/>
+      <relatedtech idref="F46"/>
    </related-techniques>
    <tests>
       <procedure>
+         <p>For each data table: </p>
          <olist>
             <item>
-               <p>Check for layout tables: determine whether the content has a relationship with
-                  other content in both its column and its row. </p>
-               <olist>
-                  <item>
-                     <p>If “no," the table is a layout table.</p>
-                  </item>
-                  <item>
-                     <p>If “yes," the table is a data table.</p>
-                  </item>
-               </olist>
-            </item>
-            <item>
-               <p>If the table is a layout table, check that the <att>summary</att> attribute is
-                  not present or <att>summary</att> attribute is null.</p>
-            </item>
-            <item>
-               <p>If the table is a data table and a <att>summary</att> is present, check that the
-                    <att>summary</att> attribute describes the table's organization or explains how
+               <p>If a <att>summary</att> is present, check that the <att>summary</att>
+                  attribute describes the table's organization or explains how
                   to use the table</p>
             </item>
             <item>
                <p>If both a <att>summary</att> attribute and a <el>caption</el> element are present
-                  for this data table, check that the <att>summary</att> does not duplicate the
-                    <el>caption</el>.</p>
+                  for the data table, check that the <att>summary</att> does not
+                  duplicate the <el>caption</el>.</p>
             </item>
          </olist>
       </procedure>
       <expected-results>
          <ulist>
             <item>
-               <p>For layout tables, #2 is true.</p>
-            </item>
-            <item>
-               <p>For data tables, #3 and #4 are true.</p>
+               <p>#1 and #2 are true.</p>
             </item>
          </ulist>
       </expected-results>


### PR DESCRIPTION
H39 and H73 don't need to mention layout table cases because F46 describes common failure cases of layout tables.

H39: Using caption elements to associate data table captions with data tables
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/H39.html

H73: Using the summary attribute of the table element to give an overview of data tables
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/H73.html

F46: Failure of Success Criterion 1.3.1 due to using th elements, caption elements, or non-empty summary attributes in layout tables
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/F46.html

In this pull request, 
- Changed layout table sentence in description to a note
- Added F46 to related techniques
  - Tweaked related techniques in H39 to align with H73 and F46
- Removed layout table check procedures in tests
