### PR TITLE
Update pointer-target-spacing.html

### DIFF
--- a/understanding/22/pointer-target-spacing.html
+++ b/understanding/22/pointer-target-spacing.html
@@ -29,7 +29,7 @@
                 <li><strong>User agent:</strong> The size of the target is controlled by the user agent and is not modified by the author;</li>
                 <li><strong>Essential:</strong> A particular presentation of the target is essential to the information being conveyed.</li>
             </ul>
-            <p class="note">This criterion has been formulated to increase the hit-area of small targets, but the group would like feedback from providers of touch-screen devices if there is another way of forming the criterion to better complement the tap-heuristics used.</p>
+            <p class="note">This criterion has been formulated to make it less likely that users accidentally hit a target that is adjacent to the one they intrend to hit. The group would like feedback from providers of touch-screen devices if there is another way of forming the criterion to better complement the tap-heuristics used.</p>
             <p class="note">Are there issues with internationalization when describing inline links?</p>
             <p class="note">Are there issues with pop-over content overlapping targets triggering failures?</p>
         </blockquote>

--- a/understanding/22/pointer-target-spacing.html
+++ b/understanding/22/pointer-target-spacing.html
@@ -29,7 +29,7 @@
                 <li><strong>User agent:</strong> The size of the target is controlled by the user agent and is not modified by the author;</li>
                 <li><strong>Essential:</strong> A particular presentation of the target is essential to the information being conveyed.</li>
             </ul>
-            <p class="note">This criterion has been formulated to make it less likely that users accidentally hit a target that is adjacent to the one they intrend to hit. The group would like feedback from providers of touch-screen devices if there is another way of forming the criterion to better complement the tap-heuristics used.</p>
+            <p class="note">This criterion has been formulated to make it less likely that users accidentally hit a target adjacent to the one they intend to hit. The group would like feedback from providers of touch-screen devices if there is another way of forming the criterion to better complement the tap-heuristics used.</p>
             <p class="note">Are there issues with internationalization when describing inline links?</p>
             <p class="note">Are there issues with pop-over content overlapping targets triggering failures?</p>
         </blockquote>


### PR DESCRIPTION
Replaced the misleading bit "increase the hit-area of small targets" in the first note to emphasise separation of targets to minimise accidental activation.
Closes #1362 