### PR TITLE
Updating hrefs for new techniques in the changelog

### DIFF
--- a/techniques/index.html
+++ b/techniques/index.html
@@ -74,9 +74,9 @@
 			<h2>Change Log</h2>
 			<p>A list of new, removed or significantly updated techniques:</p>
 			<ol>
-				<li><time datetime="2018=11-13">Nov 13th 2018</time>: Added <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C34">C34 Using media queries to un-fixing sticky headers / footers</a></li>
-				<li><time datetime="2018=11-13">Nov 13th 2018</time>: Added <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C36">C36 Allowing for text spacing override</a></li>
-				<li><time datetime="2018=11-13">Nov 13th 2018</time>: Added <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C37">C37 Using CSS max-width and height to fit images</a></li>
+				<li><time datetime="2018=11-13">Nov 13th 2018</time>: Added <a href="../css/C34">C34 Using media queries to un-fixing sticky headers / footers</a></li>
+				<li><time datetime="2018=11-13">Nov 13th 2018</time>: Added <a href="../css/C36">C36 Allowing for text spacing override</a></li>
+				<li><time datetime="2018=11-13">Nov 13th 2018</time>: Added <a href="../css/C37">C37 Using CSS max-width and height to fit images</a></li>
 				<li><time datetime="2018=11-30">Nov 30th 2018</time>: Added <a href="./general/G207">G207 Ensuring that drag-and-drop actions can be cancelled</a></li>
 				<li><time datetime="2018=11-30">Nov 30th 2018</time>: Added <a href="./failures/F95">F95 Failure of Success Criterion 1.4.13 due to content shown on hover not being hoverable</a></li>
 				<li><time datetime="2018=11-30">Nov 30th 2018</time>: Added <a href="./failures/F96">F96 Failure of Success Criterion 2.5.3 due to &quot;accessible name&quot; not containing the visible label text</a></li>


### PR DESCRIPTION
I noticed the recent ones (using absolute URLs) were broken. Changed to the relative (but wrong looking) URLs.
@michael-n-cooper is this the right way to link them? Just looks wrong to me as it starts href=“../css/C34“ but is actually “css/C34”.
If so, please just merge this and delete the brach. If not, something to discuss on the next call.