### PR TITLE
Clarify the diffrence between F40 and F41

### DIFF
--- a/wcag20/sources/techniques/failures/F40.xml
+++ b/wcag20/sources/techniques/failures/F40.xml
@@ -32,7 +32,7 @@
                                 http://www.example.com/newpage after a time limit of 5 seconds.</p>
          </description>
          <code><![CDATA[
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
    <head>     
       <title>Do not use this!</title>     
       <meta http-equiv="refresh"
@@ -62,14 +62,10 @@
          </ulist>
       </see-also>
    </resources>
-   <!--
-Related techniques
-<ulist>
-    <item><p>
-        <loc href="">Using meta refresh to create an instant client-side redirect</loc>
-    </p></item>
-</ulist>
--->
+   <related-techniques>
+      <relatedtech idref="SVR1"/>
+      <relatedtech idref="H76"/>
+   </related-techniques>
    <tests>
       <procedure>
          <olist>

--- a/wcag20/sources/techniques/failures/F41.xml
+++ b/wcag20/sources/techniques/failures/F41.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE technique
   SYSTEM "../../xmlspec.dtd">
 <technique id="F41">
-   <short-name>Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh with a
-                    time-out</short-name>
+   <short-name>Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page</short-name>
    <applicability>
       <p>HTML and XHTML</p>
    </applicability>
@@ -37,7 +36,7 @@
                                 seconds.)</p>
          </description>
          <code><![CDATA[
-<html xmlns="http://www.w3.org/1999/xhtml">   
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>     
     <title>HTML Techniques for WCAG 2.0</title>     
     <meta http-equiv="refresh" content="60" />   
@@ -48,32 +47,8 @@
 </html>
 ]]></code>
       </eg-group>
-      <eg-group role="failure">
-         <description>
-            <p>This is a deprecated example that redirects the user to another page
-                                after a number of seconds. Content developers are recommended to
-                                user server-side redirects instead. (The number in the
-                                <code><![CDATA[content]]></code> attribute is the refresh interval in
-                            seconds.)</p>
-         </description>
-         <code><![CDATA[
-<html xmlns="http://www.w3.org/1999/xhtml">   
-  <head>     
-    <title>The Tudors</title>     
-    <meta http-equiv="refresh" content="10;URL='http://example.com/'" />   
-  </head>   
-  <body>
-    <p>This page has moved to a <a href="http://example.com/">
-    example.com</a>. Please note that we now have our own 
-    domain name and will redirect you in a few seconds. Please update 
-    your links and bookmarks.</p>
-  </body> 
-</html>]]></code>
-      </eg-group>
    </examples>
-   <related-techniques>
-      <relatedtech idref="SVR1"/>
-   </related-techniques>
+   <related-techniques />
    <tests>
       <procedure>
          <olist>
@@ -81,10 +56,9 @@
                <p> Find <code><![CDATA[meta]]></code> elements in the document. </p>
             </item>
             <item>
-               <p> For each <code><![CDATA[meta]]></code> element, check if it contains the
-                                    attribute <code><![CDATA[http-equiv]]></code> with value "refresh"
-                                    (case-insensitive) and the <code><![CDATA[content]]></code> attribute with a
-                                    number (representing seconds) greater than 0. </p>
+               <p>For each <code><![CDATA[meta]]></code> element, check if it contains
+               the <code><![CDATA[http-equiv]]></code> attribute with value "refresh" (case-insensitive) and
+               the <code><![CDATA[content]]></code> attribute with a number (representing seconds) equals to or greater than 0 and without "; url=" (case-insensitive). </p>
             </item>
             <item>
                <p>check to see if there is a mechanism to turn off the refresh. </p>


### PR DESCRIPTION
F41 discusses the reloading the page and F40 discusses the redirecting the page. Currently, however , the difference between the  two common failures are not clear. We should clarify the difference.

F40: Failure of Success Criterion 2.2.1 and 2.2.4 due to using meta redirect with a time limit
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/F40.html

F41: Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh with a time-out
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/F41.html

In this pull request, 
- Changed summary of F41 to make its objective clear
  - Reloading without user permissions is an issue regardless of refresh interval
- Removed Example 2 of F41 because it's an example of F40
- Removed SVR1 from related techniques of F41 because SVR1 discusses redirecting not reloading
- Added SVR1 and H76 to F40 as related techniques (now authors can fix their issues)
- Changed tests in F40
  - Make the test fails in case content="0"
    - Reloading without user permissions is an issue regardless of refresh interval
  - Make the test not fail in case content attribute contains "; url="
    - It's a failure of F40
- (bonus) Added lang attribute to html element

H76: Using meta refresh to create an instant client-side redirect
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/H76.html

SVR1: Implementing automatic redirects on the server side instead of on the client side
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/SVR1.html
