### PR TITLE
Remove WAI glossary text on Charter

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -199,7 +199,7 @@
 						<dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
 						<dd>Provide input into other W3C groups on accessibility requirements.</dd>
 						<dt><a href="https://www.w3.org/WAI/ARIA/">ARIA Working Group</a></dt>
-						<dd>Review and help develop WCAG 2.0 Techniques for WAI-ARIA.</dd>
+						<dd>Review and help develop WCAG 2.x Techniques for WAI-ARIA.</dd>
 						<dt><a href="http://www.w3.org/Style/CSS/">Cascading Style Sheets Working Group</a></dt>
 						<dd>Advise on WCAG conformance interpretations of CSS features.</dd>
 						<dt><a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working Group</a></dt>

--- a/charter.html
+++ b/charter.html
@@ -205,7 +205,7 @@
 						<dt><a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working Group</a></dt>
 						<dd>Coordinate on accessibility guidelines that impact digital publishing.</dd>
 						<dt><a href="http://www.w3.org/WAI/EO/">Education and Outreach Working Group</a></dt>
-						<dd>Coordinate on making WCAG 2.x usable by a wider audience, on developing or reviewing strategies and materials to increase awareness and to educate Web community about WCAG 2.x, ensure WCAG 2.x uses terms from WAI Glossary properly.</dd>
+						<dd>Coordinate on making WCAG 2.x usable by a wider audience, on developing or reviewing strategies and materials to increase awareness and to educate Web community about WCAG 2.x.</dd>
 						<dt><a href="https://www.w3.org/International/">Internationalization Activity</a></dt>
 						<dd>Ensure that references to internationalization techniques are correct, and to ensure that language can be translated successfully.</dd>
 						<dt><a href="https://www.w3.org/Mobile/">Mobile Web Initiative</a></dt>


### PR DESCRIPTION
a completed / published "WAI Glossary" doesn't exist