### PR TITLE
Normalise references to 44 by 44 CSS pixels target size

### DIFF
--- a/understanding/21/target-size.html
+++ b/understanding/21/target-size.html
@@ -49,10 +49,10 @@
     <ul>
       <li><strong>Example 1: Buttons</strong><br /> Three buttons are on-screen and the touch target area of each button is 44 by 44 CSS pixels.</li>
       <li><strong>Example 2: Equivalent target</strong><br /> Multiple targets are provided on the page that perform the same function. One of the targets is 44 by 44 CSS pixels. The other targets do not have a minimum touch target of 44 by 44 CSS pixels.</li>
-      <li><strong>Example 3: Anchor Link</strong><br /> The target is an in-page link and the target is less than 44px by 44px. Users can scroll the screen using browser functions so target size does not need to be met.</li>
+      <li><strong>Example 3: Anchor Link</strong><br /> The target is an in-page link and the target is less than 44 by 44 CSS pixels. Users can scroll the screen using browser functions so target size does not need to be met.</li>
       <li><strong>Example 4: Text Link in a paragraph</strong><br /> Links within a paragraph of text have varying touch target dimensions. Links within paragraphs of text do no need to meet the 44 by 44 CSS pixels requirements.</li>
       <li><strong>Example 5: Text Link in a sentence</strong><br /> A text link that is in a sentence is excluded and does not need to meet the 44 by 44 CSS pixel requirement. If the text link is the full sentence, then the text link target touch area does
-        need to meet the 44 x 44 CSS pixels.</li>
+        need to meet the 44 by 44 CSS pixels.</li>
       <li><strong>Example 6: Footnote</strong><br /> A footnote link at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The footnote at the end of the sentence is considered to be part of the sentence.</li>
       <li><strong>Example 7: Help icon</strong><br /> A help icon within or at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The icon at the end of the sentence is considered to be part of the sentence.</li>
     </ul>
@@ -89,7 +89,7 @@
       <h2>Failure</h2>
       <ul>
         <li>Failure of success criterion 2.5.3 due to target size being less than 44 by 44 CSS pixels.</li>
-        <li>Failure of success criterion 2.5.3 due to target size of a paragraph that is also a link being less than 44 x 44 CSS pixels.</li>
+        <li>Failure of success criterion 2.5.3 due to target size of a paragraph that is also a link being less than 44 by 44 CSS pixels.</li>
       </ul>
     </section>
   </section>


### PR DESCRIPTION
Previously there were three different ways to refer to the same value. This normalises them.