### PR TITLE
Update content-on-hover-or-focus.html

### DIFF
--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -17,7 +17,7 @@
    <dd>If pointer hover can trigger the additional content, then the pointer can be moved  over the additional content without the additional content disappearing;</dd>
 
     <dt>Persistent</dt>
-    <dd>The additional content remains visible until the hover or focus trigger is removed, the user dismisses it, or its information is no longer valid.</dd>
+    <dd>The additional content remains visible until the user dismisses it, its information is no longer valid, or the hover and focus is removed.</dd>
 
   </dl>
     	

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -17,7 +17,7 @@
    <dd>If pointer hover can trigger the additional content, then the pointer can be moved  over the additional content without the additional content disappearing;</dd>
 
     <dt>Persistent</dt>
-    <dd>The additional content remains visible until the user dismisses it, its information is no longer valid, or the hover and focus is removed.</dd>
+    <dd>The additional content remains visible until the user dismisses it, its information is no longer valid, or the hover or focus is removed.</dd>
 
   </dl>
     	


### PR DESCRIPTION
As per the discussion in https://github.com/w3c/wcag/issues/582, this erratum is intended to address potential misreading of the normative text for 1.4.13 Content on Hover or Focus in the final Persistent bullet. The key objective was to replace the word "trigger" so that users would not interpret that the trigger itself must be removed to meet the criterion.

The revised version reads:
> The additional content remains visible until the user dismisses it, its information is no longer valid, or the hover or focus is removed.