### PR TITLE
Correcting two note/examples

### DIFF
--- a/guidelines/terms/20/keyboard-interface.html
+++ b/guidelines/terms/20/keyboard-interface.html
@@ -3,16 +3,16 @@
    
    <p>interface used by software to obtain keystroke input</p>
    
-   <p class="note">A keyboard interface allows users to provide keystroke input to programs even if the
-      native technology does not contain a keyboard.
-   </p>
-   
-   <p class="note">A touchscreen PDA has a keyboard interface built into its operating system as well
-      as a connector for external keyboards. Applications on the PDA can use the interface
-      to obtain keyboard input either from an external keyboard or from other applications
-      that provide simulated keyboard output, such as handwriting interpreters or speech-to-text
-      applications with "keyboard emulation" functionality.
-   </p>
+    <div class="note">
+        <p>A keyboard interface allows users to provide keystroke input to programs even if the
+        native technology does not contain a keyboard.</p>
+
+        <p class="example">A touchscreen PDA has a keyboard interface built into its operating system as well
+        as a connector for external keyboards. Applications on the PDA can use the interface
+        to obtain keyboard input either from an external keyboard or from other applications
+        that provide simulated keyboard output, such as handwriting interpreters or speech-to-text
+        applications with "keyboard emulation" functionality.</p>
+    </div>
    
    <p class="note">Operation of the application (or parts of the application) through a keyboard-operated
       mouse emulator, such as MouseKeys, does not qualify as operation through a keyboard

--- a/guidelines/terms/20/technology.html
+++ b/guidelines/terms/20/technology.html
@@ -14,7 +14,7 @@
       applications.
    </p>
    
-   <p class="note">Some common examples of Web content technologies include HTML, CSS, SVG, PNG, PDF,
+   <p class="example">Some common examples of Web content technologies include HTML, CSS, SVG, PNG, PDF,
       Flash, and JavaScript.
    </p>
    


### PR DESCRIPTION
There was an accidental changes from 2.0 to 2.1, where two examples were converted to notes.

**Prior to merge:** The CSS for the keyboard-interface definition needs testing in context, as it now nests the example in the note.