### PR TITLE
Fixed JavaScript error in SCR30 working example

### DIFF
--- a/wcag20/Techniques/working-examples/SCR30/expand-links.html
+++ b/wcag20/Techniques/working-examples/SCR30/expand-links.html
@@ -13,8 +13,9 @@ var linkContext = {
 function doExpand() {
 	var links = document.links;
 	
-	for each (link in links) {
-		var cn = link.className;
+	for (linkIndex in links) {
+		var link = links[linkIndex],
+		    cn = link.className;
 		if (linkContext[cn]) {
 			span = link.appendChild(document.createElement("span"));
 			span.setAttribute("class", "linkexpansion");


### PR DESCRIPTION
The [SCR30 working example](https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SCR30/expand-links) does not work, it was using invalid JavaScript:

```javascript
for each (link in links) {
    ....
```