### PR TITLE
Removed G139 from Situation B techniques for Status Messages Understanding doc

### DIFF
--- a/understanding/21/status-messages.html
+++ b/understanding/21/status-messages.html
@@ -135,7 +135,6 @@
 								<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G83" class="general">G83: Providing text descriptions to identify required fields that were not completed</a></li>
 								<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G84" class="general">G84: Providing a text description when the user provides information that is not in the list of allowed values</a></li>
 								<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G85" class="general">G85: Providing a text description when user input falls outside the required format or values</a></li>
-								<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G139" class="general">G139: Creating a mechanism that allows users to jump to errors</a></li>
 								<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G177" class="general">G177: Providing suggested correction text</a></li>
 								<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G194" class="general">G194: Providing spell checking and suggestions for text input</a></li>
 								


### PR DESCRIPTION
G139 is about Creating a mechanism that allows users to jump to errors. For pratical purposes it will almost invariably involve a change in focus (otherwise the user would need to hunt for the mechanism) or else will appear on page reload (following an attemtp at submitting a form). As such, it is not the most appropriate technique to cite in Status Messages, and I think the Understanding document is better without it.