### PR TITLE
Fix links of WCAG20-TECHS (HTML)

### DIFF
--- a/wcag20/sources/techniques/html/H28.xml
+++ b/wcag20/sources/techniques/html/H28.xml
@@ -75,7 +75,7 @@ brought by members of the National Writers Union against ......</p>  ]]></code>
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="https://www.w3.org/TR/html5/textlevel-semantics.html#the-abbr-element">HTMl5 abbr
+                       href="https://www.w3.org/TR/html5/text-level-semantics.html#the-abbr-element">HTML5 abbr
                     element</loc>
 								       </p>
             </item>

--- a/wcag20/sources/techniques/html/H62.xml
+++ b/wcag20/sources/techniques/html/H62.xml
@@ -103,13 +103,13 @@
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/ruby/">Ruby Annotation</loc>
+                       href="https://www.w3.org/TR/ruby/">Ruby Annotation</loc>
 								       </p>
             </item>
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.imsglobal.org/accessibility/accessiblevers/sec11.html">IMS Guidelines for
+                       href="https://www.imsglobal.org/accessibility/accessiblevers/sec11.html">IMS Guidelines for
                     Topic-Specific Accessibility</loc>
 								       </p>
             </item>
@@ -122,20 +122,20 @@
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/International/techniques/markup#ruby">W3C I18N
+                       href="https://www.w3.org/International/techniques/authoring-html.en.html?collapse#ruby">W3C I18N
                     Techniques: Markup and text, "Using Ruby"</loc>
 								       </p>
             </item>
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="https://www.w3.org/TR/html5/text-level-semantics.html#the-ruby-element">HTML5 ruby element</loc>
+                       href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">HTML5 ruby element</loc>
 								       </p>
            </item>
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="https://www.w3.org/TR/html5/text-level-semantics.html#the-rt-element">HTML5 rt element</loc>
+                       href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element">HTML5 rt element</loc>
 								       </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/html/H62.xml
+++ b/wcag20/sources/techniques/html/H62.xml
@@ -131,13 +131,7 @@
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
                        href="https://www.w3.org/TR/html5/text-level-semantics.html#the-ruby-element">HTML5 ruby element</loc>
 								       </p>
-            </item>
-            <item>
-               <p>
-									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="https://www.w3.org/TR/html5/text-level-semantics.html#the-rb-element">HTML5 rb element</loc>
-								       </p>
-            </item>
+           </item>
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/wcag20/sources/techniques/html/H62.xml
+++ b/wcag20/sources/techniques/html/H62.xml
@@ -116,7 +116,7 @@
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://www.w3.org/TR/css3-ruby/">CSS 3 Ruby</loc>
+                       href="https://www.w3.org/TR/css-ruby-1/">CSS Ruby Layout Module Level 1</loc>
 								       </p>
             </item>
             <item>
@@ -135,13 +135,13 @@
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="https://www.w3.org/TR/html/text-level-semantics.html#the-rb-element">HTMl5 rb element</loc>
+                       href="https://www.w3.org/TR/html5/text-level-semantics.html#the-rb-element">HTML5 rb element</loc>
 								       </p>
             </item>
             <item>
                <p>
 									         <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="https://www.w3.org/TR/html/text-level-semantics.html#the-rt-element">HTML5 rt element</loc>
+                       href="https://www.w3.org/TR/html5/text-level-semantics.html#the-rt-element">HTML5 rt element</loc>
 								       </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/html/H95.xml
+++ b/wcag20/sources/techniques/html/H95.xml
@@ -51,22 +51,22 @@
          <ulist>
             <item>
                <p>
-               	<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/html5/embedded-content-0.html#the-track-element">HTML5, the track element</loc>
+               	<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">HTML5, the track element</loc>
                </p>
             </item>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/TR/ttaf1-dfxp/">Timed Text Markup Language</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/ttml1/">Timed Text Markup Language</loc>
                </p>
             </item>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://w3c.github.io/webvtt/">WebVTT: The Web Video Text Tracks Format</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</loc>
                </p>
             </item>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://captionatorjs.com/">Captionator Polyfill</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://captionatorjs.com/">Captionator Polyfill</loc>
                </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/html/H95.xml
+++ b/wcag20/sources/techniques/html/H95.xml
@@ -61,7 +61,7 @@
             </item>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://github.com/w3c/webvtt">WebVTT: The Web Video Text Tracks Format</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://w3c.github.io/webvtt/">WebVTT: The Web Video Text Tracks Format</loc>
                </p>
             </item>
             <item>

--- a/wcag20/sources/techniques/html/H96.xml
+++ b/wcag20/sources/techniques/html/H96.xml
@@ -64,12 +64,12 @@
          <ulist>
             <item>
                <p>
-               	<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/html5/embedded-content-0.html#the-track-element">HTML5, the track element</loc>
+               	<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">HTML5, the track element</loc>
                </p>
             </item>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://w3c.github.io/webvtt/">WebVTT: The Web Video Text Tracks Format</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</loc>
                </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/html/H96.xml
+++ b/wcag20/sources/techniques/html/H96.xml
@@ -69,7 +69,7 @@
             </item>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://github.com/w3c/webvtt">WebVTT: The Web Video Text Tracks Format</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://w3c.github.io/webvtt/">WebVTT: The Web Video Text Tracks Format</loc>
                </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/html/H97.xml
+++ b/wcag20/sources/techniques/html/H97.xml
@@ -70,7 +70,7 @@
          <ulist>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/html5/sections.html#the-nav-element">HTML5 nav element</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://html.spec.whatwg.org/multipage/sections.html#the-nav-element">HTML5 nav element</loc>
                </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/html/H97.xml
+++ b/wcag20/sources/techniques/html/H97.xml
@@ -70,7 +70,7 @@
          <ulist>
             <item>
                <p>
-                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/TR/html-markup/nav.html">HTML5 nav element</loc>
+                  <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/html5/sections.html#the-nav-element">HTML5 nav element</loc>
                </p>
             </item>
          </ulist>


### PR DESCRIPTION
Per https://validator.w3.org/checklink?uri=https%3A%2F%2Fwww.w3.org%2FTR%2F2016%2FNOTE-WCAG20-TECHS-20161007%2Fhtml.html&hide_type=all&depth=&check=Check