### PR TITLE
Clarify F68 is applicable for controls that use visible labels

### DIFF
--- a/wcag20/sources/techniques/failures/F68.xml
+++ b/wcag20/sources/techniques/failures/F68.xml
@@ -108,13 +108,13 @@
                <p>Check that these input elements have a programmatically determined label associated in one of the following ways:</p>
                <olist>
                   <item>
-                     <p>the text label is contained in a <el>label</el> element that is correctly associated to the respective <el>input</el> element via the label's <att>for</att> attribute (the <att>id</att> given as value in the <att>for</att> attribute matches the <att>id</att> of the input element).</p>
+                     <p>the text label is contained in a <el>label</el> element that is correctly associated to the respective control element via the label's <att>for</att> attribute (the <att>id</att> given as value in the <att>for</att> attribute matches the <att>id</att> of the control element).</p>
                   </item>
                   <item>
                      <p>the control is contained within a <el>label</el> element that contains the label text.</p>
                   </item>
                   <item>
-                     <p>the text label is correctly programmatically associated with the <el>input</el> element via the <att>aria-labelledby</att> attribute (the <att>id</att> given as value in the <att>aria-labelledby</att> attribute matches the <att>id</att> of the text element).</p>
+                     <p>the text labels are correctly programmatically associated with the control element via the <att>aria-labelledby</att> attribute (for each the <att>id</att> given as value in the <att>aria-labelledby</att> attribute matches the <att>id</att> of the text label element).</p>
                   </item>
                </olist>
             </item>


### PR DESCRIPTION
F68 is applicable for controls that use visible labels.

> Applicability
> 
> HTML and XHTML controls that use visible labels

F68: Failure of Success Criterion 1.3.1 and 4.1.2 due to the association of label and user interface controls not being programmatically determined
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/F68.html

Thus we should remove unrelated example, related techniques and check conditions.

Example 3 is the same example of H65 which is a technique for controls that cannot use visible labels. So this pull request removed Example 3.

H65: Using the title attribute to identify form controls when the label element cannot be used
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/H65.html

The aria-label and title are techniques for controls that cannot use visible labels. Thus this pull request removed related techniques and check conditions. As the aria-labelledby can be used for controls that use visible labels such as controls in the data table, this pull request doesn't modify that.

Additional changes are
- Updated first sentence of test procedures to match notes of description (applicable input type is not limited to radio, checkbox, text, file or password)
- Replaced "input element" to "control element" in test procedure to match "For all <el>input</el> elements ... and all textarea and select elements"
- Make sure that ids in aria-labelledby are ids of the text label element instead of the control control
