### PR TITLE
Add clarification of "inactive" to user interface component glossary definition

### DIFF
--- a/guidelines/terms/20/user-interface-component.html
+++ b/guidelines/terms/20/user-interface-component.html
@@ -17,6 +17,8 @@
    <p class="note">What is meant by "component" or "user interface component" here is also sometimes
       called "user interface element".
    </p>
+
+   <p class="note">User interface components are "inactive" when they are not available for user interaction (e.g., a disabled control in HTML). An inactive user interface component is visible but not currently operable. An example would be a submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed. This should not be confused with user interface controls which are not currently "selected". For example, in a tabbed interface, the tabs which colloquially would be referred to as not being "active" are <em>not</em> "inactive user interface components" - as long as they aren't disabled completely, they can be interacted with by the user (to switch tabs in the tabbed interface), and therefore aren't "inactive". More accurately, these tabs are merely "not selected".</p>
    
    <p class="example">An applet has a "control" that can be used to move through content by line or page
       or random access. Since each of these would need to have a name and be settable independently,


### PR DESCRIPTION
Admittedly very verbose, but clarifies the subtle distinction between an inactive and a disabled control. The first sentences were cribbed from the 1.4.11 understanding document
https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html

Opted to make the clarification directly in the glossary, rather than cramming it into both the 1.4.3 and 1.4.6 understanding documents.

[it wasn't clear if this was the right document to make the edits against, as there are additional .xml files in the `/sources` folder that seem to contain glossary definition bits]

Closes https://github.com/w3c/wcag/issues/636