### PR TITLE
Removing duplicate TOC H2 in understanding index

### DIFF
--- a/understanding/index.html
+++ b/understanding/index.html
@@ -101,7 +101,6 @@
 		</section>
 		
 		<nav id="toc">
-			<h2>Understanding Pages</h2>
 			<div data-include="toc.html" data-include-replace="true"></div>
 		</nav>
 		<div data-include="../acknowledgements.html" data-include-replace="true">


### PR DESCRIPTION
To align with techniques, looks like the one in the index.html should be removed, there is one in the TOC file.