### PR TITLE
Dragging Understanding text: change 'path-based gestures' to 'dragging movements'

### DIFF
--- a/understanding/22/dragging.html
+++ b/understanding/22/dragging.html
@@ -71,7 +71,7 @@
          
          <ol>
             <li>
-                <a href="../../techniques/general/G219" class="general">Ensuring that a single pointer operable alternative is available for dragging movements that operate on content</a>
+                <a href="https://w3c.github.io/wcag/techniques/general/G219">G219: Ensuring that a single pointer operable alternative is available for dragging movements that operate on content</a>
             </li>
          </ol>
          

--- a/understanding/22/dragging.html
+++ b/understanding/22/dragging.html
@@ -87,7 +87,7 @@
 
          <ul>
             <li>								         
-                <a href="https://w3c.github.io/wcag/techniques/failures/F108" class="failure">Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</a>						       
+                <a href="https://w3c.github.io/wcag/techniques/failures/F108" class="failure">F108: Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</a>						       
             </li>
          </ul>
       </section>

--- a/understanding/22/dragging.html
+++ b/understanding/22/dragging.html
@@ -87,7 +87,7 @@
 
          <ul>
             <li>								         
-                <a href="../../techniques/failures/F108" class="failure">Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</a>						       
+                <a href="https://w3c.github.io/wcag/techniques/failures/F108" class="failure">Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</a>						       
             </li>
          </ul>
       </section>

--- a/understanding/22/dragging.html
+++ b/understanding/22/dragging.html
@@ -44,7 +44,7 @@
       <h2>Benefits of Dragging</h2>
       
       <ul>
-         <li>Users who struggle with performing dragging gestures can still operate an interface with a pointer interface.</li>
+         <li>Users who struggle with performing dragging movements can still operate an interface with a pointer interface.</li>
       </ul>
       
    </section>

--- a/understanding/22/dragging.html
+++ b/understanding/22/dragging.html
@@ -44,7 +44,7 @@
       <h2>Benefits of Dragging</h2>
       
       <ul>
-         <li>Users who struggle with performing path-based gestures can still operate an interface with a pointer interface.</li>
+         <li>Users who struggle with performing dragging gestures can still operate an interface with a pointer interface.</li>
       </ul>
       
    </section>


### PR DESCRIPTION
View [Dragging Understanding](https://raw.githack.com/w3c/wcag/dragging-understanding-edits/understanding/22/dragging.html) text.

Adresses issue #1195 Intermediate points in definition of dragging

Benefits: changed 'path-based' to 'dragging' to separate this SC more clearly from 2.5.1
Links to General and Failure Technique amended.