### PR TITLE
Fix links to CSS3 values in 1.4.3 and 1.4.6

### DIFF
--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -48,7 +48,7 @@
          <p>The point size should be obtained from the user agent, or calculated based on font
             metrics as the user agent does when evaluating this success criterion. Point sizes
             are based on the CSS pt size as defined in 
-            <a href="https://www.w3.org/TR/css-values-3/">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
+            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
             and 18pt are equivalent to approximately 18.5px and 24px.
          </p>
          

--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -48,7 +48,7 @@
          <p>The point size should be obtained from the user agent, or calculated based on font
             metrics as the user agent does when evaluating this success criterion. Point sizes
             are based on the CSS pt size as defined in 
-            <a href="">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
+            <a href="https://www.w3.org/TR/css-values-3/">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
             and 18pt are equivalent to approximately 18.5px and 24px.
          </p>
          

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -48,7 +48,7 @@
          <p>When evaluating this success criterion, the font size in points should be obtained
             from the user agent or calculated on font metrics in the way that user agents do.
             Point sizes are based on the CSS pt size as defined in 
-            <a href="">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
+            <a href="https://www.w3.org/TR/css-values-3/">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
             and 18pt are equivalent to approximately 18.5px and 24px.
          </p>
          

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -48,7 +48,7 @@
          <p>When evaluating this success criterion, the font size in points should be obtained
             from the user agent or calculated on font metrics in the way that user agents do.
             Point sizes are based on the CSS pt size as defined in 
-            <a href="https://www.w3.org/TR/css-values-3/">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
+            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
             and 18pt are equivalent to approximately 18.5px and 24px.
          </p>
          


### PR DESCRIPTION
#### The problem this is fixing

The Understanding documents of both [SC 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) and [SC 1.4.6](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html) have a note explaining that point sizes are based on the CSS point sizes defined in CSS3 Values.

'CSS3 Values' is wrapped into an anchor tag, but in both documents clicking on the link leads nowhere, because the `href` value of these anchor tags are empty strings.

#### Changes introduced

This Pull Request sets the `href` attribute of both links to `https://www.w3.org/TR/css-values-3/`.
