### PR TITLE
Updated chairs

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -104,7 +104,8 @@
 						<td>
 							<ul>
 								<li>Alastair Campbell (Nomensa)</li>
-								<li>Andrew Kirkpatrick (Adobe)</li>
+								<li>Chuck Adams (Oracle)</li>
+								<li>Rachael Montgomery (W3C Invited Expert)</li>
 							</ul>
 						</td>
 					</tr>
@@ -353,6 +354,12 @@
 								<td>19 December 2019</td>
 								<td>31 October 2022</td>
 								<td>Added WCAG 2.2 and moved previously incubated Silver to Recommendation Track.</td>
+							</tr>
+							<tr>
+								<th>4 March 2020</th>
+								<td></td>
+								<td></td>
+								<td>Andrew Kirkpatrick (Adobe) stepped down from his role as co-Chair due to increased responsibilities at Adobe. Chuck Adams (Oracle) and Rachael Montgomery (W3C Invited Expert) are appointed and join Alastair Campbell (Nomensa) continues as co-Chair.</td>
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
Per 4 March 2020 announcement: [Chuck Adams and Rachael Montgomery appointed co-Chairs of the Accessibility Guidelines Working Group; Andrew Kirkpatrick steps down](https://lists.w3.org/Archives/Member/chairs/2020JanMar/0052.html).