### PR TITLE
Proposed updates for Issue #236 clarifying definition of relative luminance.

### DIFF
--- a/wcag20/sources/wcag2-src.xml
+++ b/wcag20/sources/wcag2-src.xml
@@ -1896,30 +1896,30 @@ and operating content do not rely solely on sensory characteristics of component
           <def>
             <p>the relative brightness of any point in a colorspace, normalized to 0 for darkest black and 1 for lightest white</p>
             <note>
-              <p>For the sRGB colorspace, the relative luminance of a color is defined as L = 0.2126 * <emph role="bold">R</emph> + 0.7152 * <emph role="bold">G</emph> + 0.0722 * <emph role="bold">B</emph> where <emph role="bold">R</emph>, <emph role="bold">G</emph> and <emph role="bold">B</emph> are defined as:</p>
+              <p>For the sRGB colorspace, the relative luminance of a color is defined as L = 0.2126 * <emph role="bold">R</emph> + 0.7152 * <emph role="bold">G</emph> + 0.0722 * <emph role="bold">B</emph> where <emph role="bold">R</emph>, <emph role="bold">G</emph> and <emph role="bold">B</emph> are computed from the non-linear sRGB values by reversing the gamma-correction applied as follows:</p>
               <ulist>
                 <item>
-                  <p>if R<sub>sRGB</sub> &lt;= 0.03928 then <emph role="bold">R</emph> = R<sub>sRGB</sub>/12.92 else <emph role="bold">R</emph> = ((R<sub>sRGB</sub>+0.055)/1.055) ^ 2.4</p>
+                  <p>if R&prime;<sub>sRGB</sub> &lt;= 0.03928 then <emph role="bold">R</emph> = R&prime;<sub>sRGB</sub>/12.92 else <emph role="bold">R</emph> = ((R&prime;<sub>sRGB</sub>+0.055)/1.055) ^ 2.4</p>
                 </item>
                 <item>
-                  <p>if G<sub>sRGB</sub> &lt;= 0.03928 then <emph role="bold">G</emph> = G<sub>sRGB</sub>/12.92 else <emph role="bold">G</emph> = ((G<sub>sRGB</sub>+0.055)/1.055) ^ 2.4</p>
+                  <p>if G&prime;<sub>sRGB</sub> &lt;= 0.03928 then <emph role="bold">G</emph> = G&prime;<sub>sRGB</sub>/12.92 else <emph role="bold">G</emph> = ((G&prime;<sub>sRGB</sub>+0.055)/1.055) ^ 2.4</p>
                 </item>
                 <item>
-                  <p>if B<sub>sRGB</sub> &lt;= 0.03928 then <emph role="bold">B</emph> = B<sub>sRGB</sub>/12.92 else <emph role="bold">B</emph> = ((B<sub>sRGB</sub>+0.055)/1.055) ^ 2.4</p>
+                  <p>if B&prime;<sub>sRGB</sub> &lt;= 0.03928 then <emph role="bold">B</emph> = B&prime;<sub>sRGB</sub>/12.92 else <emph role="bold">B</emph> = ((B&prime;<sub>sRGB</sub>+0.055)/1.055) ^ 2.4</p>
                 </item>
               </ulist>
               <note role="nonumber">
-                <p>and R<sub>sRGB</sub>, G<sub>sRGB</sub>, and B<sub>sRGB</sub> are defined as:</p>
+                <p>and R&prime;<sub>sRGB</sub>, G&prime;<sub>sRGB</sub>, and B&prime;<sub>sRGB</sub> are defined as:</p>
               </note>
               <ulist>
                 <item>
-                  <p>R<sub>sRGB</sub> = R<sub>8bit</sub>/255</p>
+                  <p>R&prime;<sub>sRGB</sub> = R<sub>8bit</sub>/255</p>
                 </item>
                 <item>
-                  <p>G<sub>sRGB</sub> = G<sub>8bit</sub>/255</p>
+                  <p>G&prime;<sub>sRGB</sub> = G<sub>8bit</sub>/255</p>
                 </item>
                 <item>
-                  <p>B<sub>sRGB</sub> = B<sub>8bit</sub>/255</p>
+                  <p>B&prime;<sub>sRGB</sub> = B<sub>8bit</sub>/255</p>
                 </item>
               </ulist>
               <note role="nonumber">


### PR DESCRIPTION
Proposed updates to the definition of relative luminance to clarify how
relative luminance is calculated from non-linear (gamma-corrected) RGB.
Additionally, anytime non-linear (gamma-corrected) RGB is referenced the
prime symbol must be used.

These updates are in response to issue #236 which identified confusion over the existing definition which is based of sRGB specification. 

Collaborating with Lars Borg, color expert from Adobe, on these updates. Would like to send Lars a link to the pull request to view changes to the definition. 