### PR TITLE
Cleanup of reflow techniques.

### DIFF
--- a/understanding/21/reflow.html
+++ b/understanding/21/reflow.html
@@ -95,6 +95,7 @@
             <li><a href="../../techniques/css/C38">C38</a></li>
             <li><a href="../../techniques/client-side-script/SCR34" class="script">SCR34</a></li>
             <li><a href="../../techniques/general/G206" class="general">G206</a></li>
+            <li>@@ Using CSS <code>pre-wrap</code> so that code examples in <code>pre</code> reflow</li>
             <li>@@ New: Using PDF/UA when creating PDFs.</li>
         </ul>
     </section>
@@ -103,9 +104,8 @@
        <ul>
          <li><a href="../../techniques/css/C34">C34</a></li>
          <li><a href="../../techniques/CSS/C37">CSS, Fitting images to the viewport;</a></li>
-         <li>@@ CSS, Reflowing simple data tables.</li>
          <li>@@ CSS, Fitting data cells within the width of the viewport.</li>
-         <li>@@ Mechanism to allow mobile view at any time</li>
+         <li>@@ Mechanism to switch to a small-screen (320px wide) view at any time</li>
          </ul>
          
     </section>
@@ -113,8 +113,6 @@
         <h2>Failures</h2>
         <ul>
             <li>@@ Using fixed sized containers and fixed position content (CSS)</li>
-            <li> @@ "Interfering with a user agent's ability to zoom" i.e., author using: maximum-scale or minimum-scale or user-scalable=no or user-scalable=0 in the meta element ?? @@ Note: In <a href="https://lists.w3.org/Archives/Public/w3c-wai-gl/2016AprJun/0502.html"> Pinch zoom thread on the WCAG list</a> people did not seem to be in favor of this as a failure.</li>
-            <li> @@ (HTML) Using preformatted text or excluding preformatting text  as an exception to no two dimensional scrolling. </li>
         </ul>
     </section>
 </section><!-- end techniques -->

--- a/understanding/21/reflow.html
+++ b/understanding/21/reflow.html
@@ -3,7 +3,7 @@
 <head>
 		<meta charset="UTF-8" />
     <title>Understanding Reflow</title>
-    <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove" />
+    <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove" />
 
 </head>
 <body>

--- a/understanding/21/reflow.html
+++ b/understanding/21/reflow.html
@@ -89,12 +89,12 @@
     <section id="sufficient">
         <h3>Sufficient Techniques</h3>
         <ul>
-            <li><a href="../../techniques/css/C32">Using CSS grids to reflow content (CSS)</a></li>
-            <li><a href="../../techniques/css/C31">Using CSS Flexbox to reflow content (CSS)</a></li>
-            <li><a href="../../techniques/css/C33">C33</a></li>
-            <li><a href="../../techniques/css/C38">C38</a></li>
-            <li><a href="../../techniques/client-side-script/SCR34" class="script">SCR34</a></li>
-            <li><a href="../../techniques/general/G206" class="general">G206</a></li>
+            <li><a href="../../techniques/css/C32">C32, Using CSS grids to reflow content</a></li>
+            <li><a href="../../techniques/css/C31">C31, Using CSS Flexbox to reflow content</a></li>
+            <li><a href="../../techniques/css/C33">C33, Allowing for Reflow with Long URLs and Strings of Text</a></li>
+            <li><a href="../../techniques/css/C38">C38, Using CSS width, max-width and flexbox to fit labels and inputs </a></li>
+            <li><a href="../../techniques/client-side-script/SCR34" class="script">SCR34, Calculating size and position in a way that scales with text size</a></li>
+            <li><a href="../../techniques/general/G206" class="general">G206, Providing options within the content to switch to a layout that does not require the user to scroll horizontally to read a line of text.</a></li>
             <li>@@ Using CSS <code>pre-wrap</code> so that code examples in <code>pre</code> reflow</li>
             <li>@@ New: Using PDF/UA when creating PDFs.</li>
         </ul>
@@ -102,17 +102,18 @@
     <section id="advisory">
         <h2>Advisory Techniques</h2>
        <ul>
-         <li><a href="../../techniques/css/C34">C34</a></li>
+         <li><a href="../../techniques/css/C34">C34, Using media queries to un-fixing sticky headers / footers</a></li>
          <li><a href="../../techniques/CSS/C37">CSS, Fitting images to the viewport;</a></li>
          <li>@@ CSS, Fitting data cells within the width of the viewport.</li>
          <li>@@ Mechanism to switch to a small-screen (320px wide) view at any time</li>
-         </ul>
+        </ul>
          
     </section>
     <section id="failure">
         <h2>Failures</h2>
         <ul>
-            <li>@@ Using fixed sized containers and fixed position content (CSS)</li>
+            <li>@@ Failure due to using fixed sized containers and fixed position content (CSS)</li>
+            <li>@@ Failure due to content disappearing and not being available when content has reflowed (General)</li>
         </ul>
     </section>
 </section><!-- end techniques -->


### PR DESCRIPTION
- Transforming the pre failure technique into a positive sufficient one.
- Removing the 'reflowing simple data tables', there is disagreement that is possible without creating other accessibility issues.
- Modifying the working of the mechanism to 'switch to mobile' technique.

[Preview update](https://cdn.staticaly.com/gh/w3c/wcag/reflow-technique-list/understanding/21/reflow.html?x=3#techniques) (under techniques)