### PR TITLE
Remove empty/unnecessary example section from understanding 2.5.5

### DIFF
--- a/understanding/21/target-size.html
+++ b/understanding/21/target-size.html
@@ -56,7 +56,6 @@
       <li><strong>Example 6: Footnote</strong><br /> A footnote link at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The footnote at the end of the sentence is considered to be part of the sentence.</li>
       <li><strong>Example 7: Help icon</strong><br /> A help icon within or at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The icon at the end of the sentence is considered to be part of the sentence.</li>
     </ul>
-    <section class="example"></section>
   </section>
   <section id="resources">
     <h2>Resources</h2>


### PR DESCRIPTION
> ![Screenshot of the empty example section as rendered in the understanding document - just an empty coloured block](https://user-images.githubusercontent.com/895831/55636867-b80ef680-57bb-11e9-8c7e-3de6b0ff744b.PNG)
