### PR TITLE
corrections to Character key shorts and Reflow

### DIFF
--- a/guidelines/sc/21/character-key-shortcuts.html
+++ b/guidelines/sc/21/character-key-shortcuts.html
@@ -14,7 +14,7 @@
     <dd>A <a>mechanism</a> is available to turn the shortcut off;</dd>
       						
    <dt>Remap</dt>
-     <dd>A mechanism is available to remap the shortcut to use one or more non-printable keyboard characters (e.g. Ctrl, Alt, etc);</dd>
+     <dd>A mechanism is available to remap the shortcut to include one or more non-printable keyboard keys (e.g., Ctrl, Alt);</dd>
 
     <dt>Active only on focus</dt>
     <dd>The keyboard shortcut for a <a>user interface component</a> is only active when that component has focus.</dd>

--- a/guidelines/sc/21/reflow.html
+++ b/guidelines/sc/21/reflow.html
@@ -15,7 +15,7 @@
   
    <p class="note">320 CSS pixels is equivalent to a starting viewport width of 1280 CSS pixels wide at 400% zoom. For web content which is designed to scroll horizontally (e.g., with vertical text), 256 CSS pixels is equivalent to a starting viewport height of 1024px at 400% zoom.</p>
    
-   <p class="note">Examples of parts of content which require two-dimensional layout are images, maps, diagrams, 
+   <p class="note">Examples of content which requires two-dimensional layout are images, maps, diagrams, 
      video, games, presentations, data tables, and interfaces where it is necessary to keep toolbars in view while
      manipulating content.</p>
    				

--- a/guidelines/sc/21/reflow.html
+++ b/guidelines/sc/21/reflow.html
@@ -13,9 +13,9 @@
    </ul>
    <p>Except for parts of the content which require two-dimensional layout for usage or meaning.</p>
   
-   <p class="note">320 CSS pixels is equivalent to a starting viewport width of 1280 CSS pixels wide at 400% zoom. For web content which are designed to scroll horizontally (e.g. with vertical text), the 256 CSS pixels is equivalent to a starting viewport height of 1024px at 400% zoom.</p>
+   <p class="note">320 CSS pixels is equivalent to a starting viewport width of 1280 CSS pixels wide at 400% zoom. For web content which is designed to scroll horizontally (e.g., with vertical text), 256 CSS pixels is equivalent to a starting viewport height of 1024px at 400% zoom.</p>
    
-   <p class="note">Examples of content which require two-dimensional layout are images, maps, diagrams, 
+   <p class="note">Examples of parts of content which require two-dimensional layout are images, maps, diagrams, 
      video, games, presentations, data tables, and interfaces where it is necessary to keep toolbars in view while
      manipulating content.</p>
    				


### PR DESCRIPTION
The errata requests for these two SCs are as follows:
For Character Key Shortcuts, there are three changes.  The most important change is the replacement of "characters" by "keys" in the first bullet.  Simply, modifier keys are not characters. This change does not alter the interpretation but merely addresses the inappropriate use of a  word that could potentially cause confusion.

The second suggestion is more open to discussion, and concerns replacing "use" with the word "include". This is a suggested edit to address the literal meaning of the text. The purpose of the  mechanism is not to replace a character key with a non-printable key, but to create a keyboard shortcut combination -- e.g., instead of A use Ctrl+A. "Include" better asserts this notion.

Finally the parenthetical information has been updated to match what I believe is the acceptable style for e.g., (including a comma) and eliminating the "etc" which is superfluous in the context of an example. There is no supposition that the example is an exhaustive list, therefore the etc is unnecessary. This is a trivial change, only offered here with the assumption that if the text is being altered, such slight style questions may as well be addressed.

Reflow's changes are primarily concerned with number agreement. "content...are designed" becomes "content...is designed"

The first note has also been changed, but here rather than make "content which require" be "content which requires" we have added in "parts of" so that it reads "parts of content which require". This solution mirrors language in the SC exception.

A trivial  style change has also been added for two occurrences -- the comma after e.g.,



