### PR TITLE
Fixed incorrect ids in aria-labelledby-workshop-booking-timetable example

### DIFF
--- a/techniques/aria/ARIA9.html
+++ b/techniques/aria/ARIA9.html
@@ -70,10 +70,10 @@
 &lt;/tr&gt;
 
 &lt;tr&gt;
-	&lt;th scope="col" id="am1"&gt;9 to 12 AM&lt;/th&gt;
-	&lt;th scope="col" id="pm1"&gt;2 to 5 PM&lt;/th&gt;
-	&lt;th scope="col" id="am2"&gt;9 to 12 AM&lt;/th&gt;
-	&lt;th scope="col" id="pm2"&gt;2 to 5 PM&lt;/th&gt;
+	&lt;th scope="col" id="day1_am"&gt;9 to 12 AM&lt;/th&gt;
+	&lt;th scope="col" id="day1_pm"&gt;2 to 5 PM&lt;/th&gt;
+	&lt;th scope="col" id="day2_am"&gt;9 to 12 AM&lt;/th&gt;
+	&lt;th scope="col" id="day2_pm"&gt;2 to 5 PM&lt;/th&gt;
 &lt;/tr&gt;
 
 &lt;tr&gt;
@@ -81,21 +81,21 @@
 	&lt;td&gt;
 		&lt;h2 id="title-TM1"&gt;The Paleozoic era &lt;/h2&gt;
 		&lt;p&gt;2 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="TM1" aria-labelledby="title-TM1 track1 am1 TM1-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="TM1" aria-labelledby="title-TM1 track1 day1_am TM1-att"&gt;
                 &lt;label id="TM1-att" for="TM1"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 	
 	&lt;td&gt;
 		&lt;h2 id="title-TA1"&gt;The Mesozoic era overview&lt;/h2&gt;
 		&lt;p&gt;2 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="TA1" aria-labelledby="title-TA1 track1 am2 TA1-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="TA1" aria-labelledby="title-TA1 track1 day1_pm TA1-att"&gt;
                 &lt;label id="TA1-att" for="TA1"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 	
 	&lt;td&gt;
 		&lt;h2 id="title-FM1"&gt;The Triassic period, rise of the dinosaurs&lt;/h2&gt;
 		&lt;p&gt;1 place left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="FM1" aria-labelledby="title-FM1 track1 pm1 FM1-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="FM1" aria-labelledby="title-FM1 track1 day2_am FM1-att"&gt;
                 &lt;label id="FM1-att" for="FM1"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 
 	&lt;/td&gt;
@@ -103,7 +103,7 @@
 	&lt;td&gt;
 		&lt;h2 id="title-FA1"&gt;The Jurassic period&lt;/h2&gt;
 		&lt;p&gt;11 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="FA1" aria-labelledby="title-FA1 track1 pm2 FA1-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="FA1" aria-labelledby="title-FA1 track1 day2_pm FA1-att"&gt;
                 &lt;label id="FA1-att" for="FA1"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 &lt;/tr&gt;
@@ -114,28 +114,28 @@
 	&lt;td&gt;
 		&lt;h2 id="title-TM2"&gt;The Cretaceous period&lt;/h2&gt;
 		&lt;p&gt;18 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="TM2" aria-labelledby="title-TM2 track2 am1 TM2-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="TM2" aria-labelledby="title-TM2 track2 day1_am TM2-att"&gt;
                 &lt;label id="TM2-att" for="TM2"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 	
 	&lt;td&gt;
 		&lt;h2 id="title-TA2"&gt;The end of the dinosaurs&lt;/h2&gt;
 		&lt;p&gt;2 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="TA2" aria-labelledby="title-TA2 track2 am2 TA2-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="TA2" aria-labelledby="title-TA2 track2 day1_pm TA2-att"&gt;
                 &lt;label id="TA2-att" for="TA2"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 	
 	&lt;td&gt;
 		&lt;h2 id="title-FM2"&gt;First discoveries of dinosaurs&lt;/h2&gt;
 		&lt;p&gt;2 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="FM2" aria-labelledby="title-FM2 track2 pm1 FM2-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="FM2" aria-labelledby="title-FM2 track2 day2_am FM2-att"&gt;
                 &lt;label id="FM2-att" for="FM2"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 	
 	&lt;td&gt;
 		&lt;h2 id="title-FA2"&gt;Emerging scholarship&lt;/h2&gt;
 		&lt;p&gt;19 places left&lt;/p&gt;
-		&lt;p&gt;&lt;input type="checkbox" id="FA2" aria-labelledby="title-FA2 track2 pm2 FA2-att"&gt;
+		&lt;p&gt;&lt;input type="checkbox" id="FA2" aria-labelledby="title-FA2 track2 day2_pm FA2-att"&gt;
                 &lt;label id="FA2-att" for="FA2"&gt;Attend&lt;/label&gt;&lt;/p&gt;
 	&lt;/td&gt;
 &lt;/tr&gt;

--- a/working-examples/aria-labelledby-workshop-booking-timetable/index.html
+++ b/working-examples/aria-labelledby-workshop-booking-timetable/index.html
@@ -19,10 +19,10 @@ Dinosaur conference workshop booking table
 </tr>
 
 <tr>
-	<th scope="col" id="am1">9 to 12 AM</th>
-	<th scope="col" id="pm1">2 to 5 PM</th>
-	<th scope="col" id="am2">9 to 12 AM</th>
-	<th scope="col" id="pm2">2 to 5 PM</th>
+	<th scope="col" id="day1_am">9 to 12 AM</th>
+	<th scope="col" id="day1_pm">2 to 5 PM</th>
+	<th scope="col" id="day2_am">9 to 12 AM</th>
+	<th scope="col" id="day2_pm">2 to 5 PM</th>
 </tr>
 
 <tr>
@@ -30,30 +30,29 @@ Dinosaur conference workshop booking table
 	<td>
 		<h2 id="title-TM1">The Paleozoic era </h2>
 		<p>2 places left</p>
-		<p><input type="checkbox" id="TM1" aria-labelledby="title-TM1 track1 am1 TM1-att">
-                <label id="TM1-att" for="TM1">Attend</label></p>
+		<p><input type="checkbox" id="TM1" aria-labelledby="title-TM1 track1 day1_am TM1-att">
+    <label id="TM1-att" for="TM1">Attend</label></p>
 	</td>
 	
 	<td>
 		<h2 id="title-TA1">The Mesozoic era overview</h2>
 		<p>2 places left</p>
-		<p><input type="checkbox" id="TA1" aria-labelledby="title-TA1 track1 am2 TA1-att">
-                <label id="TA1-att" for="TA1">Attend</label></p>
+		<p><input type="checkbox" id="TA1" aria-labelledby="title-TA1 track1 day1_pm TA1-att">
+    <label id="TA1-att" for="TA1">Attend</label></p>
 	</td>
 	
 	<td>
 		<h2 id="title-FM1">The Triassic period, rise of the dinosaurs</h2>
 		<p>1 place left</p>
-		<p><input type="checkbox" id="FM1" aria-labelledby="title-FM1 track1 pm1 FM1-att">
-                <label id="FM1-att" for="FM1">Attend</label></p>
-
+		<p><input type="checkbox" id="FM1" aria-labelledby="title-FM1 track1 day2_am FM1-att">
+    <label id="FM1-att" for="FM1">Attend</label></p>
 	</td>
 	
 	<td>
 		<h2 id="title-FA1">The Jurassic period</h2>
 		<p>11 places left</p>
-		<p><input type="checkbox" id="FA1" aria-labelledby="title-FA1 track1 pm2 FA1-att">
-                <label id="FA1-att" for="FA1">Attend</label></p>
+		<p><input type="checkbox" id="FA1" aria-labelledby="title-FA1 track1 day2_pm FA1-att">
+    <label id="FA1-att" for="FA1">Attend</label></p>
 	</td>
 </tr>
 
@@ -63,29 +62,29 @@ Dinosaur conference workshop booking table
 	<td>
 		<h2 id="title-TM2">The Cretaceous period</h2>
 		<p>18 places left</p>
-		<p><input type="checkbox" id="TM2" aria-labelledby="title-TM2 track2 am1 TM2-att">
-                <label id="TM2-att" for="TM2">Attend</label></p>
+		<p><input type="checkbox" id="TM2" aria-labelledby="title-TM2 track2 day1_am TM2-att">
+    <label id="TM2-att" for="TM2">Attend</label></p>
 	</td>
 	
 	<td>
 		<h2 id="title-TA2">The end of the dinosaurs</h2>
 		<p>2 places left</p>
-		<p><input  type="checkbox" id="TA2" aria-labelledby="title-TA2 track2 am2 TA2-att">
-                <label id="TA2-att" for="TA2">Attend</label></p>
+		<p><input  type="checkbox" id="TA2" aria-labelledby="title-TA2 track2 day1_pm TA2-att">
+    <label id="TA2-att" for="TA2">Attend</label></p>
 	</td>
 	
 	<td>
 		<h2 id="title-FM2">First discoveries of dinosaurs<em></em></h2>
 		<p>2 places left</p>
-		<p><input type="checkbox" id="FM2" aria-labelledby="title-FM2 track2 pm1 FM2-att">
-                <label id="FM2-att" for="FM2">Attend</label></p>
+		<p><input type="checkbox" id="FM2" aria-labelledby="title-FM2 track2 day2_am FM2-att">
+    <label id="FM2-att" for="FM2">Attend</label></p>
 	</td>
 	
 	<td>
 		<h2 id="title-FA2">Emerging scholarship </h2>
 		<p>19 places left</p>
-		<p><input  type="checkbox" id="FA2" aria-labelledby="title-FA2 track2 pm2 FA2-att">
-                <label id="FA2-att" for="FA2">Attend</label></p>
+		<p><input  type="checkbox" id="FA2" aria-labelledby="title-FA2 track2 day2_pm FA2-att">
+    <label id="FA2-att" for="FA2">Attend</label></p>
 	</td>
 </tr>
 </table>


### PR DESCRIPTION
#### The issue that this PR is solving

In the [aria-labelledby-workshop-booking-timetable working example](https://www.w3.org/WAI/WCAG21/working-examples/aria-labelledby-workshop-booking-timetable/):
* the 'attend' checkboxes in column 2 are named using the headers of column 3;
* the 'attend' checkboxes in column 3 are named using the headers of column 2.

For example, when reading the checkbox to attend the "The Mesozoic era overview", screen readers say that that the session happens between 9 to 12am, but the table shows that it happens between 2 to 5pm.

That mismatch is also present in the code example in [ARIA Technique 9](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9#example-3-a-conference-workshop-booking-table).

#### Changes introduced by this PR

* The `aria-labelledby` attributes for the 'attend' checkboxes in columns 2 and 3 now point to the correct headers.
* The `id`s of the headers have been renamed to be more explicit, so that errors like this are easier to spot in the future.
* The code example in [ARIA Technique 9](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9#example-3-a-conference-workshop-booking-table) is updated to reflect those changes.

#### Testing

I've tested the updated markup using macOS VoiceOver.

#### Possible further improvements

I believe that the table would be more usable if the 'attend' checkboxes had the days (i.e. 'Thursday' or 'Friday') included in their accessible names. At the moment, the name of the 'attend' checkboxes only mentions the times of the day, but not the day.

If you think that this would be a worthwhile improvement, I'm happy to submit another PR with these changes, following the same [Using aria-labelledby to concatenate a label from several text nodes](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9#example-3-a-conference-workshop-booking-table) technique.