### PR TITLE
Draft of Error correction (Processes)

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -346,6 +346,8 @@
 
                 <section data-include="sc/22/accessible-authentication.html" data-include-replace="true"></section>
 
+                <section data-include="sc/20/error-correction-processes.html" data-include-replace="true"></section>
+
             </section>
 
         </section>

--- a/guidelines/sc/22/error-correction-processes.html
+++ b/guidelines/sc/22/error-correction-processes.html
@@ -5,7 +5,7 @@
     <p class="conformance-level">A</p>
 	<p class="change">New</p>
     
-    <p>For processes which require the user to submit information, all the following are true:</p>
+    <p>For <a>processes</a> which require the user to submit information, all the following are true:</p>
     <ul>
         <li>A mechanism is available for reviewing, confirming, and correcting information before finalizing the submission, unless the information cannot be modified for logical, security, or privacy reasons.</li>
         <li>A warning is provided if information entered and edited by the user invalidates other previously entered information.</li>

--- a/guidelines/sc/22/error-correction-processes.html
+++ b/guidelines/sc/22/error-correction-processes.html
@@ -1,0 +1,14 @@
+<section class="sc new">
+   
+    <h4>Error Correction (Processes)</h4>
+    
+    <p class="conformance-level">A</p>
+	<p class="change">New</p>
+    
+    <p>For processes which require the user to submit information, all the following are true:</p>
+    <ul>
+        <li>A mechanism is available for reviewing, confirming, and correcting information before finalizing the submission, unless the information cannot be modified for logical, security, or privacy reasons.</li>
+        <li>A warning is provided if information entered and edited by the user invalidates other previously entered information.</li>
+    </ul>            
+    
+ </section>

--- a/understanding/22/error-correction-processes.html
+++ b/understanding/22/error-correction-processes.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+   <meta charset="UTF-8"></meta>
+   <title>Understanding Error Correction (Processes)</title>
+   <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove"></link>
+</head>
+<body>
+   <h1>Understanding Error Correction (Processes)</h1>
+   
+    <section id="status" class="advisement">
+        <h2>Status</h2>
+        <p>This understanding document is part of the <a href="https://w3c.github.io/wcag/guidelines/22/"><strong>draft</strong> WCAG 2.2 content</a>. It may change or be removed before the final WCAG 2.2 is published.</p>
+    </section> 
+
+    <section class="remove">
+   
+        <h2>Success Criteria text</h2>
+        <blockquote>
+            <p class="conformance-level">A</p>
+            <p>For processes which require the user to submit information, all the following are true:</p>
+            <ul>
+                <li>A mechanism is available for reviewing, confirming, and correcting information before finalizing the submission, unless the information cannot be modified for logical, security, or privacy reasons.</li>
+                <li>A warning is provided if information entered and edited by the user invalidates other previously entered information.</li>
+            </ul>   
+        </blockquote>
+    </section>
+   
+    <section id="intent">
+        <h2>Intent of Error Correction (Processes)</h2>
+
+        <p>The intent of this Success Criterion is to allow users to immediately review and correct any entries made in form process. This should be possible any point in the process prior to submission without restarting the entire form process or waiting until just before submission.</p>
+
+        <p>Sometimes a web form consists of a sequence of ordered and distinct steps or sections, and users may realise that they made a mistake in an earlier part of the process. They should then be able to easily review and revise their previous entries as required. After review or correction, they should then be able to easily continue from the step they were at before and without re-entering anything.</p>
+            
+        <p>This is especially important for people with learning and cognitive disabilities who may not be able to keep a mistake in mind from the point of realization until a final review of the submission. A needed change may thus be forgotten if they are not able to immediately make it.</p>
+            
+        <p>When possible, if a previous entry is revised then any subsequent entries should remain so they do not need reentering. However in some cases, logical, security or privacy reasons may prevent this:</p>
+            
+        <ul>
+            <li><strong>Logical:</strong> Changing an entry requires that entries previously made in subsequent steps be re-entered because of a dependency relationship between them;</li>
+            <li><strong>Security:</strong> Providing the ability to change the entry would conflict with security based time-outs or otherwise create a security risk;</li>
+            <li><strong>Privacy:</strong> Providing the ability to change the entry would put privacy of personal information at risk.</li>
+        </ul>
+
+
+    </section>
+    <section id="benefits">
+      <h2>Benefits of Error Correction (Processes)</h2>
+      
+      <p>People with cognitive issues relating to memory, reading (e.g. dyslexia), numbers (e.g. dyscalculia), or perception-processing limitations will be more likely to complete processes.</p>
+      
+   </section>
+   
+   <section id="examples">
+      <h2>Examples of Error Correction (Processes)</h2>
+
+      <ul>
+         <li>A company trip booking system provides links to each previously visited screen of the process. This allows the user to easily see how to go back to the previous step and correct their entries. For example, it may be realized the trip destination was incorrectly entered as soon as they try to select from a list of available hotels. By clicking on the Destination step the correction can be made and they can then can then quickly return to the Hotel step. In addition, all entries can be double checked before final submission by using the links to visit each step. Note that in this example the Hotel list is logically dependent on the Location as so is not expected to remain unchanged after the Destination is selected.</li>
+         <li>A ticket purchase system has a multi-page form and allows users to go back, review and change earlier entries. However, tickets are a limited resource requiring management to allow fair access. When a user starts filling in the form tickets are reserved for them until they complete the process, otherwise they may find there are no longer any tickets on completion of the process. During this time error correction is possible at any time. However the user should not be allowed to hold the tickets for a long time and never complete, so a timeout is provided after which the tickets are released and the user is alerted. At this point there is no need for the user to be able correct errors without starting the process again.</li>
+      </ul>
+      
+   </section>
+
+   
+   <section id="techniques">
+      <h2>Techniques for Error Correction (Processes)</h2>
+      
+      
+      <section id="sufficient">
+         <h3>Sufficient Techniques for Error Correction (Processes)</h3>
+         
+         
+         <ol>
+            <li>
+                <a href="../../techniques/general/G65.html" class="general">Creating breadcrumbs</a>
+            </li>
+            <li>
+                @@ Next and previous buttons for navigating the process.
+            </li>
+            <li>
+                @@ Providing a warning that altering an input will invalidate previously entered information.
+            </li>
+         </ol>
+         
+      </section>
+      
+      <section id="advisory">
+         <h3>Additional Techniques (Advisory) for Error Correction (Processes)</h3>
+         
+      </section>
+      
+      <section id="failure">
+         <h3>Failures for Error Correction (Processes)</h3>
+
+      </section>
+      
+   </section>
+   <section id="resources">
+        <h2>Resources</h2>
+
+        
+    </section>
+   
+</body>
+</html>


### PR DESCRIPTION
Initial draft of the new criteria from the [google doc](https://docs.google.com/document/d/1b6Qa7r_nWEUo4fJw230Ys6HteSZTl_lMpfQ-pMiODnA/edit#).

You can preview the:
- [SC text and understanding document](https://raw.githack.com/w3c/wcag/wcag22-error-correction/understanding/22/error-correction-processes.html).

The first technique is actually a current one (breadcrumbs), there are two other technique ideas that could be drafted later.

Previous survey: https://www.w3.org/2002/09/wbs/35422/wcag22-confirm-before-submission/results
Last minutes: https://www.w3.org/2020/03/25-ag-minutes.html#item03


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/1157.html" title="Last updated on Jul 12, 2020, 9:15 PM UTC (ed9ac71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/1157/0c37c39...ed9ac71.html" title="Last updated on Jul 12, 2020, 9:15 PM UTC (ed9ac71)">Diff</a>