### PR TITLE
Update HTTP/1.1 resource to RFC 7231

### DIFF
--- a/wcag20/sources/understanding/consistent-behavior-no-extreme-changes-context.xml
+++ b/wcag20/sources/understanding/consistent-behavior-no-extreme-changes-context.xml
@@ -65,7 +65,7 @@
          </item>
          <item>
             <p> 
-               <loc href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3">HTTP/1.1 Status Code Definitions: Redirection 3xx</loc>.
+               <loc href="https://tools.ietf.org/html/rfc7231#section-6.4">HTTP/1.1 Status Code Definitions: Redirection 3xx</loc>.
               </p>
          </item>
       </ulist>


### PR DESCRIPTION
HTTP/1.1 Semantics is defined in RFC 7231 now.