### PR TITLE
editorial changes to existing 1.4.11 understanding doc

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -22,7 +22,7 @@
 				<figure>
 					<!-- example from https://getbootstrap.com/docs/4.1/components/buttons/ -->
 					<img alt="Two buttons on a white background. The first has a blue border to indicate its boundary, white internal background and blue text. The second adds a thick blue-grey outer border to show focus." src="img/first-button-example.png" /> 
-					<figcaption>An active control showing the visual boundary by default (color of <code>#007bff</code> on white), and the focus indicator.</figcaption>
+					<figcaption>An active control showing the visual boundary by default (color of <code>#007bff</code> on white), and the focus indicator</figcaption>
 				</figure>
 				
 				<p>This success criteria does not require that controls have a visual boundary indicating the hit area, but if the visual indicator of the control is the only way to identify the control, then that indicator must have sufficient contrast. If text (or an icon) within a button is visible and there is no visual indication of the hit area, or the visual indication does not provide the only indication, then there is no contrast requirement beyond the text contrast (<a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>) or icon contrast covered by the Graphical Objects part of this Success Criteria. Note that for people with cognitive disabilities it is recommended to delineate the boundary of controls to aid in the recognition of controls and therefore the completion of activities.</p>
@@ -31,14 +31,14 @@
 
 				<figure>
 					<img alt="Two buttons, the first with no visual indicator except text saying 'button'. The second is the same but with an added grey border." src="img/minimal-button.png" /> 
-					<figcaption>An active control without a visual boundary, but with a focus indicator when focused.</figcaption>
+					<figcaption>An active control without a visual boundary, but with a focus indicator when focused</figcaption>
 				</figure>
 
-				<p>The <a href="use-of-color">Use of Color</a> success criteria addresses changing <strong>only the color</strong> of an object (or text) without otherwise altering the object's form. If a controls indicator of state (e.g. button background) varies only by color this is acceptable if the luminosity contrast ratio between the colors of the states differ by at least 3:1, or if there is another indicator of state. For example, a text link that only differs from adjacent text using color and there is no other visual indication that the text is linked (e.g. the link underline is removed) needs to ensure that the link color meets the 3:1 luminosity contrast ratio relative to the non-linked text color in order to meet the related Success Criteria 1.4.1.</p>
+				<p>The <a href="use-of-color">Use of Color</a> success criteria addresses changing <strong>only the color</strong> of an object (or text) without otherwise altering the object's form. If a control's indicator of state (e.g., button background) varies only by color this is acceptable if the luminosity contrast ratio between the colors of the states differ by at least 3:1, or if there is another indicator of state. For example, a text link that only differs from adjacent text using color where there is no other visual indication that the text is linked (i.e., the link underline is removed) needs to ensure that the link color meets the 3:1 luminosity contrast ratio relative to the non-linked text color in order to meet the related Success Criteria 1.4.1.</p>
 
 				<figure>
 					<img alt="Two buttons, the first has a blue outline and inner white background with blue text. The second has a blue background with white text, reversing the color scheme." src="img/button-example2.png" /> 
-					<figcaption>An active control with a visual boundary, and a focus (or other) state that is highlighted with a contrasting change of color.</figcaption>
+					<figcaption>An active control with a visual boundary, and a focus (or other) state that is highlighted with a contrasting change of color</figcaption>
 				</figure>
 
         <section>
@@ -111,10 +111,10 @@
 				<section id="inactive-controls">
 					<h4>Inactive User Interface Components</h4>
 
-					<p>User Interface Components that are not available for user interaction (eg: a disabled control in HTML) are not required to meet contrast requirements in WCAG 2.1. An inactive user interface component is visible but not currently operable. Example: A submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed.</p>
+					<p>User Interface Components that are not available for user interaction (e.g., a disabled control in HTML) are not required to meet contrast requirements in WCAG 2.1. An inactive user interface component is visible but not currently operable. An example would be a submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed.</p>
 					<figure>
 						<img src="img/inactive-button.png" alt="Grey button with non-contrasting grey text." width="120" />
-						<figcaption>An in-active button using default browser styles.</figcaption>
+						<figcaption>An inactive button using default browser styles</figcaption>
 					</figure>
 					<p>Inactive components, such as disabled controls in HTML, are not available for user interaction. The decision to exempt inactive controls from the contrast requirements was based on a number of considerations:</p>
 					<ul>
@@ -134,7 +134,7 @@
 							</ul>
 						</li>
 					</ul>
-					<p>A one-size fits all solution has been very difficult to establish, a method of varying the presentation of disabled controls, or adding an icon for disabled controls, based on user preferences is anticipated as an advancement in future.</p>
+					<p>A one-size-fits-all solution has been very difficult to establish. A method of varying the presentation of disabled controls, such as adding an icon for disabled controls, based on user preferences is anticipated as an advancement in the future.</p>
 
 				</section>
 			</section><!-- end user-interface-component section -->
@@ -225,12 +225,12 @@
 				<section>
 				<h4>Dynamic Examples</h4>
 
-				<p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, there must be contrasting colors or text in order to find the graphics. Within that area, information available by a conforming method (e.g. focusable elements) can be used to make that information available dynamically as text, or dynamically increase the contrast.</p>
+				<p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, there must be contrasting colors or text in order to find the graphics. Within that area, information available by a conforming method (e.g., focusable elements) can be used to make that information available dynamically as text, or dynamically increase the contrast.</p>
 
 				<!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
 				<figure>
 					<img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350" /> 
-					<figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series.</figcaption>
+					<figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
 				</figure>
 				</section>
 				<section>


### PR DESCRIPTION
This commit is ancillary to the request in https://github.com/w3c/wcag/issues/481 to propogate the inactive control information to the two 2.0 Contrast SCs.
- It fixes up the inconsistent use of e.g., and i.e., ;
- removes terminating punctuation in figure captions that are sentence fragments (but for now leaves in place periods in those captions that form complete sentences; pending clarity from @michael-n-cooper );
- does trivial editorial changes (adding a missing possessive, removing or adding dashes as necessary);
- slightly alters a phrase for better readability