### PR TITLE
Underline links in the head of the spec.

### DIFF
--- a/css/additional.css
+++ b/css/additional.css
@@ -162,13 +162,6 @@ div.sc div.note p.prefix {
     margin-bottom: 0;
 }
 
-/* Un-do the removal of underlines from the links in the head area */
-
-.head p:not(.copyright) > a, .head > a:first-child {
-    border-bottom: 1px solid #707070;
-}
-
-
 span.screenreader {position: absolute; left: -10000px}
 
 /* tabbed styles - repeated here to keep cover sheets consistent with /TR/ style */

--- a/css/additional.css
+++ b/css/additional.css
@@ -162,6 +162,12 @@ div.sc div.note p.prefix {
     margin-bottom: 0;
 }
 
+/* Un-do the removal of underlines from the links in the head area */
+
+.head p:not(.copyright) > a, .head > a:first-child {
+    border-bottom: 1px solid #707070;
+}
+
 
 span.screenreader {position: absolute; left: -10000px}
 

--- a/guidelines/guidelines.css
+++ b/guidelines/guidelines.css
@@ -50,4 +50,8 @@ dd.new, dd.proposed, dd.changed {
 div.note-title, div.ednote-title {
 	color: #008400
 }
+/* make links in W3C masthead bold, since we can't make them underline */
 span.screenreader {position: absolute; left: -10000px}
+.head p:not(.copyright) > a, .head > a:first-child {
+	font-weight: bold;
+}

--- a/techniques/techniques.css
+++ b/techniques/techniques.css
@@ -3,3 +3,7 @@ body {}
 #masthead li {
 	margin: 0;
 }
+/* make links in W3C masthead bold, since we can't make them underline */
+.head p:not(.copyright) > a, .head > a:first-child {
+	font-weight: bold;
+}

--- a/understanding/understanding.css
+++ b/understanding/understanding.css
@@ -207,3 +207,7 @@ p.sctxt {
 video {
     max-width: 100%;
 }
+/* make links in W3C masthead bold, since we can't make them underline */
+.head p:not(.copyright) > a, .head > a:first-child {
+	font-weight: bold;
+}


### PR DESCRIPTION
A very constrained bit of CSS to over-ride the base.css

Closes #1048 
Closes #562