### PR TITLE
fix link typo in 1.4.4 understanding doc

### DIFF
--- a/understanding/20/images-of-text.html
+++ b/understanding/20/images-of-text.html
@@ -49,7 +49,7 @@
       </p>
       
       <p>See also 
-         <a href="images-of-text-no-exception">1.4.4: Images of Text (No Exception)</a>.
+         <a href="images-of-text-no-exception">1.4.9: Images of Text (No Exception)</a>.
       </p>
       
       


### PR DESCRIPTION
Link points (correctly) to 1.4.9: Images of text (no exception), but current text of link incorrectly had SC number 1.4.4.