### PR TITLE
Issue159

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA4.xml
+++ b/wcag20/sources/techniques/aria/ARIA4.xml
@@ -24,7 +24,7 @@
          <head>A simple toolbar</head>
          <description>
             <p>The WAI-ARIA Authoring Practices document <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="http://www.w3.org/TR/2010/WD-wai-aria-practices-20100916/#accessiblewidget">demonstrates a toolbar containing three buttons</loc>. The <el>div</el> element has a role of "toolbar", and the <el>img</el> elements have "button" roles:</p>
+                    href="https://www.w3.org/TR/wai-aria-practices-1.1/#accessiblewidget">demonstrates a toolbar containing three buttons</loc>. The <el>div</el> element has a role of "toolbar", and the <el>img</el> elements have "button" roles:</p>
             <codeblock xml:space="preserve"><![CDATA[
     <div role="toolbar"
       tabindex="0" 

--- a/wcag20/sources/techniques/aria/ARIA4.xml
+++ b/wcag20/sources/techniques/aria/ARIA4.xml
@@ -123,7 +123,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/html-aapi/#html-element-to-accessibility-api-role-mapping-matrix">HTML to Platform Accessibility APIs Implementation Guide: HTML Element to Accessibility API Role Mapping Matrix</loc>
+                       href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</loc>
                </p>
             </item>
             <item>
@@ -135,7 +135,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/aria-in-html/">Using WAI-ARIA in HTML</loc> 
+                       href="https://www.w3.org/TR/aria-in-html/">Notes on Using ARIA in HTML</loc> 
                </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/aria/ARIA4.xml
+++ b/wcag20/sources/techniques/aria/ARIA4.xml
@@ -62,8 +62,8 @@
       <eg-group>
          <head>A Tree Widget</head>
          <description>
-            <p>The WAI-ARIA Primer <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="http://www.w3.org/TR/wai-aria-primer/#exampletree">demonstrates a tree widget</loc>. Note the use of the roles "tree", "treeitem", and "group" to identify the tree and its structure. Here is a simplified excerpt from the code:</p>
+            <p>The WAI-ARIA 1.1 Authoring Practices Guide <loc xmlns:xlink="http://www.w3.org/1999/xlink"
+                    href="https://www.w3.org/TR/wai-aria-practices-1.1/#exampletree">demonstrates a tree widget</loc>. Note the use of the roles "tree", "treeitem", and "group" to identify the tree and its structure. Here is a simplified excerpt from the code:</p>
             <codeblock xml:space="preserve"><![CDATA[
 <ul role="tree" tabindex="0">
   <li role="treeitem">Birds</li>
@@ -124,12 +124,6 @@
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
                        href="http://www.w3.org/TR/html-aapi/#html-element-to-accessibility-api-role-mapping-matrix">HTML to Platform Accessibility APIs Implementation Guide: HTML Element to Accessibility API Role Mapping Matrix</loc>
-               </p>
-            </item>
-            <item>
-               <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/wai-aria-primer/">WAI-ARIA 1.0 Primer</loc>
                </p>
             </item>
             <item>


### PR DESCRIPTION
Removed the link to the ARIA Primer,
Switched the first example to reference the ARIA 1.1 APG and switched the 2nd example to also reference the ARIA 1.1 APG which has replaced the ARIA Primer.