### PR TITLE
F55: Remove Example 3 as it's same as Example 2

### DIFF
--- a/wcag20/sources/techniques/failures/F55.xml
+++ b/wcag20/sources/techniques/failures/F55.xml
@@ -29,9 +29,6 @@
       <eg-group role="failure">
          <code><![CDATA[<a onFocus="this.blur()" href="Page.html"><img src="myImage.gif"></a> ]]></code>
       </eg-group>
-      <eg-group role="failure">
-         <code><![CDATA[<a href="link.html" onfocus="if(this.blur)this.blur();">Link Phrase</a> ]]></code>
-      </eg-group>
    </examples>
    <resources/>
    <related-techniques/>


### PR DESCRIPTION
Remove Example 3 as it's same as Example 2.

F55: Failure of Success Criteria 2.1.1, 2.4.7, and 3.2.1 due to using script to remove focus when focus is received
http://www.w3.org/WAI/GL/2014/WD-WCAG20-TECHS-20140724/F55.html
