### PR TITLE
fix: Move data-include-replace to TOC element

### DIFF
--- a/understanding/index.html
+++ b/understanding/index.html
@@ -100,9 +100,8 @@
 
 		</section>
 		
-		<nav id="toc">
+		<nav id="toc" data-include="toc.html" data-include-replace="true">
 			<h2>Understanding Pages</h2>
-			<div data-include="toc.html" data-include-replace="true"></div>
 		</nav>
 		<div data-include="../acknowledgements.html" data-include-replace="true">
 			<p>Acknowledgements</p>


### PR DESCRIPTION
The replacement template includes the same `nav` element.
Fixes #548