### PR TITLE
Tech fitting images viewport

### DIFF
--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -33,7 +33,7 @@
     <section id="examples">
       <h2>Examples</h2>
       <section class="example">
-        <h3>Example 1: Simple fitting images in HTML and CSS</h3>
+        <h3>Example 1: Fitting images in HTML and CSS</h3>
         <p>The following simple example uses HTML and CSS to create a fitting image. The layout regions adjust their size as the viewport is adjusted. The images subsequently adjust their size to fit within the layout region containers.</p>
         <p>The zoom level can be increased to 400% without requiring scrolling in more than one direction. This particular example uses a percent size for the <code>max-with</code> and auto size for the <code>height</code> of the image to remain the original dimensions.</p>
 

--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-	<head>
-		<title>Using CSS max-width and height to fit images</title>
-		<link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
-	</head>
-	<body>
-		<h1>Using CSS max-width and height to fit images</h1>
-		<section id="meta">
-			<h2>Metadata</h2>
-			<p id="id"></p>
-			<p id="technology">css</p>
-			<p id="type">sufficient</p>
-		</section>
-		<section id="applicability">
-			<h2>When to Use</h2>
-			<p>This technique is applicable to Cascading Style Sheet / HTML technologies.</p>
-		</section>
-		<section id="description">
-			<h2>Description</h2>
-      <p>The objective of this technique is to be able to present images without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for text intended to scroll horizontally. This is done by using CSS <code>max-width</code> and <code>height</code> property techniques that adapt to the available space and keep the original dimensions of the image.</p>
+  <head>
+    <title>Using CSS max-width and height to fit images</title>
+    <link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
+  </head>
+  <body>
+    <h1>Using CSS max-width and height to fit images</h1>
+    <section id="meta">
+      <h2>Metadata</h2>
+      <p id="id"></p>
+      <p id="technology">css</p>
+      <p id="type">sufficient</p>
+    </section>
+    <section id="applicability">
+      <h2>When to Use</h2>
+      <p>This technique is applicable to Cascading Style Sheet / HTML technologies.</p>
+    </section>
+    <section id="description">
+      <h2>Description</h2>
+      <p>The objective of this technique is to be able to present images without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for content intended to scroll horizontally. This is done by using CSS <code>max-width</code> and <code>height</code> property techniques that adapt to the available space and keep the original dimensions of the image.</p>
       
       <p>Layouts define layout regions that reflow as needed to display the region on the screen. Although the exact layout and available space in the regions for images therefore varies, the fitting in and the dimensions of the images within the region remain the same when done right. This is an effective way to create designs that present well on different devices and for users with different zoom preferences.</p>
       <p>The basic principles of fitting images are to:</p>
@@ -30,12 +30,12 @@
       
       <p>All images require design finesse by making sure the original size fits the biggest size of the available spaces to achieve good-looking results at a wide range of viewport sizes and zoom levels.</p>
       
-		</section>
-		<section id="examples">
-			<h2>Examples</h2>
+    </section>
+    <section id="examples">
+      <h2>Examples</h2>
       <section class="example">
-				<h3>Example 1: Simple fitting images in HTML and CSS</h3>
-				<p>The following simple example uses HTML and CSS to create a fitting image. The layout regions adjust their size as the viewport is adjusted. The images subsequently adjust their size to fit within the layout region containers.</p>
+        <h3>Example 1: Simple fitting images in HTML and CSS</h3>
+        <p>The following simple example uses HTML and CSS to create a fitting image. The layout regions adjust their size as the viewport is adjusted. The images subsequently adjust their size to fit within the layout region containers.</p>
         <p>The zoom level can be increased to 400% without requiring scrolling in more than one direction. This particular example uses a percent size for the <code>max-with</code> and auto size for the <code>height</code> of the image to remain the original dimensions.</p>
 
 <pre>
@@ -59,12 +59,12 @@
 </code>
 </pre>
         
-				<p>Working example: <a href="https://rawgit.com/w3c/wcag/example-fitting-images-viewport/working-examples/css-fitting-images/index.html">Using Fitting Images for Reflow</a></p>
+        <p>Working example: <a href="https://rawgit.com/w3c/wcag/example-fitting-images-viewport/working-examples/css-fitting-images/index.html">Using Fitting Images for Reflow</a></p>
         
-			</section>
-		</section>
-		<section id="tests">
-			<h2>Tests</h2>      
+      </section>
+    </section>
+    <section id="tests">
+      <h2>Tests</h2>      
       <section class="test-procedure">
         <h3>Procedure</h3>
         <ol>
@@ -79,12 +79,12 @@
         <h3>Expected Results</h3>
         <p>Check that #3 and #4 are true.</p>
 </section>
-		</section>
-		<section id="related">
-			<h2>Related Techniques</h2>
-			<ul>
-				<li>ID</li>
-			</ul>
-		</section>
-	</body>
+    </section>
+    <section id="related">
+      <h2>Related Techniques</h2>
+      <ul>
+        <li>ID</li>
+      </ul>
+    </section>
+  </body>
 </html>

--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -19,7 +19,7 @@
     <section id="description">
       <h2>Description</h2>
       <p>The objective of this technique is to be able to present images without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for content intended to scroll horizontally. This is done by using CSS <code>max-width</code> and <code>height</code> property techniques that adapt to the available space and keep the original dimensions of the image.</p>      
-      <p>Responsive layouts can add or remove colomns or layout blocks, and each part of the layout can be wider or smaller at different points. This technique ensures images do not break out of their layout area, including in one-column layouts where it would cause scrolling.</p>
+      <p>Responsive layouts can add or remove columns or layout blocks, and each part of the layout can be wider or smaller at different points. This technique ensures images do not break out of their layout area, including in one-column layouts where it would cause scrolling.</p>
       <p>The basic principles of fitting images are to:</p>
       
       <ol>

--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Using media queries and grid CSS to reflow columns</title>
+    <link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
+  </head>
+  <body>
+    <h1>Using media queries and grid CSS to reflow columns</h1>
+    <section id="meta">
+      <h2>Metadata</h2>
+      <p id="id"></p>
+      <p id="technology">css</p>
+      <p id="type">sufficient</p>
+    </section>
+    <section id="applicability">
+      <h2>When to Use</h2>
+    </section>
+    <section id="description">
+      <h2>Description</h2>
+      <p>The objective of this technique is to be able to present content without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for text intended to scroll horizontally. This is done by using layout techniques that adapt to the available viewport space.</p>
+      <p><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid layouts</a> define layout regions that reflow as needed to display the region on the screen. Although the exact layout therefore varies, the relationship of elements and the reading order remains the same when done right. This is an effective way to create designs that present well on different devices and for users with different content-size preferences.</p>
+      <p>The basic principles of grid layouts are to:</p>
+      <ol>
+        <li>Define the size of layout regions using grid properties and media queries for specific viewport sizes, so they enlarge, shrink or wrap in the available space and respond to zoom levels;</li>       
+         <li>Position the layout regions in the grid container as a row of adjacent grid items, which may wrap to new rows as needed in much the same way as words in a paragraph wrap.</li>
+      </ol>
+      <p class="note">Use of grid layout CSS can cause a keyboard navigation disconnect by making the visual layout and source-code order different. The <a href="https://www.w3.org/TR/css-grid-1/#placement-a11y">CSS Grid Layout Module Level 1 warns</a> against re-ordering content by grid item placement as they cause an incorrect focus order for keyboard users and others.</p>
+    </section>
+    <section id="examples">
+      <h2>Examples</h2>
+      <section class="example">
+        <h3>Example 1: Grid layout in HTML and CSS - Medium complexity</h3>
+        <p>The following medium complexity example uses HTML and CSS to create a grid layout. The layout regions adjust their size as the viewport is adjusted. When the total viewport width matches the width defined via media queries, columns wrap to be positioned below, rather than beside each other or vice versa.</p>
+        
+        <p>The zoom level can be increased to 400% without requiring scrolling in more than one direction. This particular example uses fr units as a fraction of the free space of the grid container for the grid items by using the "grid-template-columns" property and are laid out in source order.</p>
+<pre><code>
+  &lt;!DOCTYPE html&gt;
+    &lt;html lang="en"&gt;
+      &lt;head&gt;
+        &lt;meta charset="UTF-8"&gt;
+        &lt;title&gt;CSS: Using media queries and grid CSS to reflow columns&lt;/title&gt;
+        &lt;style&gt;
+
+        /* Reflow Styling */
+        header[role="banner"]       { grid-area: header; }
+        main[role="main"]           { grid-area: main; }
+        aside[role="complementary"] { grid-area: aside; }
+        footer[role="contentinfo"]  { grid-area: footer; }
+
+        .grid,
+        .subgrid {
+          display: grid;
+          grid-template-columns: 1fr;
+        }
+
+        .grid {
+          grid-template-areas:
+          'header'
+          'main'
+          'aside'
+          'footer';
+          width: 100%;
+        }
+
+        .subgrid {
+          width: calc(100% + 2em);
+          margin: 0 -1em;
+        }
+
+        .grid-item,
+        .subgrid-item {
+          padding: 1em;
+        }
+
+        @media all and (min-width: 576px) {
+          .subgrid {
+            grid-template-columns: 1fr 1fr;
+            margin-bottom: 1rem;
+          }
+          .subgrid-item {
+            padding-bottom: 0.25em;
+          }
+        }
+
+        @media all and (min-width: 992px) { 
+          .grid {
+            grid-template-areas:
+              'header header header'
+              'main main aside'
+              'footer footer footer';
+            grid-template-columns: 1fr 1fr 1fr;
+          }
+        }
+
+        &lt;/style&gt;
+
+      &lt;/head&gt;
+
+      &lt;body class="grid"&gt;
+
+        &lt;header role="banner" class="grid-item"&gt;
+          ...
+        &lt;/header&gt;
+
+        &lt;main role="main" class="grid-item"&gt;        
+          ...
+          ...
+          &lt;div class="subgrid"&gt;
+            &lt;div class="subgrid-item"&gt;
+              ...
+            &lt;/div&gt;
+            &lt;div class="subgrid-item"&gt;
+              ...
+            &lt;/div&gt;
+          &lt;/div&gt;
+        &lt;/main&gt;
+
+        &lt;aside role="complementary" class="grid-item"&gt;
+          ...
+        &lt;/aside&gt;
+
+        &lt;footer role="contentinfo" class="grid-item"&gt;
+          ...
+        &lt;/footer&gt;
+
+      &lt;/body&gt;
+    &lt;/html&gt;
+</code></pre>
+        <p class="working-example">Working example: <a href="../../working-examples/css-grid/">Using media queries and grid CSS to reflow columns</a></p>
+      </section>
+    </section>
+    <section id="tests">
+      <h2>Tests</h2>
+      <section class="test-procedure">
+        <h3>Procedure</h3>
+        <ol>
+          <li>Display the web page in a user agent capable of 400% zoom and set the viewport dimensions (in CSS pixels) to 1280 wide and 1024 high.</li>
+          <li>Zoom in by 400%.</li>
+          <li>For content read horizontally, check that all content and functionality is available without horizontal scrolling.</li>
+          <li>For content read vertically, check that all content and functionality is available without vertical scrolling.</li>
+        </ol>
+      <p class="note">If the browser is not capable of zooming to 400%, you can reduce the width or height of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
+      </section>
+      <section class="test-results">
+        <h3>Expected Results</h3>
+        <p>Check that #3 and #4 are true.</p>
+      </section>
+    </section>
+    <section id="related">
+      <h2>Related Techniques</h2>
+      <ul>
+        <li><a href="../../techniques/css/C31">Flexbox reflow technique</a></li>
+      </ul>
+    </section>
+    <section id="resources">
+      <h2>Related resources</h2>
+      <ul>
+        <li><a href="https://www.w3.org/TR/css-grid-1/">CSS Grid Layout module level 1</a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout"><abbr title="Mozilla Development Network">MDN</abbr> grid layout index</a></li>
+        <li><a href="http://gridbyexample.com/">Grid by example</a></li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -1,164 +1,90 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head>
-    <title>Using media queries and grid CSS to reflow columns</title>
-    <link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
-  </head>
-  <body>
-    <h1>Using media queries and grid CSS to reflow columns</h1>
-    <section id="meta">
-      <h2>Metadata</h2>
-      <p id="id"></p>
-      <p id="technology">css</p>
-      <p id="type">sufficient</p>
-    </section>
-    <section id="applicability">
-      <h2>When to Use</h2>
-    </section>
-    <section id="description">
-      <h2>Description</h2>
-      <p>The objective of this technique is to be able to present content without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for text intended to scroll horizontally. This is done by using layout techniques that adapt to the available viewport space.</p>
-      <p><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout">Grid layouts</a> define layout regions that reflow as needed to display the region on the screen. Although the exact layout therefore varies, the relationship of elements and the reading order remains the same when done right. This is an effective way to create designs that present well on different devices and for users with different content-size preferences.</p>
-      <p>The basic principles of grid layouts are to:</p>
+	<head>
+		<title>Using CSS max-width and height to fit images</title>
+		<link rel="stylesheet" type="text/css" href="https://rawgit.com/w3c/wcag21/master/css/sources.css"/>
+	</head>
+	<body>
+		<h1>Using CSS max-width and height to fit images</h1>
+		<section id="meta">
+			<h2>Metadata</h2>
+			<p id="id"></p>
+			<p id="technology">css</p>
+			<p id="type">sufficient</p>
+		</section>
+		<section id="applicability">
+			<h2>When to Use</h2>
+			<p>This technique is applicable to Cascading Style Sheet / HTML technologies.</p>
+		</section>
+		<section id="description">
+			<h2>Description</h2>
+      <p>The objective of this technique is to be able to present images without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for text intended to scroll horizontally. This is done by using CSS <code>max-width</code> and <code>height</code> property techniques that adapt to the available space and keep the original dimensions of the image.</p>
+      
+      <p>Layouts define layout regions that reflow as needed to display the region on the screen. Although the exact layout and available space in the regions for images therefore varies, the fitting in and the dimensions of the images within the region remain the same when done right. This is an effective way to create designs that present well on different devices and for users with different zoom preferences.</p>
+      <p>The basic principles of fitting images are to:</p>
+      
       <ol>
-        <li>Define the size of layout regions using grid properties and media queries for specific viewport sizes, so they enlarge, shrink or wrap in the available space and respond to zoom levels;</li>       
-         <li>Position the layout regions in the grid container as a row of adjacent grid items, which may wrap to new rows as needed in much the same way as words in a paragraph wrap.</li>
+        <li>Define the max-width property for images, and;</li>
+        <li>Define the height property for images, so they enlarge or shrink in the available space and respond to zoom levels.</li>
       </ol>
-      <p class="note">Use of grid layout CSS can cause a keyboard navigation disconnect by making the visual layout and source-code order different. The <a href="https://www.w3.org/TR/css-grid-1/#placement-a11y">CSS Grid Layout Module Level 1 warns</a> against re-ordering content by grid item placement as they cause an incorrect focus order for keyboard users and others.</p>
-    </section>
-    <section id="examples">
-      <h2>Examples</h2>
+      
+      <p>All images require design finesse by making sure the original size fits the biggest size of the available spaces to achieve good-looking results at a wide range of viewport sizes and zoom levels.</p>
+      
+		</section>
+		<section id="examples">
+			<h2>Examples</h2>
       <section class="example">
-        <h3>Example 1: Grid layout in HTML and CSS - Medium complexity</h3>
-        <p>The following medium complexity example uses HTML and CSS to create a grid layout. The layout regions adjust their size as the viewport is adjusted. When the total viewport width matches the width defined via media queries, columns wrap to be positioned below, rather than beside each other or vice versa.</p>
+				<h3>Example 1: Simple fitting images in HTML and CSS</h3>
+				<p>The following simple example uses HTML and CSS to create a fitting image. The layout regions adjust their size as the viewport is adjusted. The images subsequently adjust their size to fit within the layout region containers.</p>
+        <p>The zoom level can be increased to 400% without requiring scrolling in more than one direction. This particular example uses a percent size for the <code>max-with</code> and auto size for the <code>height</code> of the image to remain the original dimensions.</p>
+
+<pre>
+<code>
+
+&lt;style&gt;
+
+/* Fitting Images Styling */
+
+.img-responsive {
+  max-width: 100%;
+  height: auto;
+}
+
+&lt;/style&gt;
+
+&lt;div class="panel"&gt;
+  &lt;img class="img-responsive" src="..." alt=""&gt;
+  ...
+&lt;/div&gt;
+</code>
+</pre>
         
-        <p>The zoom level can be increased to 400% without requiring scrolling in more than one direction. This particular example uses fr units as a fraction of the free space of the grid container for the grid items by using the "grid-template-columns" property and are laid out in source order.</p>
-<pre><code>
-  &lt;!DOCTYPE html&gt;
-    &lt;html lang="en"&gt;
-      &lt;head&gt;
-        &lt;meta charset="UTF-8"&gt;
-        &lt;title&gt;CSS: Using media queries and grid CSS to reflow columns&lt;/title&gt;
-        &lt;style&gt;
-
-        /* Reflow Styling */
-        header[role="banner"]       { grid-area: header; }
-        main[role="main"]           { grid-area: main; }
-        aside[role="complementary"] { grid-area: aside; }
-        footer[role="contentinfo"]  { grid-area: footer; }
-
-        .grid,
-        .subgrid {
-          display: grid;
-          grid-template-columns: 1fr;
-        }
-
-        .grid {
-          grid-template-areas:
-          'header'
-          'main'
-          'aside'
-          'footer';
-          width: 100%;
-        }
-
-        .subgrid {
-          width: calc(100% + 2em);
-          margin: 0 -1em;
-        }
-
-        .grid-item,
-        .subgrid-item {
-          padding: 1em;
-        }
-
-        @media all and (min-width: 576px) {
-          .subgrid {
-            grid-template-columns: 1fr 1fr;
-            margin-bottom: 1rem;
-          }
-          .subgrid-item {
-            padding-bottom: 0.25em;
-          }
-        }
-
-        @media all and (min-width: 992px) { 
-          .grid {
-            grid-template-areas:
-              'header header header'
-              'main main aside'
-              'footer footer footer';
-            grid-template-columns: 1fr 1fr 1fr;
-          }
-        }
-
-        &lt;/style&gt;
-
-      &lt;/head&gt;
-
-      &lt;body class="grid"&gt;
-
-        &lt;header role="banner" class="grid-item"&gt;
-          ...
-        &lt;/header&gt;
-
-        &lt;main role="main" class="grid-item"&gt;        
-          ...
-          ...
-          &lt;div class="subgrid"&gt;
-            &lt;div class="subgrid-item"&gt;
-              ...
-            &lt;/div&gt;
-            &lt;div class="subgrid-item"&gt;
-              ...
-            &lt;/div&gt;
-          &lt;/div&gt;
-        &lt;/main&gt;
-
-        &lt;aside role="complementary" class="grid-item"&gt;
-          ...
-        &lt;/aside&gt;
-
-        &lt;footer role="contentinfo" class="grid-item"&gt;
-          ...
-        &lt;/footer&gt;
-
-      &lt;/body&gt;
-    &lt;/html&gt;
-</code></pre>
-        <p class="working-example">Working example: <a href="../../working-examples/css-grid/">Using media queries and grid CSS to reflow columns</a></p>
-      </section>
-    </section>
-    <section id="tests">
-      <h2>Tests</h2>
+				<p>Working example: <a href="https://rawgit.com/w3c/wcag/example-fitting-images-viewport/working-examples/css-fitting-images/index.html">Using Fitting Images for Reflow</a></p>
+        
+			</section>
+		</section>
+		<section id="tests">
+			<h2>Tests</h2>      
       <section class="test-procedure">
         <h3>Procedure</h3>
         <ol>
           <li>Display the web page in a user agent capable of 400% zoom and set the viewport dimensions (in CSS pixels) to 1280 wide and 1024 high.</li>
           <li>Zoom in by 400%.</li>
-          <li>For content read horizontally, check that all content and functionality is available without horizontal scrolling.</li>
-          <li>For content read vertically, check that all content and functionality is available without vertical scrolling.</li>
+          <li>For content read horizontally, check that all images fit in their available space without horizontal scrolling.</li>
+          <li>For content read vertically, check that all images fit in their available space without vertical scrolling.</li>
         </ol>
-      <p class="note">If the browser is not capable of zooming to 400%, you can reduce the width or height of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
+        <p>NB: If the browser is not capable of zooming to 400%, you can reduce the width of the browser proportionally. For example, at 300% zoom the viewport should be sized to 960px wide.</p>
       </section>
       <section class="test-results">
         <h3>Expected Results</h3>
         <p>Check that #3 and #4 are true.</p>
-      </section>
-    </section>
-    <section id="related">
-      <h2>Related Techniques</h2>
-      <ul>
-        <li><a href="../../techniques/css/C31">Flexbox reflow technique</a></li>
-      </ul>
-    </section>
-    <section id="resources">
-      <h2>Related resources</h2>
-      <ul>
-        <li><a href="https://www.w3.org/TR/css-grid-1/">CSS Grid Layout module level 1</a></li>
-        <li><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout"><abbr title="Mozilla Development Network">MDN</abbr> grid layout index</a></li>
-        <li><a href="http://gridbyexample.com/">Grid by example</a></li>
-      </ul>
-    </section>
-  </body>
+</section>
+		</section>
+		<section id="related">
+			<h2>Related Techniques</h2>
+			<ul>
+				<li>ID</li>
+			</ul>
+		</section>
+	</body>
 </html>

--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -47,7 +47,6 @@
 
 .img-responsive {
   max-width: 100%;
-  height: auto;
 }
 
 &lt;/style&gt;

--- a/techniques/css/tech-fitting-images-viewport.html
+++ b/techniques/css/tech-fitting-images-viewport.html
@@ -18,9 +18,8 @@
     </section>
     <section id="description">
       <h2>Description</h2>
-      <p>The objective of this technique is to be able to present images without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for content intended to scroll horizontally. This is done by using CSS <code>max-width</code> and <code>height</code> property techniques that adapt to the available space and keep the original dimensions of the image.</p>
-      
-      <p>Layouts define layout regions that reflow as needed to display the region on the screen. Although the exact layout and available space in the regions for images therefore varies, the fitting in and the dimensions of the images within the region remain the same when done right. This is an effective way to create designs that present well on different devices and for users with different zoom preferences.</p>
+      <p>The objective of this technique is to be able to present images without introducing a horizontal scroll bar at a width equivalent to 320 CSS pixels, or a vertical scroll bar at a height equivalent to 256 CSS pixels for content intended to scroll horizontally. This is done by using CSS <code>max-width</code> and <code>height</code> property techniques that adapt to the available space and keep the original dimensions of the image.</p>      
+      <p>Responsive layouts can add or remove colomns or layout blocks, and each part of the layout can be wider or smaller at different points. This technique ensures images do not break out of their layout area, including in one-column layouts where it would cause scrolling.</p>
       <p>The basic principles of fitting images are to:</p>
       
       <ol>


### PR DESCRIPTION
New technique for Using Fitting Images for Reflow, you can preview [Using CSS max-width and height to fit images](https://rawgit.com/w3c/wcag/tech-fitting-images-viewport/techniques/css/tech-fitting-images-viewport.html), and there is an associated [example page](https://rawgit.com/w3c/wcag/example-fitting-images-viewport/working-examples/css-fitting-images/index.html).