### PR TITLE
JS error in script-expand-links working example, issue 817

### DIFF
--- a/techniques/client-side-script/SCR30.html
+++ b/techniques/client-side-script/SCR30.html
@@ -23,9 +23,10 @@ function doExpand() {
 	var links = document.links;
 	
 	for (var i=0; i<links.length; i++) {
-		var cn = links[i].className;
+		var link = links[i];
+		var cn = link.className;
 		if (linkContext[cn]) {
-			span = links[i].appendChild(document.createElement("span"));
+			span = link.appendChild(document.createElement("span"));
 			span.setAttribute("class", "linkexpansion");
 			span.appendChild(document.createTextNode(linkContext[cn]));
 		}

--- a/techniques/client-side-script/SCR30.html
+++ b/techniques/client-side-script/SCR30.html
@@ -22,7 +22,7 @@ var linkContext = {
 function doExpand() {
 	var links = document.links;
 	
-	for (var i=0; i<links.length; i++) {
+	for (var i=0; i&lt;links.length; i++) {
 		var link = links[i];
 		var cn = link.className;
 		if (linkContext[cn]) {

--- a/techniques/client-side-script/SCR30.html
+++ b/techniques/client-side-script/SCR30.html
@@ -22,10 +22,10 @@ var linkContext = {
 function doExpand() {
 	var links = document.links;
 	
-	for (link of links) {
-		var cn = link.className;
+	for (var i=0; i<links.length; i++) {
+		var cn = links[i].className;
 		if (linkContext[cn]) {
-			span = link.appendChild(document.createElement("span"));
+			span = links[i].appendChild(document.createElement("span"));
 			span.setAttribute("class", "linkexpansion");
 			span.appendChild(document.createTextNode(linkContext[cn]));
 		}

--- a/working-examples/script-expand-links/index.html
+++ b/working-examples/script-expand-links/index.html
@@ -13,10 +13,10 @@ var linkContext = {
 function doExpand() {
 	var links = document.links;
 	
-	for each (link in links) {
-		var cn = link.className;
+	for (var i=0; i<links.length; i++) {
+		var cn = links[i].className;
 		if (linkContext[cn]) {
-			span = link.appendChild(document.createElement("span"));
+			span = links[i].appendChild(document.createElement("span"));
 			span.setAttribute("class", "linkexpansion");
 			span.appendChild(document.createTextNode(linkContext[cn]));
 		}

--- a/working-examples/script-expand-links/index.html
+++ b/working-examples/script-expand-links/index.html
@@ -14,9 +14,10 @@ function doExpand() {
 	var links = document.links;
 	
 	for (var i=0; i<links.length; i++) {
-		var cn = links[i].className;
+		var link = links[i];
+		var cn = link.className;
 		if (linkContext[cn]) {
-			span = links[i].appendChild(document.createElement("span"));
+			span = link.appendChild(document.createElement("span"));
 			span.setAttribute("class", "linkexpansion");
 			span.appendChild(document.createTextNode(linkContext[cn]));
 		}


### PR DESCRIPTION
Should fix #817 

As noted in the issue, I only had luck in all the browsers I tried using a regular `for` loop, and as noted in the commit message, I didn't actually test the code in the techniques file (just copied and pasted the same diff from the working example).