### PR TITLE
Removing ed-note about stable URL

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -453,7 +453,7 @@
                     <p>Conformance claims are <strong>not required</strong>. Authors can conform to WCAG 2.1 without making a claim. However, if a conformance claim is made, then the conformance claim <strong>must</strong> include the following information:</p>
                     <ol>
                         <li><strong>Date</strong> of the claim</li>
-                        <li><strong>Guidelines title, version and URI </strong> "Web Content Accessibility Guidelines 2.1 at <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>" <span class="ednote">In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec.</span></li>
+                        <li><strong>Guidelines title, version and URI </strong> "Web Content Accessibility Guidelines 2.1 at <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>"</li>
                         <li><strong>Conformance level</strong> satisfied: (Level A, AA or AAA)</li>
                         <li>
                             <p><strong>A concise description of the Web pages</strong>, such as a list of URIs for which the claim is made, including whether subdomains are included in the claim.</p>


### PR DESCRIPTION
Given that any changes should be backwards compatible, would it be best to simply to the stable WCAG21 url, rather than a dated one?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/427.html" title="Last updated on Jul 11, 2018, 3:44 PM GMT (b1fd6ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/427/273cdfc...b1fd6ad.html" title="Last updated on Jul 11, 2018, 3:44 PM GMT (b1fd6ad)">Diff</a>