### PR TITLE
Fixed invalid HTML example

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA13.xml
+++ b/wcag20/sources/techniques/aria/ARIA13.xml
@@ -29,11 +29,11 @@
          <head>Identify a landmark with on-page text</head>
          <description>
             <p>Below is an example of <att>aria-labelledby</att> used on a complementary Landmark. The region of the document to which the heading pertains could be marked with the <att>aria-labelledby</att> property containing the value of the <att>id</att> for the header.</p>
-            <codeblock xml:space="preserve"><![CDATA[<p role="complementary" aria-labelledby="hdr1">
+            <codeblock xml:space="preserve"><![CDATA[<div role="complementary" aria-labelledby="hdr1">
  <h1 id="hdr1">
     Top News Stories
  </h1>
-</p>]]></codeblock>
+</div>]]></codeblock>
          </description>
       </eg-group>
       <eg-group>


### PR DESCRIPTION
the first example was invalid HTML, you can't have a Heading element inside a P element.