### PR TITLE
Fix: Correct broken link

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -78,7 +78,7 @@
 			</section>
         	<section>
         		<h3>Requirements for WCAG 2.1</h3>
-                <p>WCAG 2.1 meets a set of <a href="https://w3c.github.io/wcag/requirements/">requirements for WCAG 2.1</a> which, in turn, inherit requirements from WCAG 2.0. Requirements structure the overall framework of guidelines and ensure backwards compatibility. The Working Group also used a less formal set of acceptance criteria for success criteria, to help ensure success criteria are similar in style and quality to those in WCAG 2.0. These requirements constrained what could be included in WCAG 2.1. This constraint was important to preserve its nature as a dot-release of WCAG 2.</p>
+                <p>WCAG 2.1 meets a set of <a href="https://w3c.github.io/wcag/wcag21/requirements/">requirements for WCAG 2.1</a> which, in turn, inherit requirements from WCAG 2.0. Requirements structure the overall framework of guidelines and ensure backwards compatibility. The Working Group also used a less formal set of acceptance criteria for success criteria, to help ensure success criteria are similar in style and quality to those in WCAG 2.0. These requirements constrained what could be included in WCAG 2.1. This constraint was important to preserve its nature as a dot-release of WCAG 2.</p>
         	</section>
     		<section>
                 <h3>Comparison with WCAG 2.0</h3>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -78,7 +78,7 @@
 			</section>
         	<section>
         		<h3>Requirements for WCAG 2.1</h3>
-                <p>WCAG 2.1 meets a set of <a href="https://w3c.github.io/wcag/wcag21/requirements/">requirements for WCAG 2.1</a> which, in turn, inherit requirements from WCAG 2.0. Requirements structure the overall framework of guidelines and ensure backwards compatibility. The Working Group also used a less formal set of acceptance criteria for success criteria, to help ensure success criteria are similar in style and quality to those in WCAG 2.0. These requirements constrained what could be included in WCAG 2.1. This constraint was important to preserve its nature as a dot-release of WCAG 2.</p>
+                <p>WCAG 2.1 meets a set of <a href="https://w3c.github.io/wcag21/requirements/">requirements for WCAG 2.1</a> which, in turn, inherit requirements from WCAG 2.0. Requirements structure the overall framework of guidelines and ensure backwards compatibility. The Working Group also used a less formal set of acceptance criteria for success criteria, to help ensure success criteria are similar in style and quality to those in WCAG 2.0. These requirements constrained what could be included in WCAG 2.1. This constraint was important to preserve its nature as a dot-release of WCAG 2.</p>
         	</section>
     		<section>
                 <h3>Comparison with WCAG 2.0</h3>


### PR DESCRIPTION
Add /wcag21 to 2.1 requirements link to fix 404 error


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/raven-wills/wcag/pull/515.html" title="Last updated on Oct 10, 2018, 7:36 PM GMT (aa40a9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/515/57173ca...raven-wills:aa40a9c.html" title="Last updated on Oct 10, 2018, 7:36 PM GMT (aa40a9c)">Diff</a>