### PR TITLE
Technique: Reflow for long URLs

### DIFF
--- a/techniques/css/reflow-url.html
+++ b/techniques/css/reflow-url.html
@@ -2,25 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 <title>Allowing for Reflow with Long URLs</title>
-<link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
-<style>
-/* specific for IE10 & 11, they do not support these declarations with "a" selector */
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
- * { 
-word-wrap: break-word;
-	}
-}
-/* for all Edge, does not support these declarations with "a" selector */
-@supports (-ms-ime-align:auto) {
- * { 
-word-wrap: break-word;
-	}
-}
+<link rel="stylesheet" type="text/css" href="../../css/sources.css"/>
 
-	.wrapped { 
-overflow-wrap: break-word;
-	}
-	</style>
 </head>
 <body>
 <h1>Allowing for Reflow with Long URLs</h1>
@@ -39,11 +22,10 @@ overflow-wrap: break-word;
     <li>"?" Question (IE,  Chrome, Safari) </li>
     <li>&quot;&amp;&quot; Ampersand (Firefox only)</li>
   </ul> 
-  Sometimes these are not enough to ensure that long URLs will not overflow the viewport. 
+  <p>Sometimes these are not enough to ensure that long URLs will not overflow the viewport.</p>
 </section>
 <section id="examples">
   <h2>Examples</h2>
-  <p class="instructions"></p>
   <section class="example">
     <h3>Example: Breaking long URLs</h3>
     <p>Using the following CSS will cause long URLs to break at appropriate places (hyphens, spaces, etc.) and within words without causing reflow. </p>
@@ -63,20 +45,21 @@ overflow-wrap: break-word;
   <section class="test-procedure">
     <h3>Procedure</h3>
     <p>For strings of text that are wider than 320px:</p>
-<ul>
-  <li>Display the web page in a user agent capable of 400% zoom and set the viewport dimensions (in CSS pixels) to 1280 wide and 1024 high.</li>
-  <li>Zoom in by 400%.</li>
-  <li>For content read horizontally, check that all content and functionality is available without horizontal scrolling.</li>
-  <li>For content read vertically, check that all content and functionality is available without vertical scrolling.</li>
-</ul>
+    <ul>
+      <li>Display the web page in a user agent capable of 400% zoom and set the viewport dimensions (in CSS pixels) to 1280 wide and 1024 high.</li>
+      <li>Zoom in by 400%.</li>
+      <li>For content read horizontally, check that all content and functionality is available without horizontal scrolling.</li>
+      <li>For content read vertically, check that all content and functionality is available without vertical scrolling.</li>
+    </ul>
 
-<p>If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
- </section>
+    <p class="note">If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
+  </section>
   <section class="test-results">
-<h3>Expected Results</h3>
+    <h3>Expected Results</h3>
 
-<p>#3 and #4 are true.</p>
+    <p>#3 and #4 are true.</p>
   
+  </section>
 </section>
 <section id="related">
   <h2>Related Techniques</h2>

--- a/techniques/css/reflow-url.html
+++ b/techniques/css/reflow-url.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-<title>Allowing for Reflow with Long URLs</title>
+<title>Allowing for Reflow with Long URLs and Strings of Text</title>
 <link rel="stylesheet" type="text/css" href="../../css/sources.css"/>
 
 </head>
 <body>
-<h1>Allowing for Reflow with Long URLs</h1>
+<h1>Allowing for Reflow with Long URLs and Strings of Text</h1>
 <section id="meta"></section>
 <section id="applicability">
   <h2>When to Use</h2>
@@ -31,8 +31,8 @@
     <p>Using the following CSS will cause long URLs to break at appropriate places (hyphens, spaces, etc.) and within words without causing reflow. </p>
     <p>List of CSS declarations used and why they are used:</p>
     <ul>
-     <li><strong>overflow-break: break-word</strong>: Allows words to be broken and wrapped within words. </li>
-	    <li><strong>word-break: break-word</strong>: Allows words to be broken and wrapped within. (Microsoft only)</li>
+     <li><strong>overflow-wrap: break-word</strong>: Allows words to be broken and wrapped within words. </li>
+	    <li><strong>word-wrap: break-word</strong>: Allows words to be broken and wrapped within. (Microsoft only)</li>
     </ul>
     <pre>    a {overflow-wrap: break-word;}</pre>
     <p>Note:  IE and Edge  only support this declaration when used with the * (wildcard) selector</p>
@@ -44,20 +44,20 @@
   <h2>Tests</h2>
   <section class="test-procedure">
     <h3>Procedure</h3>
-    <p>For strings of text that are wider than 320px:</p>
-    <ul>
+    <p>For strings of text that are wider than 320px check:</p>
+    <ol>
       <li>Display the web page in a user agent capable of 400% zoom and set the viewport dimensions (in CSS pixels) to 1280 wide and 1024 high.</li>
       <li>Zoom in by 400%.</li>
       <li>For content read horizontally, check that all content and functionality is available without horizontal scrolling.</li>
       <li>For content read vertically, check that all content and functionality is available without vertical scrolling.</li>
-    </ul>
+    </ol>
 
     <p class="note">If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
   </section>
   <section class="test-results">
     <h3>Expected Results</h3>
 
-    <p>#3 and #4 are true.</p>
+    <p>Checks #3 and #4 are true.</p>
   
   </section>
 </section>

--- a/techniques/css/reflow-url.html
+++ b/techniques/css/reflow-url.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+<title>Allowing for Reflow with Long URLs</title>
+<link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
+<style>
+/* specific for IE10 & 11, they do not support these declarations with "a" selector */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+ * { 
+word-wrap: break-word;
+	}
+}
+/* for all Edge, does not support these declarations with "a" selector */
+@supports (-ms-ime-align:auto) {
+ * { 
+word-wrap: break-word;
+	}
+}
+
+	.wrapped { 
+overflow-wrap: break-word;
+	}
+	</style>
+</head>
+<body>
+<h1>Allowing for Reflow with Long URLs</h1>
+<section id="meta"></section>
+<section id="applicability">
+  <h2>When to Use</h2>
+  <p class="instructions">This technique is applicable to Cascading Style Sheet / HTML technologies.</p>
+</section>
+<section id="description">
+  <h2>Description</h2>
+  <p>Long URLs can break reflow when the page is zoomed. The objective of this technique is to present URLs without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels or a vertical scroll bar at a height equivalent to 256 CSS pixels. This is done by using CSS techniques that adapt to the available viewport space. Note: Using a human readable text link, rather than a long URL, is better for usability and accessibility.</p>
+  <p>By default most browsers will wrap long URLs at the following characters:   
+  <ul>
+    <li>&quot;-&quot; Hyphen  </li>
+    <li>&quot; &quot; Space</li>
+    <li>"?" Question (IE,  Chrome, Safari) </li>
+    <li>&quot;&amp;&quot; Ampersand (Firefox only)</li>
+  </ul> 
+  Sometimes these are not enough to ensure that long URLs will not overflow the viewport. 
+</section>
+<section id="examples">
+  <h2>Examples</h2>
+  <p class="instructions"></p>
+  <section class="example">
+    <h3>Example: Breaking long URLs</h3>
+    <p>Using the following CSS will cause long URLs to break at appropriate places (hyphens, spaces, etc.) and within words without causing reflow. </p>
+    <p>List of CSS declarations used and why they are used:</p>
+    <ul>
+     <li><strong>overflow-break: break-word</strong>: Allows words to be broken and wrapped between letters. </li>
+	    <li><strong>word-break: break-word</strong>: Allows words to be broken and wrapped between letters. (Microsoft only)</li>
+    </ul>
+    <pre>    .wrapped {overflow-wrap: break-word;}</pre>
+    <p>Note:  IE and Edge  only support this declaration when used with the following declaration.</p>
+    <pre>    /* specific for IE10 & 11, they do not support these declarations with "a" selector */<br>
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {<br>
+         * { word-wrap: break-word;}<br>
+    }<br><br>
+    /* for all Edge, does not support these declarations with "a" selector */<br>
+    @supports (-ms-ime-align:auto) {<br>
+        * { word-wrap: break-word;}<br>
+    }</pre>
+  <p><a href="../../working-examples/css-reflow-url/">Working Example</a></p>
+  </section>
+</section>
+<section id="tests">
+  <h2>Tests</h2>
+  <section class="test-procedure">
+    <h3>Procedure</h3>
+    <ol>
+      <li>Display content in a user agent capable of 400% zoom with a viewport-width of 1280 CSS pixels.</li>
+      <li>If the text is read horizontally: Zoom in by 400%.   
+      <li>Check whether URL content and functionality is available without horizontal scrolling.</li>
+      <li>If the text is read vertically: Set the viewport height to 256 CSS pixels.</li>
+      <li>Check whether URL content and functionality is available without vertical scrolling.</li>
+    </ol>
+    <p>Note: If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
+    <ol>
+	    <li>Display content in a user agent with a Responsive Design Mode feature.</li>
+      <li>Turn on the Responsive Design Mode - set width to 320 pixels or select a device with width of 320 pixels.
+      <li>Check whether URL content and functionality is available without horizontal scrolling.</li>
+      <li>If the text is read vertically: Set the viewport height to 256 CSS pixels.</li>
+      <li>Check whether URL content and functionality is available without vertical scrolling.</li>
+  </section>
+  <section class="test-results">
+    <h3>Expected Results</h3>
+    <ul>
+      <li>Check #3 is true.</li>
+      <li>Check #5 is true.</li>
+    </ul>
+  </section>
+</section>
+<section id="related">
+  <h2>Related Techniques</h2>
+  <ul>
+    <li>ID</li>
+  </ul>
+</section>
+</body>
+</html>

--- a/techniques/css/reflow-url.html
+++ b/techniques/css/reflow-url.html
@@ -31,7 +31,7 @@ overflow-wrap: break-word;
 </section>
 <section id="description">
   <h2>Description</h2>
-  <p>Long URLs can break reflow when the page is zoomed. The objective of this technique is to present URLs without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels or a vertical scroll bar at a height equivalent to 256 CSS pixels. This is done by using CSS techniques that adapt to the available viewport space. Note: Using a human readable text link, rather than a long URL, is better for usability and accessibility.</p>
+  <p>Long sets of characters without a space, such as URLs shown as content, can break reflow when the page is zoomed. The objective of this technique is to present URLs without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels or a vertical scroll bar at a height equivalent to 256 CSS pixels. This is done by using CSS techniques that adapt to the available viewport space. Note: Using a human readable text link, rather than a long URL, is better for usability and accessibility.</p>
   <p>By default most browsers will wrap long URLs at the following characters:   
   <ul>
     <li>&quot;-&quot; Hyphen  </li>
@@ -49,19 +49,12 @@ overflow-wrap: break-word;
     <p>Using the following CSS will cause long URLs to break at appropriate places (hyphens, spaces, etc.) and within words without causing reflow. </p>
     <p>List of CSS declarations used and why they are used:</p>
     <ul>
-     <li><strong>overflow-break: break-word</strong>: Allows words to be broken and wrapped between letters. </li>
-	    <li><strong>word-break: break-word</strong>: Allows words to be broken and wrapped between letters. (Microsoft only)</li>
+     <li><strong>overflow-break: break-word</strong>: Allows words to be broken and wrapped within words. </li>
+	    <li><strong>word-break: break-word</strong>: Allows words to be broken and wrapped within. (Microsoft only)</li>
     </ul>
-    <pre>    .wrapped {overflow-wrap: break-word;}</pre>
-    <p>Note:  IE and Edge  only support this declaration when used with the following declaration.</p>
-    <pre>    /* specific for IE10 & 11, they do not support these declarations with "a" selector */<br>
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {<br>
-         * { word-wrap: break-word;}<br>
-    }<br><br>
-    /* for all Edge, does not support these declarations with "a" selector */<br>
-    @supports (-ms-ime-align:auto) {<br>
-        * { word-wrap: break-word;}<br>
-    }</pre>
+    <pre>    a {overflow-wrap: break-word;}</pre>
+    <p>Note:  IE and Edge  only support this declaration when used with the * (wildcard) selector</p>
+    <pre>    * { word-wrap: break-word;}</pre>
   <p><a href="../../working-examples/css-reflow-url/">Working Example</a></p>
   </section>
 </section>
@@ -69,28 +62,21 @@ overflow-wrap: break-word;
   <h2>Tests</h2>
   <section class="test-procedure">
     <h3>Procedure</h3>
-    <ol>
-      <li>Display content in a user agent capable of 400% zoom with a viewport-width of 1280 CSS pixels.</li>
-      <li>If the text is read horizontally: Zoom in by 400%.   
-      <li>Check whether URL content and functionality is available without horizontal scrolling.</li>
-      <li>If the text is read vertically: Set the viewport height to 256 CSS pixels.</li>
-      <li>Check whether URL content and functionality is available without vertical scrolling.</li>
-    </ol>
-    <p>Note: If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
-    <ol>
-	    <li>Display content in a user agent with a Responsive Design Mode feature.</li>
-      <li>Turn on the Responsive Design Mode - set width to 320 pixels or select a device with width of 320 pixels.
-      <li>Check whether URL content and functionality is available without horizontal scrolling.</li>
-      <li>If the text is read vertically: Set the viewport height to 256 CSS pixels.</li>
-      <li>Check whether URL content and functionality is available without vertical scrolling.</li>
-  </section>
+    <p>For strings of text that are wider than 320px:</p>
+<ul>
+  <li>Display the web page in a user agent capable of 400% zoom and set the viewport dimensions (in CSS pixels) to 1280 wide and 1024 high.</li>
+  <li>Zoom in by 400%.</li>
+  <li>For content read horizontally, check that all content and functionality is available without horizontal scrolling.</li>
+  <li>For content read vertically, check that all content and functionality is available without vertical scrolling.</li>
+</ul>
+
+<p>If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
+ </section>
   <section class="test-results">
-    <h3>Expected Results</h3>
-    <ul>
-      <li>Check #3 is true.</li>
-      <li>Check #5 is true.</li>
-    </ul>
-  </section>
+<h3>Expected Results</h3>
+
+<p>#3 and #4 are true.</p>
+  
 </section>
 <section id="related">
   <h2>Related Techniques</h2>

--- a/working-examples/css-reflow-url/index.html
+++ b/working-examples/css-reflow-url/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
     <meta charset="UTF-8">
-    <title>Using media queries and grid CSS to reflow columns</title>
+    <title>Allowing for Reflow with Long URLs</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script>
 $(document).ready(function(){
@@ -151,20 +151,15 @@ word-wrap: break-word;
     </header>
 <main role="main" class="grid-item">
   <h1>Allowing for Reflow with Long URLs</h1>
-  <p>Long URLs can break reflow when the page is zoomed. See the technique <a href="../../techniques/css/TBC">Allowing for Reflow with Long URLs</a> for further details.</p>
+  <p>Long URLs can break reflow when the page is zoomed. See the technique <a href="../../techniques/css/TBC">Allowing for Reflow with Long URLs and Strings of Text</a> for further details.</p>
 
   <p>The default state of this page is to be 320px wide (like a mobile-sized display) with no styling on the links. You should see link-text breaking the boundaries of their containers. Some of which will cause horizontal scrolling at 320px wide, or you will see the URLs break-out of their container. When the style 'a.wrapped {overflow-wrap: break-word;} is toggled with the button, the long URLs will wrap within their respective containers. </p>
   <button>Toggle CSS for long URLs</button>  
 
-  <p>Example 1 - URL with words, spaces, dashes, and underscores which allow the URL to wrap in some browsers:</p>
-  <ul>
-    <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
-  </ul>
-
-  <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes, but some long sections of unbroken alphanumeric characters.
+  <p>Example - URL with equal signs, underscores, ampersands, and dashes, but some long sections of unbroken alphanumeric characters.
   Note: due to the * selector all examples work in IE/Edge styled or not.</p>
   <ul>
-    <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;pd_rd_r=83748ec1-7f0811e898f0e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=367013868N2MAQAMF45G1WDFW&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
+    <li><a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;pd_rd_r=83748ec1-7f0811e898f0e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=367013868N2MAQAMF45G1WDFW&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
   </ul>
   
 </main>

--- a/working-examples/css-reflow-url/index.html
+++ b/working-examples/css-reflow-url/index.html
@@ -26,41 +26,19 @@ aside[role="complementary"] {
 footer[role="contentinfo"] {
 	grid-area: footer;
 }
-.grid,  .subgrid {
+.grid {
 	display: grid;
-	grid-template-columns: 1fr;
+	overflow-x: auto;
 }
 .grid {
 	grid-template-areas: 'header'  'main'  'aside'  'footer';
-	width: 100%;
+	width: 320px;
 }
-.subgrid {
-	width: calc(100% + 2em);
-	margin: 0 -1em;
-}
-.grid-item,  .subgrid-item {
+.grid-item {
 	padding: 1em;
 }
 .grid > * {
 min-width: 0;
-}
-.subgrid > * {
-min-width: 0;
-}
- @media all and (min-width: 576px) {
-.subgrid {
-	grid-template-columns: 1fr 1fr;
-	margin-bottom: 1rem;
-}
-.subgrid-item {
-	padding-bottom: 0.25em;
-}
-}
- @media all and (min-width: 992px) {
-.grid {
-	grid-template-areas: 'header header header'  'main main aside'  'footer footer footer';
-	grid-template-columns: 1fr 1fr 1fr;
-}
 }
 
 /* Content Styling */
@@ -169,93 +147,29 @@ word-wrap: break-word;
     </head>
 
     <body class="grid">
-<header role="banner" class="grid-item"> <a href="https://w3.org/"><img alt="W3C" class="logo" src="https://www.w3.org/WAI/assets/images/w3c.svg">Header</a>
-      <nav>
-    <ul>
-          <li><a href="#">Home</a></li>
-          <li><a href="#">Products</a></li>
-          <li><a href="#">About</a></li>
-          <li><a href="#">Contact</a></li>
-        </ul>
-  </nav>
+<header role="banner" class="grid-item"> <a href="https://w3.org/"><img alt="W3C" class="logo" src="https://www.w3.org/WAI/assets/images/w3c.svg"></a>
     </header>
 <main role="main" class="grid-item">
-      <h1>Allowing for Reflow with Long URLs</h1>
-      <p>Long URLs can break reflow when the page is zoomed. The objective of this technique is to present URLs without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels or a vertical scroll bar at a height equivalent to 256 CSS pixels. This is done by using CSS techniques that adapt to the available viewport space. Note: Using human readable text links, rather than long URLS, is better for usability and accessibility. </p>
-      <p>By default most browsers will wrap long URLs at the following characters: </p>
-      <ul>
-    <li>&quot;-&quot; Hyphen </li>
-    <li>&quot; &quot; Space</li>
-    <li>"?" Question (IE, Chrome, Safari) </li>
-    <li>&quot;&amp;&quot; Ampersand (Firefox only)</li>
-  </ul>
-      <p>Sometimes these are not enough to ensure that long URLs will not overflow the viewport. Because of browser link wrapping rules (see list above), links will wrap or not in different places.  Note: Due to browser specific CSS, all examples below wrap in IE/Edge. The button has no effect in IE/Edge.</p>
-  <p>The default state of this page is that no anchors are styled. You should see links breaking the boundaries of their containers. Some of which will cause horizontal scrolling. When the style 'a.wrapped {overflow-wrap: break-word;} is toggled with the button, the long URLs will wrap within their respective containers. </p>
- <button>Toggle CSS for long URLs</button>  
-      <p>Example 1 - URL with words, spaces, dashes, and underscores</p>
-           <ul>
+  <h1>Allowing for Reflow with Long URLs</h1>
+  <p>Long URLs can break reflow when the page is zoomed. See the technique <a href="../../techniques/css/TBC">Allowing for Reflow with Long URLs</a> for further details.</p>
+
+  <p>The default state of this page is to be 320px wide (like a mobile-sized display) with no styling on the links. You should see link-text breaking the boundaries of their containers. Some of which will cause horizontal scrolling at 320px wide, or you will see the URLs break-out of their container. When the style 'a.wrapped {overflow-wrap: break-word;} is toggled with the button, the long URLs will wrap within their respective containers. </p>
+  <button>Toggle CSS for long URLs</button>  
+
+  <p>Example 1 - URL with words, spaces, dashes, and underscores which allow the URL to wrap in some browsers:</p>
+  <ul>
     <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
   </ul>
-      <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.
-    Note: due to the * selector all examples work in IE/Edge styled or not.</p>
-      <ul>
-    <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
+
+  <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes, but some long sections of unbroken alphanumeric characters.
+  Note: due to the * selector all examples work in IE/Edge styled or not.</p>
+  <ul>
+    <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;pd_rd_r=83748ec1-7f0811e898f0e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=367013868N2MAQAMF45G1WDFW&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
   </ul>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc porttitor lorem vitae quam aliquam, vel vulputate dolor ultricies. Sed sed nunc ipsum. Aliquam rhoncus risus pellentesque, faucibus nunc sodales, laoreet risus. Nulla interdum purus at facilisis porta.</p>
-<div class="subgrid">
-    <div class="subgrid-item">
-          <div class="panel">
-        <h3>Panel 1</h3>
-        <p>Nam venenatis turpis in erat tincidunt, non laoreet sem egestas. Etiam feugiat vehicula risus, non lobortis turpis aliquam nec. Nunc nec cursus arcu. In felis sapien, dictum a metus in, vehicula fermentum sem. Morbi in aliquam lorem. Suspendisse in interdum nunc.</p>
-        <p>Example 1 - URL with words, spaces, dashes, and underscores<br>
-          Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
-        <ul>
-          <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
-            </ul>
-        <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.<br>
-          Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
-        <ul>
-          <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
-            </ul>
-      </div>
-        </div>
-    <div class="subgrid-item">
-          <div class="panel">
-        <h3>Panel 2</h3>
-        <p>Curabitur semper dui dui, quis interdum felis ullamcorper ut. Sed mauris eros, ullamcorper eget dolor a, fringilla consequat mi. In tortor lorem, varius in accumsan et, volutpat eu dolor. Proin fermentum velit non nulla blandit pharetra.</p>
-        <p>Example 1 - URL with words, spaces, dashes, and underscores<br>
-Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
-        <ul>
-          <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
-        </ul>
-        <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.
-              <br>
-              Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
-        <ul>
-          <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
-            </ul>
-      </div>
-        </div>
- </div>
-    </main>
-<aside role="complementary" class="grid-item">
-      <h2>Aside</h2>
-      <p>Quisque ac ultricies massa. Ut eu aliquam sem. Aenean sit amet pharetra tellus, eu sollicitudin sem. Curabitur sit amet erat mi. Proin rutrum pretium nisl nec ornare. Curabitur ultricies eros justo, vel tempus augue consequat eget. Ut lacinia orci a eleifend facilisis.</p>
-      <p>Example 1 - URL with words, spaces, dashes, and underscores<br>
-      Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
-      <ul>
-    <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
-  </ul>
-      <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.
-        <br>
-        Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
-      <ul>
-    <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
-  </ul>
-    </aside>
+  
+</main>
 <footer role="contentinfo" class="grid-item">
-      <h2>Footer</h2>
-      <p>Copyright © 2018 W3C <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>) <a href="/Consortium/Legal/ipr-notice">Usage policies apply</a>. </p>
-    </footer>
+    <h2>Footer</h2>
+</footer>
 </body>
 </html>

--- a/working-examples/css-reflow-url/index.html
+++ b/working-examples/css-reflow-url/index.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    <meta charset="UTF-8">
+    <title>Using media queries and grid CSS to reflow columns</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script>
+$(document).ready(function(){
+    $("button").click(function(){
+        $("a").toggleClass("wrapped");
+    });
+});
+</script>
+    <style>
+/* Reflow Styling */
+
+header[role="banner"] {
+	grid-area: header;
+}
+main[role="main"] {
+	grid-area: main;
+}
+aside[role="complementary"] {
+	grid-area: aside;
+}
+footer[role="contentinfo"] {
+	grid-area: footer;
+}
+.grid,  .subgrid {
+	display: grid;
+	grid-template-columns: 1fr;
+}
+.grid {
+	grid-template-areas: 'header'  'main'  'aside'  'footer';
+	width: 100%;
+}
+.subgrid {
+	width: calc(100% + 2em);
+	margin: 0 -1em;
+}
+.grid-item,  .subgrid-item {
+	padding: 1em;
+}
+.grid > * {
+min-width: 0;
+}
+.subgrid > * {
+min-width: 0;
+}
+ @media all and (min-width: 576px) {
+.subgrid {
+	grid-template-columns: 1fr 1fr;
+	margin-bottom: 1rem;
+}
+.subgrid-item {
+	padding-bottom: 0.25em;
+}
+}
+ @media all and (min-width: 992px) {
+.grid {
+	grid-template-areas: 'header header header'  'main main aside'  'footer footer footer';
+	grid-template-columns: 1fr 1fr 1fr;
+}
+}
+
+/* Content Styling */
+
+html {
+	box-sizing: border-box;
+}
+*,  *::before,  *::after {
+	box-sizing: inherit;
+}
+body {
+	font-family: Noto Sans, Trebuchet MS, Helvetica Neue, Arial, sans-serif;
+	background-color: #fafafc;
+	margin: 0;
+}
+a:hover {
+	text-decoration: none;
+}
+h1, h2, h3 {
+	color: #005a6a;
+}
+h1 {
+	font-size: 2rem;
+	margin: 0;
+}
+h2 {
+	font-size: 1.5em;
+	margin-top: 0;
+}
+h3 {
+	font-size: 1.2em;
+	margin-top: 0;
+}
+header[role="banner"] {
+	background-color: #005a9c;
+	margin-top: 1em;
+}
+header nav ul {
+	list-style: none;
+}
+header nav ul li {
+	display: inline;
+	padding: 0 0.25em;
+}
+nav {
+	position: relative;
+	border-top: 1px solid #005a9c;
+	border-bottom: 1px solid #005a9c;
+	background-color: #003366;
+	margin: 0 -1em -1em -1em;
+}
+nav ul {
+	padding-left: 1em;
+}
+header nav ul li a {
+	color: #ffffff;
+}
+main[role="main"] {
+	background: #ffffff;
+	padding-bottom: 0;
+}
+aside[role="complementary"] {
+	border-left: 1px solid #dddddd;
+}
+footer[role="contentinfo"] {
+	color: #ffffff;
+	background-color: #3b3b3b;
+}
+footer h2 {
+	color: #ffffff;
+}
+.logo {
+	width: 90px;
+	vertical-align: middle;
+	margin: 0 .5em 1em 0;
+}
+.panel {
+	background-color: #fafafc;
+	border: 1px solid #ddd;
+	padding: 1rem;
+}
+    /* URL styling */
+    /* specific for IE10 & 11, they do not support these declarations with "a" or ".wrapped" selector
+      also, must use "word-wrap" property rather than "overflow-wrap" */
+    
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+* {
+	word-wrap: break-word;
+}
+}
+
+/* for all Edge, does not support these declarations with "a" or ".wrapped" selector, so must use "*" selector */
+@supports (-ms-ime-align:auto) {
+ * {
+word-wrap: break-word;
+ overflow-wrap: break-word;
+}
+}
+/* all other browsers long url styling */
+
+.wrapped {
+	word-wrap:break-word;
+	overflow-wrap: break-word;
+}
+</style>
+    </head>
+
+    <body class="grid">
+<header role="banner" class="grid-item"> <a href="https://w3.org/"><img alt="W3C" class="logo" src="https://www.w3.org/WAI/assets/images/w3c.svg">Header</a>
+      <nav>
+    <ul>
+          <li><a href="#">Home</a></li>
+          <li><a href="#">Products</a></li>
+          <li><a href="#">About</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+  </nav>
+    </header>
+<main role="main" class="grid-item">
+      <h1>Allowing for Reflow with Long URLs</h1>
+      <p>Long URLs can break reflow when the page is zoomed. The objective of this technique is to present URLs without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels or a vertical scroll bar at a height equivalent to 256 CSS pixels. This is done by using CSS techniques that adapt to the available viewport space. Note: Using human readable text links, rather than long URLS, is better for usability and accessibility. </p>
+      <p>By default most browsers will wrap long URLs at the following characters: </p>
+      <ul>
+    <li>&quot;-&quot; Hyphen </li>
+    <li>&quot; &quot; Space</li>
+    <li>"?" Question (IE, Chrome, Safari) </li>
+    <li>&quot;&amp;&quot; Ampersand (Firefox only)</li>
+  </ul>
+      <p>Sometimes these are not enough to ensure that long URLs will not overflow the viewport. Because of browser link wrapping rules (see list above), links will wrap or not in different places.  Note: Due to browser specific CSS, all examples below wrap in IE/Edge. The button has no effect in IE/Edge.</p>
+  <p>The default state of this page is that no anchors are styled. You should see links breaking the boundaries of their containers. Some of which will cause horizontal scrolling. When the style 'a.wrapped {overflow-wrap: break-word;} is toggled with the button, the long URLs will wrap within their respective containers. </p>
+ <button>Toggle CSS for long URLs</button>  
+      <p>Example 1 - URL with words, spaces, dashes, and underscores</p>
+           <ul>
+    <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
+  </ul>
+      <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.
+    Note: due to the * selector all examples work in IE/Edge styled or not.</p>
+      <ul>
+    <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
+  </ul>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc porttitor lorem vitae quam aliquam, vel vulputate dolor ultricies. Sed sed nunc ipsum. Aliquam rhoncus risus pellentesque, faucibus nunc sodales, laoreet risus. Nulla interdum purus at facilisis porta.</p>
+<div class="subgrid">
+    <div class="subgrid-item">
+          <div class="panel">
+        <h3>Panel 1</h3>
+        <p>Nam venenatis turpis in erat tincidunt, non laoreet sem egestas. Etiam feugiat vehicula risus, non lobortis turpis aliquam nec. Nunc nec cursus arcu. In felis sapien, dictum a metus in, vehicula fermentum sem. Morbi in aliquam lorem. Suspendisse in interdum nunc.</p>
+        <p>Example 1 - URL with words, spaces, dashes, and underscores<br>
+          Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
+        <ul>
+          <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
+            </ul>
+        <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.<br>
+          Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
+        <ul>
+          <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
+            </ul>
+      </div>
+        </div>
+    <div class="subgrid-item">
+          <div class="panel">
+        <h3>Panel 2</h3>
+        <p>Curabitur semper dui dui, quis interdum felis ullamcorper ut. Sed mauris eros, ullamcorper eget dolor a, fringilla consequat mi. In tortor lorem, varius in accumsan et, volutpat eu dolor. Proin fermentum velit non nulla blandit pharetra.</p>
+        <p>Example 1 - URL with words, spaces, dashes, and underscores<br>
+Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
+        <ul>
+          <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
+        </ul>
+        <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.
+              <br>
+              Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
+        <ul>
+          <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
+            </ul>
+      </div>
+        </div>
+ </div>
+    </main>
+<aside role="complementary" class="grid-item">
+      <h2>Aside</h2>
+      <p>Quisque ac ultricies massa. Ut eu aliquam sem. Aenean sit amet pharetra tellus, eu sollicitudin sem. Curabitur sit amet erat mi. Proin rutrum pretium nisl nec ornare. Curabitur ultricies eros justo, vel tempus augue consequat eget. Ut lacinia orci a eleifend facilisis.</p>
+      <p>Example 1 - URL with words, spaces, dashes, and underscores<br>
+      Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
+      <ul>
+    <li>No style applied: <a href="#">http://Iterative.approaches-to-corporate_strategy.net/foster collaborative thinking.to.further/the_overall-value proposition.htm</a></li>
+  </ul>
+      <p>Example 2 - URL with equal signs, underscores, ampersands, and dashes.
+        <br>
+        Note: Due to specific browser CSS, all examples work in IE/Edge. The button has no effect.</p>
+      <ul>
+    <li>No style applied: <a href="#">https://www.somecompany.com/gp/product/0060899220/ref=s9u_ri_gw_i7/135-1685811-9188658?ie=UTF8&amp;fpl=fresh&amp;pd_rd_i=0060899220&amp;pd_rd_r=83748ec1-7f08-11e8-98f0-e51cfb7ffc73&amp;pd_rd_w=KYrDt&amp;pd_rd_wg=lx9SR&amp;pf_rd_m=ATVPDKIKX0DER&amp;pf_rd_s=&amp;pf_rd_r=3868N2MAQAMF45G1WDFW&amp;pf_rd_t=36701&amp;pf_rd_p=5cd472c0-39fe-4ebd-be4b-f95163d1a3f5&amp;pf_rd_i=desktop</a></li>
+  </ul>
+    </aside>
+<footer role="contentinfo" class="grid-item">
+      <h2>Footer</h2>
+      <p>Copyright © 2018 W3C <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>) <a href="/Consortium/Legal/ipr-notice">Usage policies apply</a>. </p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Where a URL is shown on the page (not just in an href), it can create horizontal scrolling at higher zooms or smaller viewports.

This is a technique from @allanj-uaag, I just ported it over to get reviews & updates.

View the [rendered version of the technique](https://rawgit.com/w3c/wcag/tech-reflow-url/techniques/css/reflow-url.html), and the [example](https://rawgit.com/w3c/wcag/tech-reflow-url/working-examples/css-reflow-url/).