### PR TITLE
Issue #99 Added Failure PDF Header/fiiter information not available

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,10 @@
+{
+  "group": 35422,
+  "contacts": [
+    {
+      "github": "michael-n-cooper",
+      "w3c": "cooper"
+    }
+  ],
+  "policy": "restricted" 
+}

--- a/wcag20/sources/techniques/failures/F94.xml
+++ b/wcag20/sources/techniques/failures/F94.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE technique
+  SYSTEM "../../xmlspec.dtd">
+<technique id="F93">
+   <short-name>Failure of Success Criterion 1.3.1 due to information in PDF headers and footers, marked as artifacts, not being programmatically determinable in another way</short-name>
+   <applicability>
+      <p>PDF</p>
+   </applicability>
+   <applies-to>
+      <success-criterion idref="content-structure-separation-programmatic" relationship="failure"/>
+   </applies-to>
+   <description>
+<p>This failure occurs when information in a header or footer is not available to people who are blind using screen readers. If this information is marked as an artifact and not provided in another way to these users, then they may be disadvantaged by not having this information. Many authors mark up footers as artifacts to prevent the document from being overly "chatty" or interupting to flow of a sentence when the footer is read at the bottom of the page in the middle of the sentence. If authors do this, they must provide ALL the information in the footer in another way that can be read by screen readers, such as providing author information and date on the title page of the document and/or ensuring the PDF page numbers reflect the footer page numbers etc.</p>
+   </description>
+   <examples>
+      <eg-group>
+         <head>Page numbers in the footer not being confused with the PDF page number</head>
+         <description>
+            <p>In this example, the footer information is marked as an artifact and is not read by a screen reader, but the pages in Acrobat do not acurately reflect them [insert screen shot of Acrobat page number different than footer page number]</p>
+         </description>
+      </eg-group>
+      <eg-group>
+         <head>more examples</head>
+         <description>
+            <p>more text</p>
+         </description>
+      </eg-group>
+   </examples>
+   <resources>
+      <see-also>
+         <ulist>
+            <item>
+               <p>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/TR/WCAG20-TECHS/PDF17.html">Specifying consistent page numbering for PDF documents</loc>
+               </p>
+            </item>
+           
+         </ulist>
+      </see-also>
+   </resources>
+   <related-techniques/>
+   <tests>
+      <procedure>
+         <olist>
+            <item>
+               <p>Check if the headers and/or footers is marked as an artifact.</p>
+            </item>
+            <item>
+               <p>Check on whether the information in the headers and/or footers is NOT available in text or in some other programatic way in the document. (i.e., on title page, in prose in the main body, PDF pages match header/footer page numbers etc.)</p>
+            </item>
+            
+          </olist>
+      </procedure>
+      <expected-results>
+         <ulist>
+            <item>
+               <p>If checks 1-2 are true, then this failure condition applies and the content fails the Success Criterion.</p>
+            </item>
+         </ulist>
+      </expected-results>
+   </tests>
+</technique>


### PR DESCRIPTION
I create a failure #94 file in the source >techniques>failures> folder... 
Ass per issue #99 
This is my first attempt at a pull request for a new technique using Git for desktop. 

I'm not sure why Michael's json entry is in here but I think it's the same as before... so nothing to worry about. Let me know if this works.