### PR TITLE
Adding 'to trigger a function' to target definition

### DIFF
--- a/guidelines/terms/21/target.html
+++ b/guidelines/terms/21/target.html
@@ -1,7 +1,7 @@
 <dt><dfn>target</dfn></dt>
 <dd>
    					
-     <p>region of the display that will accept a pointer action, such as the interactive area of a user interface component</p> 
+     <p>region of the display that will accept a pointer action to trigger a function, such as the interactive area of a user interface component</p> 
     <p class="note">If two or more touch targets are overlapping, the overlapping area should not be included in the measurement of the target size, except when the overlapping targets perform the same action or open the same page.</p>
   
 </dd>


### PR DESCRIPTION
Based on the discussion for Target Spacing, one point was to refine the definition of targets:

> target
> region of the display that will accept a pointer action **to trigger a function**, such as the interactive area of a user interface component

We could do that for 2.2 only, but it seems to be a suitable refinement for a 2.1 errata.

The question is really: Is there any change is scope that adding this small bit of text would imply? (The intention is no change in scope.)