### PR TITLE
Fix typos in 'The relation of Reflow to... Resize Text'

### DIFF
--- a/understanding/21/reflow.html
+++ b/understanding/21/reflow.html
@@ -55,7 +55,7 @@
     	</section>
       <section>
  <h3>The relation of Reflow to the Success Criterion 1.4.4 Resize Text</h3>
-        <p>The focus of the Reflow Success Criterion is to enable users to zoom in without having to scroll in two directions. The Resize Text (<a href="resize-text" class="sc">Success criterion 1.4.4</a>) also applies, so it should be possible to increase the size of all text by at least 200% <em>as well</em>. If text is reduced in size when people zoom in (or for small-screen usage), it should still be possible to get to 200% bigger. For example, if text is set at 20px when the window is 1280px wide, at 200% zoom it should be at least 20px (so 200% larger), but at 400% zoom it could be set to 10px (therefore still 200% larger than the 100% view. It is not required to be 200% larger at every breakpoint, but it should be possible to get 200% large text in some way.</p>
+        <p>The focus of the Reflow Success Criterion is to enable users to zoom in without having to scroll in two directions. <a href="resize-text" class="sc">Success Criterion 1.4.4 Resize Text</a> also applies, so it should be possible to increase the size of all text to at least 200% while simultaneously meeting the reflow requirement. If text is reduced in size when people zoom in (or for small-screen usage), it should still be possible to get to 200% enlargement. For example, if text is set at 20px when the window is 1280px wide, at 200% zoom it should be at least 20px (so 200% of the default size), but at 400% zoom it could be set to 10px (therefore still 200% of the default 100% view). It is not required to achieve 200% enlargement at every breakpoint, but it should be possible to get 200% enlargement in some way.</p>
       </section>
     </section>
   


### PR DESCRIPTION
Clarify that 1.4.4 does not require resizing text to 200% _larger than_ the default, but only to 200% _of_ the default.