### PR TITLE
Fix link to `prefers-reduced-motion` working example

### DIFF
--- a/techniques/css/C39.html
+++ b/techniques/css/C39.html
@@ -40,7 +40,7 @@
   /* CSS to disable motion goes here */
 }</pre>
     <p class="working-example">
-      <a href="../../working-examples/css-reduced-motion-query/index.html">Working example of 'prefers-reduced-motion' CSS Media Query</a>
+      <a href="../../working-examples/css-reduced-motion-query/">Working example of 'prefers-reduced-motion' CSS Media Query</a>
     </p>
   </section>
 </section>


### PR DESCRIPTION
not sure why, but the `index.html` bit breaks the link (even though in the repo the file is actually `index.html` ... maybe the live version rewrites these? missing configuration on the live site?)

this fixes the live version (but may mean it can't be viewed properly in a local copy)

Closes #1101 