### PR TITLE
Status message added to 2.4.11

### DIFF
--- a/understanding/22/focus-visible-enhanced.html
+++ b/understanding/22/focus-visible-enhanced.html
@@ -8,6 +8,12 @@
 <body>
    <h1>Understanding Focus Visible (Enhanced)</h1>
    
+    <section id="status" class="advisement">
+        <h2>Status</h2>
+        <p>This understanding document is part of the <a href="https://w3c.github.io/wcag/guidelines/22/"><strong>draft</strong> WCAG 2.2 content</a>. It may change or be removed before the final WCAG 2.2 is published.</p>
+    </section>
+
+
    <section class="remove">
    
         <h2>Focus Visible (Enhanced) Success Criteria text</h2>
@@ -25,6 +31,7 @@
      </section>
    
     <section id="intent">
+        
         <h2>Intent of Focus Visible (Enhanced)</h2>
 
 

--- a/xslt/generate-understanding.xslt
+++ b/xslt/generate-understanding.xslt
@@ -253,6 +253,7 @@
 							<xsl:apply-templates select="$meta/content/html:*[position() &gt; 1]" mode="sc-info"/>
 						</blockquote>
 						<main>
+							<xsl:apply-templates select="//html:section[@id = 'status']"/>
 							<xsl:apply-templates select="//html:section[@id = 'intent']"/>
 							<xsl:apply-templates select="//html:section[@id = 'benefits']"/>
 							<xsl:apply-templates select="//html:section[@id = 'examples']"/>


### PR DESCRIPTION
As the understanding document for the new WCAG 2.2 SCs are popping up in the regular understanding docs area, we need to highlight the status of those documents.

I've used some CSS from the basic styles available (class=advisement), but not sure where that section would pop out of the build process.