### PR TITLE
Editorial change to normative text of 1.4.12: at least > up to

### DIFF
--- a/guidelines/sc/21/text-spacing.html
+++ b/guidelines/sc/21/text-spacing.html
@@ -9,10 +9,10 @@
    <p>In content implemented using markup languages that support the following <a>text</a> <a>style properties</a>, no loss of content or functionality occurs by setting all of the following and by changing no other style property:</p>
    
    <ul>
-     <li>Line height (line spacing) to at least 1.5 times the font size;</li>
-     <li>Spacing following paragraphs to at least 2 times the font size;</li>
-     <li>Letter spacing (tracking) to at least 0.12 times the font size;</li>
-     <li>Word spacing to at least 0.16 times the font size.</li>
+     <li>Line height (line spacing) up to 1.5 times the font size;</li>
+     <li>Spacing following paragraphs up to 2 times the font size;</li>
+     <li>Letter spacing (tracking) up to 0.12 times the font size;</li>
+     <li>Word spacing up to 0.16 times the font size.</li>
    </ul>
  
  <p>Exception: Human languages and scripts that do not make use of one or more of these text style properties in written text can conform using only the properties that exist for that combination of language and script.</p>


### PR DESCRIPTION
In line with the discussion at https://github.com/w3c/wcag/issues/635 this is an editorial (non-substantive) change to the normative language of SC 1.4.12 which better clarifies the intent of the
SC. Using "up to" (the same way that SC 1.4.4 uses "up to 200%" as pointed out by @mraccess77 ) better conveys that testing should ideally be done for any values from the default up to those
defined in the normative text. It also makes it clearer that values that go beyond those defined normatively that result in loss of content or functionality do NOT result in a failure of the SC.

Closes https://github.com/w3c/wcag/issues/635