### PR TITLE
List skip-link and landmark techniques as related to each other

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA11.xml
+++ b/wcag20/sources/techniques/aria/ARIA11.xml
@@ -175,6 +175,8 @@
       </see-also>
    </resources>
    <related-techniques>
+      <relatedtech idref="G1"/>
+      <relatedtech idref="G124"/>
       <relatedtech idref="H69"/>
       <relatedtech idref="SCR28"/>
    </related-techniques>

--- a/wcag20/sources/techniques/general/G1.xml
+++ b/wcag20/sources/techniques/general/G1.xml
@@ -44,6 +44,7 @@
       </see-also>
    </resources>
    <related-techniques>
+      <relatedtech idref="ARIA11"/>
       <relatedtech idref="G123"/>
       <relatedtech idref="G124"/>
    </related-techniques>

--- a/wcag20/sources/techniques/general/G124.xml
+++ b/wcag20/sources/techniques/general/G124.xml
@@ -32,6 +32,7 @@
       </see-also>
    </resources>
    <related-techniques>
+      <relatedtech idref="ARIA11"/>
       <relatedtech idref="G1"/>
       <relatedtech idref="G123"/>
    </related-techniques>


### PR DESCRIPTION
Skip-links and landmarks have overlapping use cases. Their techniques pages should be shown as related to each other.