### PR TITLE
Qualify Sufficient Techniques

### DIFF
--- a/understanding/20/link-purpose-link-only.html
+++ b/understanding/20/link-purpose-link-only.html
@@ -44,16 +44,14 @@
       <p>The Success Criterion includes an exception for links for which the purpose of the
          link cannot be determined from the information on the Web page. In this situation,
          the person with the disability is not at a disadvantage; there is no additional context
-         available to understand the link purpose. However, whatever amount of context is available
-         on the Web page that can be used to interpret the purpose of the link must be made
-         available in the link text to satisfy the Success Criterion.
+         available to understand the link purpose.
       </p>
       
       <p>The word "mechanism" is used to allow authors to either make all links fully understandable
          out of context by default or to provide a way to make them this way. This is done
          because for some pages, making the links all unambiguous by themselves makes the pages
          easier for some users and harder for others. Providing the ability to make the links
-         unambiguous (by them selves) or not provides both users with disabilities with the
+         unambiguous (by themselves) or not provides both users with and without disabilities with the
          ability to use the page in the format that best meets their needs.
       </p>
       
@@ -153,14 +151,7 @@
             								       
             <a href="http://webaim.org/techniques/hypertext/">WebAIM Techniques for Hypertext Links</a>
             							     
-         </li>
-         
-         <li>
-            	
-            <a href="http://www.rnib.org.uk/blogs/expert-series?Name=Hidden%20barriers">Hidden barriers - out of sight</a>
-            							     
-         </li>
-         
+         </li>       
       </ul>
       
    </section>
@@ -171,16 +162,23 @@
       
       <section id="sufficient">
          <h3>Sufficient Techniques for Link Purpose (Link Only)</h3>
+       
+        <div class="note">
+               <div role="heading" class="note-title marker" aria-level="4">Note</div>        
+        <p><em>Note:</em> Some of the Sufficient Techniques listed below provide self-contained link purpose only to some groups of users. <a class="aria" href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8">ARIA8: Using aria-label for link purpose</a> replaces the visible link text with a more fleshed-out description in the value of the aria-label attribute, providing the purpose of the link to visually impaired users using a screen reader. The Technique, however, does not help users with cognitive disabilities since the visual context does not provide the purpose of the link.</p>
+        <p>Similarly, <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C7" class="css">Supplementing link text with hidden text</a> helps screen reader users, but since the supplemented text providing the link purpose is invisible, it does not help sighted users with cognitive disabilities.</p>
+          <div>
+
          
          
-         <ol>
-            
+         <ol>       
             <li>
-               
-               <a href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8" class="aria"></a>
-               
-            </li>
-            
+                 
+               <a class="aria" href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8">ARIA8: Using aria-label for link purpose</a>
+                     
+                     
+                  </li>
+           
             <li>
                									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G91" class="general">Providing link text that describes the purpose of a link</a>
@@ -192,7 +190,7 @@
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H30" class="html">Providing link text that describes the purpose of a link for anchor elements</a>
                								       
             </li>
-            
+
             <li>
                									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H24" class="html">Providing a text alternative for the area element</a>
@@ -285,8 +283,7 @@
       </section>
       
       <section id="advisory">
-         <h3>Additional Techniques (Advisory) for Link Purpose (Link Only)</h3>
-         
+         <h3>Additional Techniques (Advisory) for Link Purpose (Link Only)</h3> 
          
          <ul>
             


### PR DESCRIPTION
Added a note after h3 Sufficient Techniques to flag the fact that the value of two of Techniques listed is limited to screen reader users: ARIA8 (Using aria-label for link purpose) and C7 (Using CSS to hide a portion of the link text).