### PR TITLE
Errata/clarification of 2.2.1 Timing Adjustable extension

### DIFF
--- a/guidelines/sc/20/timing-adjustable.html
+++ b/guidelines/sc/20/timing-adjustable.html
@@ -32,7 +32,8 @@
          
          <p>The user is warned before time expires and given at least 20 seconds to extend the
             time limit with a simple action (for example, "press the space bar"), and the user
-            is allowed to extend the time limit at least ten times; or
+            is allowed to extend the time limit to at least ten times the length of the default setting
+            (either in one extension, or as a cumulative series of extensions); or
          </p>
          
       </dd>


### PR DESCRIPTION
Based on the discussion in https://lists.w3.org/Archives/Public/w3c-wai-gl/2020JanMar/0161.html this is a first attempt at making it more explicit what the confusing "at least ten times" means. It appears this has been misinterpreted by some as "ten times" meaning that a site needs to provide ten separate warnings/options to extend, when in fact it appears this, like the previous point about adjusting timing, is meant as "ten times the length of time".