### PR TITLE
Link page about avoiding new window links to new window link warning

### DIFF
--- a/techniques/general/G200.html
+++ b/techniques/general/G200.html
@@ -27,6 +27,7 @@
          
       </section>
    </section><section id="related"><h2>Related Techniques</h2><ul>
+      <li><a href="G201">G201</a></li>
       <li><a href="../html/H83">H83</a></li>
       <li><a href="../client-side-script/SCR24">SCR24</a></li>
    </ul></section><section id="resources"><h2>Resources</h2>

--- a/wcag20/sources/techniques/general/G200.xml
+++ b/wcag20/sources/techniques/general/G200.xml
@@ -56,6 +56,7 @@
       </see-also>
    </resources>
    <related-techniques>
+      <relatedtech idref="G201"/>
       <relatedtech idref="H83"/>
       <relatedtech idref="SCR24"/>
    </related-techniques>


### PR DESCRIPTION
Link G200 to G201.

These are related and should be linked. The link in the other direction is already present.