### PR TITLE
Update link and add meta viewport directive to css fit labels working example

### DIFF
--- a/techniques/css/C38.html
+++ b/techniques/css/C38.html
@@ -128,7 +128,7 @@ select {
 </code>
 </pre>
         
-        <p class="working-examples">Working example: <a href="../../working-examples/css-fitting-inputs/index.html">Using Adjustable Labels and Inputs for Reflow</a></p>
+        <p class="working-examples">Working example: <a href="../../working-examples/css-fit-labels-inputs/">Using Adjustable Labels and Inputs for Reflow</a></p>
         
       </section>
     </section>

--- a/working-examples/css-fit-labels-inputs/index.html
+++ b/working-examples/css-fit-labels-inputs/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Using Adjustable Labels and Inputs for Reflow</title>
     <style>
 


### PR DESCRIPTION
as otherwise media queries won't kick in properly on mobile/tablet

Closes https://github.com/w3c/wcag/issues/679