### PR TITLE
Suggest using a more meaningful label

### DIFF
--- a/wcag20/Techniques/working-examples/G65/ex3.html
+++ b/wcag20/Techniques/working-examples/G65/ex3.html
@@ -17,7 +17,7 @@
   </head>
   <body>
     <h1>Breadcrumb Example</h1>
-    <nav aria-label="Breadcrumbs">
+    <nav aria-label="Location">
       <h2>You are here:</h2>
       <ul>
         <li><a href="/">Acme Company</a> &#8594;</li>


### PR DESCRIPTION
Minor suggestion to change the `aria-label` to be something that describes what the `<nav>` is for rather than the design pattern. The function of 'breadcrumbs' may not be clear to some people (or may not translate well... I'm guessing!) and how they are implemented (as either an indcation of ones location in the heirarchy or as an indication of ones journey through a website) is ambiguous.