### PR TITLE
Adding xmlns declaration

### DIFF
--- a/understanding/21/reflow.html
+++ b/understanding/21/reflow.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
 		<meta charset="UTF-8" />
     <title>Understanding Reflow</title>


### PR DESCRIPTION
The [reflow understanding doc](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html) isn’t being processed (plain-html doc), only difference I can see is the html tag / xmlns.

Does anything else need to happen to solve this?

If I was confident in the publication process I'd just merge it in, but if it is that simple please merge and delete this branch.

Thanks,

-Alastair