### PR TITLE
Dragging movement glossary definition: Deleting reference to intermediate point

### DIFF
--- a/guidelines/terms/22/dragging-movement.html
+++ b/guidelines/terms/22/dragging-movement.html
@@ -2,6 +2,6 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-   <p>an operation where the pointer engages with an element on the down event and the element (or a representation of its position) follows the pointer until the up event</p>
+   <p>an operation where the pointer engages with an element on the down event and the element (or a representation of its position) follows the pointer</p>
    <p class="note">The element could be, for example, a list item, a text element, or an image.</p>
 </dd>

--- a/guidelines/terms/22/dragging-movement.html
+++ b/guidelines/terms/22/dragging-movement.html
@@ -2,6 +2,6 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-   <p>an operation where the pointer engages with an element on the down event and the element (or a representation of its position) follows the pointer until the up event, without requiring movement through an intermediate point</p>
+   <p>an operation where the pointer engages with an element on the down event and the element (or a representation of its position) follows the pointer until the up event</p>
    <p class="note">The element could be, for example, a list item, a text element, or an image.</p>
 </dd>


### PR DESCRIPTION
Deleted the qualification "without requiring movement through an intermediate point". This was initially included in the definition to separate 'dragging movement' more clearly from single pointer gestures. Since the 'single pointer' definition has no reference to the intermediate point requirement (see Understanding text for 2.5.1) , including it in the definition of dragging movement is likely to cause confusion.

Closes issue #1195 