### PR TITLE
Update Working Example ARIA24

### DIFF
--- a/guidelines/terms/20/contrast-ratio.html
+++ b/guidelines/terms/20/contrast-ratio.html
@@ -15,20 +15,20 @@
    
    <p class="note">Contrast ratios can range from 1 to 21 (commonly written 1:1 to 21:1).</p>
    
-   <p class="note">Because authors do not have control over user settings as to how text is rendered
-      (for example font smoothing or anti-aliasing), the contrast ratio for text can be
+   <p class="note">Because authors do not have control over user settings as to how text and non-text content is rendered
+      (for example font smoothing or anti-aliasing), the contrast ratio can be
       evaluated with anti-aliasing turned off.
    </p>
    
    <p class="note">For the purpose of Success Criteria 1.4.3 and 1.4.6, contrast is measured with respect
-      to the specified background over which the text is rendered in normal usage. If no
-      background color is specified, then white is assumed.
+      to the specified background over which the content is rendered in normal usage. If no
+      background color is specified, then white is assumed. If no
+      foreground color is specified, then black is assumed.
    </p>
    
-   <p class="note">Background color is the specified color of content over which the text is to be rendered
-      in normal usage. It is a failure if no background color is specified when the text
+   <p class="note">It is a failure if no background color is specified when the foreground
       color is specified, because the user's default background color is unknown and cannot
-      be evaluated for sufficient contrast. For the same reason, it is a failure if no text
+      be evaluated for sufficient contrast. For the same reason, it is a failure if no foreground
       color is specified when a background color is specified.
    </p>
    

--- a/techniques/aria/ARIA19.html
+++ b/techniques/aria/ARIA19.html
@@ -3,7 +3,7 @@
    </section><section id="description"><h2>Description</h2>
       <p>The purpose of this technique is to notify Assistive Technologies (AT) when an input error occurs. The <code class="att">aria-live</code> attribute makes it possible for an AT (such as a screen reader) to be notified when error messages are injected into a Live Region container. The content within the <code class="att">aria-live</code> region is automatically read by the AT, without the AT having to focus on the place where the text is displayed.
 </p>
-      <p>There are also a number of <a href="https://www.w3.org/WAI/PF/aria-practices/#chobet">special case live region roles</a> which can be used instead of applying live region properties directly.</p>
+      <p>There are also a number of <a href="https://www.w3.org/TR/wai-aria-1.1/#live_region_roles">special case live region roles</a> which can be used instead of applying live region properties directly.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>Injecting error messages into a container with role=alert already present in the DOM</h3>

--- a/understanding/20/on-input.html
+++ b/understanding/20/on-input.html
@@ -42,8 +42,23 @@
          
       </div>
       
+      <div class="note">
+         
+         <p>If the user interface component is not fully operable with the keyboard due to the <a class="glossary">change of context</a>, 
+		    this would be a violation of SC 2.1.1.
+         </p>
+         
+      </div>
       
-   </section>
+      <div class="note">
+         
+         <p>A <a class="glossary">change of context</a> should only be made if this makes further operation of the application easier. 
+		 If the change of context makes the operation difficult for impaired people, it is recommended to avoid the context change. 
+         </p>
+         
+      </div>
+
+  </section>
    <section id="benefits">
       <h2>Benefits of On Input</h2>
       

--- a/understanding/20/on-input.html
+++ b/understanding/20/on-input.html
@@ -42,23 +42,8 @@
          
       </div>
       
-      <div class="note">
-         
-         <p>If the user interface component is not fully operable with the keyboard due to the <a class="glossary">change of context</a>, 
-		    this would be a violation of SC 2.1.1.
-         </p>
-         
-      </div>
       
-      <div class="note">
-         
-         <p>A <a class="glossary">change of context</a> should only be made if this makes further operation of the application easier. 
-		 If the change of context makes the operation difficult for impaired people, it is recommended to avoid the context change. 
-         </p>
-         
-      </div>
-
-  </section>
+   </section>
    <section id="benefits">
       <h2>Benefits of On Input</h2>
       

--- a/working-examples/aria-icon-font-img-role/index.html
+++ b/working-examples/aria-icon-font-img-role/index.html
@@ -44,8 +44,8 @@
     .icon-star-bg:before    { content: "\e982"; }
     .icon-star-half:before  { content: "\e983"; }
 
-    .grey { color: #949494; }
-    .yellow { color: #f8c102; }
+    .grey { color: #6e6e6e; text-shadow: 0 0 2px black, 0 0 2px black, 0 0 2px black, 0 0 2px black;}
+    .yellow { color: #f8c102; text-shadow: 0 0 2px black, 0 0 2px black, 0 0 2px black, 0 0 2px black;}
 
     /* EXAMPLE 2 */
 
@@ -122,7 +122,17 @@
       margin-bottom: 2rem;
       padding: 1rem;
     }
-
+	
+	.sr-only {
+	  position: absolute;
+	  width: 1px;
+	  height: 1px;
+	  padding: 0;
+	  margin: -1px;
+	  overflow: hidden;
+	  clip: rect(0,0,0,0);
+	  border: 0;
+	}
     </style>
 
     <script>
@@ -161,7 +171,8 @@
 
       <h3>Do...</h3>
       <p>
-        <span class="icon icon-star-bg yellow" role="img" aria-label="Favorite"></span>
+        <span class="icon icon-star-bg yellow" role="img" aria-hidden="true"></span>
+		<span class="sr-only">Favorite</span>
       </p>
 
       <button onclick="fontFamilyToggle()">Toggle font family</button>
@@ -182,9 +193,10 @@
 
       <h3>Do...</h3>
       <p>
-        <span class="icon-stacked" role="img" aria-label="Favorite star half filled">
-         <span class="icon icon-star-bg grey" role="img" aria-hidden="true"></span>
-         <span class="icon icon-star-half yellow" role="img" aria-hidden="true"></span>
+        <span class="icon-stacked" role="img" aria-hidden="true">
+         <span class="icon icon-star-bg grey" role="img"></span>
+         <span class="icon icon-star-half yellow" role="img"></span>
+		 <span class="sr-only">Favorite star half filled</span>
         </span>
       </p>
 
@@ -206,7 +218,8 @@
       <h3>Do...</h3>
       <p>
         <a href="email.html">
-          <span class="icon icon-email" role="img" aria-label="Email"></span>
+          <span class="icon icon-email" role="img" aria-hidden="true"></span>
+		  <span class="sr-only">Email</span>
         </a>
       </p>
 


### PR DESCRIPTION
Fixes: https://github.com/w3c/wcag/issues/1007

I have changed the following:
* Frame (shadow) around the stars, so that contrast is sufficient
* Contrast between yellow and gray in the star increased, thus contrast greater than 3:1
* all font icons marked with aria-hidden=true, and aria-label removed
* Alternative text of the icons in the source code as text (class=sr-only), so that the text is also visible without CSS (see F87)