### PR TITLE
Trivial: remove unnecessary space before tag closing bracket

### DIFF
--- a/techniques/general/G212.html
+++ b/techniques/general/G212.html
@@ -14,11 +14,11 @@
 		</section>
 		<section id="applicability">
 			<h2>When to Use</h2>
-			<p >This technique applies to nearly all technologies.</p>
+			<p>This technique applies to nearly all technologies.</p>
 		</section>
 		<section id="description">
 			<h2>Description</h2>
-			<p >The objective of this technique is to ensure that users who attempt to interact with a control do not trigger the action of the event accidentally. This can be accomplished most directly by relying on the pointer's up-event (for example, the onclick or mouseup event).  </p>
+			<p>The objective of this technique is to ensure that users who attempt to interact with a control do not trigger the action of the event accidentally. This can be accomplished most directly by relying on the pointer's up-event (for example, the onclick or mouseup event).  </p>
       		<p>The easiest way to meet this success criterion is simply to use the default behavior of controls and not override that behaviour with an explicit down-event trigger. The up-event is the default behaviour for almost all controls and any programming or markup language.  </p>
      		<p>In native languages where a control is fired on the down event it is usually for good reason and is easily recoverable. For instance, an HTML input element could have the cursor enter the editable area on the “pointer down” event, because the action is trivially reversible, and as such meets the requirements of the Pointer Cancellation SC. This is because if the user realizes they made a mistake after pressing down the control, they can simply move their pointer away from the hit area while still holding down the pointer, then release their pointer and the event is not triggered. </p>
 		</section>

--- a/wcag20/Techniques/working-examples/ARIA1/ex1.html
+++ b/wcag20/Techniques/working-examples/ARIA1/ex1.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
 "http://www.w3.org/TR/html4/strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="content-type" content="text/xhtml; charset=utf-8" />
 <title>Demonstration of describedby property</title>
@@ -80,9 +80,9 @@ window.onload=setDescribedBy;
 <body>
 <p>The buttons on this page use the Accessible Rich Internet Applications describedby property to provide more detailed information about the button action</p>
 <div class="form">
-<p><span class="left" id="fontDesc" >Select the font faces and sizes to be used on this page</span><span class="right"><button id="fontB" onclick="doAction('Fonts');"> Fonts </button></span></p>
-<p><span class="left" id="colorDesc" >Select the colors to be used on this page</span><span class="right"><button id="colorB" onclick="doAction('Colors');"> Colors </button></span></p>
-<p><span class="left" id="customDesc" >Customize the layout and styles used on this page</span><span class="right"><button id="customB" onclick="doAction('Customize');"> Customize </button></span></p>
+<p><span class="left" id="fontDesc">Select the font faces and sizes to be used on this page</span><span class="right"><button id="fontB" onclick="doAction('Fonts');"> Fonts </button></span></p>
+<p><span class="left" id="colorDesc">Select the colors to be used on this page</span><span class="right"><button id="colorB" onclick="doAction('Colors');"> Colors </button></span></p>
+<p><span class="left" id="customDesc">Customize the layout and styles used on this page</span><span class="right"><button id="customB" onclick="doAction('Customize');"> Customize </button></span></p>
 </div>
 <p>The link in the next paragraph has been updated with the Accessible Rich Internet Applications describedby property to provide more information
 about the link</p>

--- a/wcag20/Techniques/working-examples/C29/ex3/index.php
+++ b/wcag20/Techniques/working-examples/C29/ex3/index.php
@@ -18,7 +18,7 @@ else
 <title>Using PHP $_GET to apply a different external CSS file</title>
    
 
-  <link rel="stylesheet" type="text/css" media="screen" href="<?php echo($thestyle);?>.css" >
+  <link rel="stylesheet" type="text/css" media="screen" href="<?php echo($thestyle);?>.css">
 
 </head>
 

--- a/wcag20/Techniques/working-examples/F1/cssposfailure.html
+++ b/wcag20/Techniques/working-examples/F1/cssposfailure.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd" >
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/wcag20/Techniques/working-examples/F1/cssposfailurenostyle.html
+++ b/wcag20/Techniques/working-examples/F1/cssposfailurenostyle.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd" >
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"  "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/wcag20/Techniques/working-examples/SL1/AlternativeAudioChannelTestPage.html
+++ b/wcag20/Techniques/working-examples/SL1/AlternativeAudioChannelTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>AlternativeAudioChannel</title>

--- a/wcag20/Techniques/working-examples/SL10/BasicSubmitButtonTestPage.html
+++ b/wcag20/Techniques/working-examples/SL10/BasicSubmitButtonTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>BasicSubmitButton</title>

--- a/wcag20/Techniques/working-examples/SL11/PauseBouncyBall.html
+++ b/wcag20/Techniques/working-examples/SL11/PauseBouncyBall.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>PauseBouncyBall</title>

--- a/wcag20/Techniques/working-examples/SL13/HighContrastTestPage.html
+++ b/wcag20/Techniques/working-examples/SL13/HighContrastTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>HighContrast</title>

--- a/wcag20/Techniques/working-examples/SL14/SimpleNumericUpDownTestPage.html
+++ b/wcag20/Techniques/working-examples/SL14/SimpleNumericUpDownTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>KeysNumericUpDown</title>

--- a/wcag20/Techniques/working-examples/SL15/ApplicationLevelKeyHandlingTestPage.html
+++ b/wcag20/Techniques/working-examples/SL15/ApplicationLevelKeyHandlingTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ApplicationLevelKeyHandling</title>

--- a/wcag20/Techniques/working-examples/SL16/MediaTimelineMarkersTestPage.html
+++ b/wcag20/Techniques/working-examples/SL16/MediaTimelineMarkersTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>MediaTimelineMarkers</title>

--- a/wcag20/Techniques/working-examples/SL17/ReplaceAudioWithTranscriptTextTestPage.html
+++ b/wcag20/Techniques/working-examples/SL17/ReplaceAudioWithTranscriptTextTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ReplaceAudioWithTranscriptText</title>

--- a/wcag20/Techniques/working-examples/SL18/ButtonNontextTextCompositionTestPage.html
+++ b/wcag20/Techniques/working-examples/SL18/ButtonNontextTextCompositionTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ButtonNontextTextComposition</title>

--- a/wcag20/Techniques/working-examples/SL19/AutomationPropertiesHelpTextTestPage.html
+++ b/wcag20/Techniques/working-examples/SL19/AutomationPropertiesHelpTextTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>AutomationPropertiesHelpText</title>

--- a/wcag20/Techniques/working-examples/SL2/VisibleFocusTemplateTestPage.html
+++ b/wcag20/Techniques/working-examples/SL2/VisibleFocusTemplateTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>VisibleFocusTemplate</title>

--- a/wcag20/Techniques/working-examples/SL20/SimplePeerForwardingTestPage.html
+++ b/wcag20/Techniques/working-examples/SL20/SimplePeerForwardingTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>SimplePeerForwarding</title>

--- a/wcag20/Techniques/working-examples/SL21/StopAnimationTestPage.html
+++ b/wcag20/Techniques/working-examples/SL21/StopAnimationTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>StopAnimation</title>

--- a/wcag20/Techniques/working-examples/SL22/BrowserZoomTestPage.html
+++ b/wcag20/Techniques/working-examples/SL22/BrowserZoomTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>BrowserZoom</title>

--- a/wcag20/Techniques/working-examples/SL23/ByAnimationFontSizeTestPage.html
+++ b/wcag20/Techniques/working-examples/SL23/ByAnimationFontSizeTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>StyleSwitcherFontSize</title>

--- a/wcag20/Techniques/working-examples/SL23/StyleSwitcherFontSizeTestPage.html
+++ b/wcag20/Techniques/working-examples/SL23/StyleSwitcherFontSizeTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>StyleSwitcherFontSize</title>

--- a/wcag20/Techniques/working-examples/SL24/MediaElementControlsAutoPlayTestPage.html
+++ b/wcag20/Techniques/working-examples/SL24/MediaElementControlsAutoPlayTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>MediaElementControlsAutoPlay</title>

--- a/wcag20/Techniques/working-examples/SL25/ProgrammaticFocusTestPage.html
+++ b/wcag20/Techniques/working-examples/SL25/ProgrammaticFocusTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ProgrammaticFocus</title>

--- a/wcag20/Techniques/working-examples/SL26/LabelsTestPage.html
+++ b/wcag20/Techniques/working-examples/SL26/LabelsTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>Labels</title>

--- a/wcag20/Techniques/working-examples/SL27/LangPropertiesTestPage.html
+++ b/wcag20/Techniques/working-examples/SL27/LangPropertiesTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>LangProperties</title>

--- a/wcag20/Techniques/working-examples/SL29/TabNavigationTestPage.html
+++ b/wcag20/Techniques/working-examples/SL29/TabNavigationTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabNavigation</title>

--- a/wcag20/Techniques/working-examples/SL3/MediaElementControlsTestPage.html
+++ b/wcag20/Techniques/working-examples/SL3/MediaElementControlsTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>MediaElementControls</title>

--- a/wcag20/Techniques/working-examples/SL30/ButtonNontextTextCompositionTestPage.html
+++ b/wcag20/Techniques/working-examples/SL30/ButtonNontextTextCompositionTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ButtonNontextTextComposition</title>

--- a/wcag20/Techniques/working-examples/SL31/DocumentStructureTestPage.html
+++ b/wcag20/Techniques/working-examples/SL31/DocumentStructureTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>DocumentStructure</title>

--- a/wcag20/Techniques/working-examples/SL34/TabSequenceTestPage.html
+++ b/wcag20/Techniques/working-examples/SL34/TabSequenceTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabSequence</title>

--- a/wcag20/Techniques/working-examples/SL34/TabSequence_EnabledTestPage.html
+++ b/wcag20/Techniques/working-examples/SL34/TabSequence_EnabledTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabSequenceEnabled</title>

--- a/wcag20/Techniques/working-examples/SL34/TabSequence_TabIndexTestPage.html
+++ b/wcag20/Techniques/working-examples/SL34/TabSequence_TabIndexTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabSequence_TabIndex</title>

--- a/wcag20/Techniques/working-examples/SL35/AccessibleValidationTestPage.html
+++ b/wcag20/Techniques/working-examples/SL35/AccessibleValidationTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>AccessibleValidation</title>

--- a/wcag20/Techniques/working-examples/SL4/SilverFishTestPage.html
+++ b/wcag20/Techniques/working-examples/SL4/SilverFishTestPage.html
@@ -1,4 +1,4 @@
-﻿ <html xmlns="http://www.w3.org/1999/xhtml" >
+﻿ <html xmlns="http://www.w3.org/1999/xhtml">
  <head runat="server">
     <title>SilverFish</title>
  </head>

--- a/wcag20/Techniques/working-examples/SL5/ImageEquivalentTestPage.html
+++ b/wcag20/Techniques/working-examples/SL5/ImageEquivalentTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ImageEquivalent</title>

--- a/wcag20/Techniques/working-examples/SL6/SimpleNumericUpDownTestPage.html
+++ b/wcag20/Techniques/working-examples/SL6/SimpleNumericUpDownTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>SimpleNumericUpDown</title>

--- a/wcag20/Techniques/working-examples/SL7/FocusVisualCustomControlTestPage.html
+++ b/wcag20/Techniques/working-examples/SL7/FocusVisualCustomControlTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
 	<title>FocusVisualCustomControl</title>

--- a/wcag20/Techniques/working-examples/SL8/HelpTextAndToolTipTestPage.html
+++ b/wcag20/Techniques/working-examples/SL8/HelpTextAndToolTipTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>HelpTextAndToolTip</title>

--- a/wcag20/Techniques/working-examples/SL9/BuiltInKeyEquivalenceTestPage.html
+++ b/wcag20/Techniques/working-examples/SL9/BuiltInKeyEquivalenceTestPage.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>BuiltInKeyEquivalence</title>

--- a/wcag20/sources/quickref.xslt
+++ b/wcag20/sources/quickref.xslt
@@ -192,7 +192,7 @@ script type="text/javascript" src="annotate.js" xmlns="http://www.w3.org/1999/xh
       <xsl:if test="$show.techniques != '0'">
         <!-- Sufficient Techniques -->
                <xsl:processing-instruction name="php"><![CDATA[ if($bSufficient) { ]]></xsl:processing-instruction>   
-        <div class="sufficient" xmlns="http://www.w3.org/1999/xhtml" >
+        <div class="sufficient" xmlns="http://www.w3.org/1999/xhtml">
         <xsl:apply-templates select="$guide-src//spec/body/div1/div2[@id=$anchor2]/div3[@role='techniques']/div4[@role='sufficient']"/>
         </div>
         <xsl:processing-instruction name="php"><![CDATA[ } ]]></xsl:processing-instruction> 
@@ -652,7 +652,7 @@ script type="text/javascript" src="annotate.js" xmlns="http://www.w3.org/1999/xh
     </xsl:for-each>
   </xsl:template>
   <xsl:template match="p[@role='i'] | p[@role='v']">
-    <p  >
+    <p>
       <xsl:if test="@id">
         <xsl:attribute name="id"><xsl:value-of select="@id"/></xsl:attribute>
       </xsl:if>

--- a/wcag20/sources/slices-techniques-common.xsl
+++ b/wcag20/sources/slices-techniques-common.xsl
@@ -77,7 +77,7 @@
     </xsl:otherwise></xsl:choose>
   </xsl:template>
   <!-- create Technology Collection Pages -->
-  <xsl:template match="body/div1" >
+  <xsl:template match="body/div1">
   	<xsl:variable name="filename">
   		<xsl:apply-templates select="." mode="slice-techniques-filename"/>
   	</xsl:variable>
@@ -385,11 +385,11 @@
   <xsl:template name="navigation.top">
     <xsl:param name="prev" select="''"/>
     <xsl:param name="next" select="''"/>
-    <a name="top" >
+    <a name="top">
       <xsl:text> </xsl:text>
     </a>
     <xsl:comment> TOP NAVIGATION BAR </xsl:comment>
-    <ul id="navigation" >
+    <ul id="navigation">
       <li>
         <strong><a href="Overview.html#contents" title="Table of Contents">Contents</a></strong>
       </li>
@@ -413,7 +413,7 @@
       </xsl:choose>
       <xsl:choose>
         <xsl:when test="$next">
-          <li >
+          <li>
             <a>
               <xsl:attribute name="title"><xsl:call-template name="href.nav"><xsl:with-param name="target" select="$next"/></xsl:call-template></xsl:attribute>
               <xsl:attribute name="href"><xsl:call-template name="href.target"><xsl:with-param name="target" select="$next"/><!--<xsl:with-param name="just.filename" select="1"/>--></xsl:call-template></xsl:attribute>
@@ -431,7 +431,7 @@
 		<hr />
 		<strong >Quick Table of Contents</strong>
 		<hr />
-		<ul class="toc" >
+		<ul class="toc">
 			<xsl:apply-templates mode="toc" select=".">
 				<xsl:with-param name="just.filename" select="'0'"/>
 			</xsl:apply-templates>
@@ -442,7 +442,7 @@
     <xsl:param name="prev" select="''"/>
     <xsl:param name="next" select="''"/>
     <xsl:comment> BOTTOM NAVIGATION BAR </xsl:comment>
-    <ul id="navigationbottom" >
+    <ul id="navigationbottom">
       <li>
         <strong><a href="#top">Top</a></strong>
       </li>

--- a/wcag20/sources/slices-understanding-common.xsl
+++ b/wcag20/sources/slices-understanding-common.xsl
@@ -692,7 +692,7 @@
           </xsl:when>
         	<xsl:when test="../@role='examples'">
         		<xsl:if test="not(../p or ../olist or ../ulist or ../div4)">
-        			<p  >(none currently documented)</p>
+        			<p>(none currently documented)</p>
         		</xsl:if>
         	</xsl:when>
         </xsl:choose>

--- a/wcag20/sources/techniques/aria/ARIA20.xml
+++ b/wcag20/sources/techniques/aria/ARIA20.xml
@@ -46,7 +46,7 @@
             <p>A user can expand links on a bank website after logging in to see details of term deposit accounts. The details are within a span marked up with <prop>region</prop> role. The heading for the region has <code><![CDATA[role=heading]]></code> and is included in the <att>aria-labelledby</att> that names the region.</p>
          <codeblock role="html5"><![CDATA[
 <ol>
-	<li><a id="l1" href="#" aria-expanded="false" title="Show details" aria-controls="block1" >John Henry's Account</a><img src="images/panel_expand.gif" alt="" />
+	<li><a id="l1" href="#" aria-expanded="false" title="Show details" aria-controls="block1">John Henry's Account</a><img src="images/panel_expand.gif" alt="" />
 		 <div id="block1" class="nowHidden" tabindex="-1" aria-labelledby="l1 cd1" role="region"><span id="cd1" role="heading" aria-level="3">Certificate of  Deposit:</span>
 		 <table>
 			 <tr><th scope="row">Account:</th> <td>25163522</td></tr>

--- a/wcag20/sources/techniques/css/C29.xml
+++ b/wcag20/sources/techniques/css/C29.xml
@@ -287,7 +287,7 @@ else
 
 In the <head> section:
 
-   <link rel="stylesheet" type="text/css" media="screen" href="<?php echo($thestyle);?>.css" >
+   <link rel="stylesheet" type="text/css" media="screen" href="<?php echo($thestyle);?>.css">
 
 In <body> section:
 

--- a/wcag20/sources/techniques/failures/F3.xml
+++ b/wcag20/sources/techniques/failures/F3.xml
@@ -88,7 +88,7 @@ ul#booklist li.outstock {
          <head/>
          <description>
             <p>Using the code from example 1, the same background image is declared in the HTML style attribute:</p>
-            <codeblock xml:space="preserve"><![CDATA[<p id="bestinterest" style="background: transparent url(/images/TopRate.png) no-repeat top left;" >
+            <codeblock xml:space="preserve"><![CDATA[<p id="bestinterest" style="background: transparent url(/images/TopRate.png) no-repeat top left;">
 Where else would you find a better interest rate?
 <p>]]></codeblock>
             <p>In the following code, the background image declaration is created in a client script:</p>

--- a/wcag20/sources/techniques/failures/F49.xml
+++ b/wcag20/sources/techniques/failures/F49.xml
@@ -56,7 +56,7 @@
          <code role="html401"><![CDATA[
 <table>
 <tr>
-  <td ><img src="logo.gif" alt="XYZ mountaineering"></td>
+  <td><img src="logo.gif" alt="XYZ mountaineering"></td>
   <td rowspan="2" valign="bottom">top!</td>
 </tr>
 <tr>

--- a/wcag20/sources/techniques/failures/F69.xml
+++ b/wcag20/sources/techniques/failures/F69.xml
@@ -73,7 +73,7 @@
 							<p>The page uses frame but scrolling is set to "no". When the page size is increased using zoom, the content is hidden. </p>
 							<codeblock><![CDATA[<frameset rows="30%,*">
   <frame src="frameScrollingNo.html" scrolling=”no”>
-  <frame src="main.html" >
+  <frame src="main.html">
 </frameset>]]></codeblock>
 							<p>The section where scrolling is set to "no" gets truncated when the screen size is increased using browser zoom function, as shown in the image below.</p>
 							<p><image><img source="/WAI/WCAG20/Techniques/working-examples/F69/frame_no-scrollbars.png"/><alt>Illustration of example 3: Frame with no scrollbars</alt></image></p>

--- a/wcag20/sources/techniques/general/G189.xml
+++ b/wcag20/sources/techniques/general/G189.xml
@@ -40,7 +40,7 @@
          <code><![CDATA[
               ...
                 <h1>Books for download</h1>
-                <p><a href="books-full-links.html" >Full link Version</a></p>
+                <p><a href="books-full-links.html">Full link Version</a></p>
                 <ul>
                 <li>The History of the Web: 
                 <a href="history.docx" class="hist">Word</a>, 
@@ -56,7 +56,7 @@
          <code><![CDATA[
               ...
                 <h1>Books for download</h1>
-                <p><a href="books-short-links.html" >Short link Version</a></p>
+                <p><a href="books-short-links.html">Short link Version</a></p>
                 <ul>
                 <li>The History of the Web: 
                 <a href="history.docx" class="hist">The History of the Web(Word)</a>, 

--- a/wcag20/sources/techniques/html/H65.xml
+++ b/wcag20/sources/techniques/html/H65.xml
@@ -73,11 +73,11 @@
          </description>
          <code role="html401"><![CDATA[<fieldset><legend>Phone number</legend>
 <input id="areaCode" name="areaCode" title="Area Code" 
-type="text" size="3" value="" >
+type="text" size="3" value="">
 <input id="exchange" name="exchange" title="First three digits of phone number" 
-type="text" size="3" value="" >
+type="text" size="3" value="">
 <input id="lastDigits" name="lastDigits" title="Last four digits of phone number" 
-type="text" size="4" value="" >
+type="text" size="4" value="">
 </fieldset> ]]></code>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/html/H91.xml
+++ b/wcag20/sources/techniques/html/H91.xml
@@ -249,13 +249,13 @@
             <p>Example 7a has a role of "editable text" from the <el>textarea</el> element. The name is "Type your speech here" from the <el>label</el> element. The value is the content inside the <el>textarea</el> element, in this case "Four score and seven years ago". </p>
          </description>
          <code role="xhtml"><![CDATA[<label for="ta_1">Type your speech here</label>
-<textarea id="ta_1" >Four score and seven years ago</textarea>
+<textarea id="ta_1">Four score and seven years ago</textarea>
                     ]]></code>
          <description>
             <exsubhead>Example 7b</exsubhead>
             <p>Example 7b has the same role, the name is set using the 'title' attribute, and the value is the empty string.</p>
          </description>
-         <code role="xhtml"><![CDATA[<textarea id="ta_1" title="Type your speech here" >Four score and seven years ago</textarea>
+         <code role="xhtml"><![CDATA[<textarea id="ta_1" title="Type your speech here">Four score and seven years ago</textarea>
                     ]]></code>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/silverlight/SL4.xml
+++ b/wcag20/sources/techniques/silverlight/SL4.xml
@@ -105,7 +105,7 @@
     						translated text. </p>
             <p>The following is the HTML page (some infrastructure and parameters
     					omitted for clarity): </p>
-            <codeblock xml:space="preserve"><![CDATA[<html xmlns="http://www.w3.org/1999/xhtml" >
+            <codeblock xml:space="preserve"><![CDATA[<html xmlns="http://www.w3.org/1999/xhtml">
 <body>
 
     <object data="data:application/x-silverlight-2," type="application/x-silverlight-2" width="100%" height="25px" lang="en">

--- a/wcag20/sources/xmlspec-wcag-howto.xsl
+++ b/wcag20/sources/xmlspec-wcag-howto.xsl
@@ -81,10 +81,10 @@
           </xsl:call-template>
 			Advisory Techniques for Guideline <xsl:value-of select="../../head"/> (not success criteria specific)</h3>
         <div   class="textbody">
-          <p  >Specific techniques for meeting each Success Criterion for this guideline are listed in the understanding sections for each Success Criterion (listed below). If there are techniques, however, for addressing this guideline that do not fall under any of the success criteria, they are listed here. These techniques are not required or sufficient for meeting any success criteria, but can make certain types of Web content more accessible to more people.</p>
+          <p>Specific techniques for meeting each Success Criterion for this guideline are listed in the understanding sections for each Success Criterion (listed below). If there are techniques, however, for addressing this guideline that do not fall under any of the success criteria, they are listed here. These techniques are not required or sufficient for meeting any success criteria, but can make certain types of Web content more accessible to more people.</p>
           <xsl:choose>
             <xsl:when test="count(../ulist) = 0">
-              <ul  >
+              <ul>
                 <li>All advisory techniques for this guideline relate to specific success criteria.</li>
               </ul>
             </xsl:when>
@@ -156,14 +156,14 @@
     </xsl:choose>
     <xsl:choose>
       <xsl:when test="../@role='resources'">
-        <p  >Resources are for information purposes only, no endorsement implied.</p>
+        <p>Resources are for information purposes only, no endorsement implied.</p>
       	<xsl:if test="not(../p or ../olist or ../ulist or ../div4)">
-          <p  >(none currently documented)</p>
+          <p>(none currently documented)</p>
         </xsl:if>
       </xsl:when>
     	<xsl:when test="../@role='examples'">
     		<xsl:if test="not(../p or ../olist or ../ulist or ../div4)">
-    			<p  >(none currently documented)</p>
+    			<p>(none currently documented)</p>
     		</xsl:if>
     	</xsl:when>
     </xsl:choose>
@@ -217,19 +217,19 @@
     </h4>
     <xsl:choose>
       <xsl:when test="../@role='failures'">
-        <p >The following are common mistakes that are considered failures of Success Criterion <xsl:call-template name="sc-number"><xsl:with-param name="id" select="../../../@id"/></xsl:call-template> by the <acronym title="Web Content Accessibility Guidelines">WCAG</acronym> Working Group.</p>
+        <p>The following are common mistakes that are considered failures of Success Criterion <xsl:call-template name="sc-number"><xsl:with-param name="id" select="../../../@id"/></xsl:call-template> by the <acronym title="Web Content Accessibility Guidelines">WCAG</acronym> Working Group.</p>
       	<xsl:if test="not(../p or ../olist or ../ulist or ../div5)">
-          <p  >(No failures currently documented)</p>
+          <p>(No failures currently documented)</p>
         </xsl:if>
       </xsl:when>
       <xsl:when test="../@role='tech-optional'">
-        <p >Although not required for conformance, the following additional techniques should be considered in order to make content more accessible. Not all techniques can be used or would be effective in all situations.</p>
+        <p>Although not required for conformance, the following additional techniques should be considered in order to make content more accessible. Not all techniques can be used or would be effective in all situations.</p>
       	<xsl:if test="not(../p or ../olist or ../ulist or ../div5)">
-          <p  >(none currently documented)</p>
+          <p>(none currently documented)</p>
         </xsl:if>
       </xsl:when>
       <xsl:when test="../div5[@role='situation']">
-        <p class="instructions"  >
+        <p class="instructions">
           <strong>Instructions:</strong> Select the situation below that matches your content. Each situation includes numbered techniques (or combinations of techniques) that the Working Group deems to be sufficient for that situation.
 </p>
       </xsl:when>
@@ -301,7 +301,7 @@
   </xsl:template>
   <!-- mode: toc rewrote this section so that TOC would result in actual lists-->
   <xsl:template mode="toc" match="div1">
-    <li  >
+    <li>
               <xsl:attribute name="class"><xsl:value-of select="@id"></xsl:value-of></xsl:attribute>
       <a>
         <xsl:attribute name="href"><xsl:call-template name="href.target"><xsl:with-param name="target" select="."/></xsl:call-template></xsl:attribute>
@@ -442,7 +442,7 @@
     <hr class="divider"  />
   </xsl:template>
     <xsl:template match="div1|div2|div3|div4|div5" mode="specref">
-    <em  ><a>
+    <em><a>
       <xsl:attribute name="href"><xsl:choose>
       	<!-- MC: This is a special case kludge to get link to cc4 and cc5 from glossary to work. Really we need to handle specref from included content, but I'm low on time. -->
       	<xsl:when test="@id = 'cc4' or @id = 'cc5'"><xsl:value-of select="concat($glthisversion, '#', @id)"/></xsl:when><xsl:otherwise><xsl:call-template name="href.target"/></xsl:otherwise></xsl:choose></xsl:attribute>
@@ -467,12 +467,12 @@
 		</dt>
 	</xsl:template>
 		<xsl:template match="def" mode="noid">
-		<dd  >
+		<dd>
 			<xsl:apply-templates/>
 		</dd>
 	</xsl:template>
   <xsl:template match="div5">
-    <div  >
+    <div>
       <xsl:apply-templates/>
     </div>
   </xsl:template>
@@ -481,8 +481,8 @@
   	<!-- termdef: sentence or phrase defining a term - BBC: modified here to remove duplicate ids -->
 	<xsl:template match="termdef">
 		<xsl:text></xsl:text>
-		<a   name="{@id}" title="{@term}">	</a>
-		 <strong  ><xsl:value-of select="@term"></xsl:value-of>:</strong>
+		<a name="{@id}" title="{@term}">	</a>
+		 <strong><xsl:value-of select="@term"></xsl:value-of>:</strong>
 		<xsl:text> </xsl:text>
 		<xsl:apply-templates/>
 		<xsl:text> </xsl:text>

--- a/working-examples/aria-icon-font-img-role/fonts/icon-font-role-img.svg
+++ b/working-examples/aria-icon-font-img-role/fonts/icon-font-role-img.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata>
 <json>

--- a/working-examples/css-two-focus-colors/dotted.html
+++ b/working-examples/css-two-focus-colors/dotted.html
@@ -23,7 +23,7 @@
         
     </style>
 </head>
-<body >
+<body>
 
     <h1>Example page for a 2 color focus ring - dotted</h1>
 

--- a/working-examples/css-two-focus-colors/lined.html
+++ b/working-examples/css-two-focus-colors/lined.html
@@ -24,7 +24,7 @@
         
     </style>
 </head>
-<body >
+<body>
 
     <h1>Example page for a 2 color focus ring - lined</h1>
 

--- a/working-examples/script-action-links/index.html
+++ b/working-examples/script-action-links/index.html
@@ -29,7 +29,7 @@
  </head>
  <body onload="setUpActions();">
  <p>Here is the link to modify with a javascript action:
- <a href="http://example.com/noscript.html" id="actionLink" >Link to invoke JavaScript.</a></p>
+ <a href="http://example.com/noscript.html" id="actionLink">Link to invoke JavaScript.</a></p>
 
 <p>The anchor element on the page is given a unique <code>id</code> attribute.  The <code>href</code> attribute of the anchor element should contain a valid URI that will perform the action on the server or will load a Web page that explains that JavaScript is required to interact with the site.  A script uses the Document Object Model (DOM) to find the anchor element by its id and add the onclick handler to the anchor element. Note that the anchor element must be loaded into the DOM before it can be found and modified. This is usually accomplished by calling the script from the onload event of the <code>body</code> element.  The script to add the onclick event handler will only execute if the user agent supports and has JavaScript enabled.   The unmodified anchor element will be used if the user agent does not support JavaScript.   Using JavaScript to add the action to the anchor element will ensure that the user is not confused by an unresponsive action if they load the Web page in a user agent which does not support JavaScript.</p>
  </p></body>

--- a/working-examples/silverlight-accessible-validation/index.html
+++ b/working-examples/silverlight-accessible-validation/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>AccessibleValidation</title>

--- a/working-examples/silverlight-alternative-audio-channel/index.html
+++ b/working-examples/silverlight-alternative-audio-channel/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>AlternativeAudioChannel</title>

--- a/working-examples/silverlight-application-level-key-handling/index.html
+++ b/working-examples/silverlight-application-level-key-handling/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ApplicationLevelKeyHandling</title>

--- a/working-examples/silverlight-automation-properties-help-text/index.html
+++ b/working-examples/silverlight-automation-properties-help-text/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>AutomationPropertiesHelpText</title>

--- a/working-examples/silverlight-basic-submit-button/index.html
+++ b/working-examples/silverlight-basic-submit-button/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>BasicSubmitButton</title>

--- a/working-examples/silverlight-browser-zoom/index.html
+++ b/working-examples/silverlight-browser-zoom/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>BrowserZoom</title>

--- a/working-examples/silverlight-built-in-key-equivalence/index.html
+++ b/working-examples/silverlight-built-in-key-equivalence/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>BuiltInKeyEquivalence</title>

--- a/working-examples/silverlight-button-nontext-text-composition/index.html
+++ b/working-examples/silverlight-button-nontext-text-composition/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ButtonNontextTextComposition</title>

--- a/working-examples/silverlight-button-text-alternative/index.html
+++ b/working-examples/silverlight-button-text-alternative/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ButtonNontextTextComposition</title>

--- a/working-examples/silverlight-by-animation-font-size/index.html
+++ b/working-examples/silverlight-by-animation-font-size/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>StyleSwitcherFontSize</title>

--- a/working-examples/silverlight-document-structure/index.html
+++ b/working-examples/silverlight-document-structure/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>DocumentStructure</title>

--- a/working-examples/silverlight-focus-visual-custom-control/index.html
+++ b/working-examples/silverlight-focus-visual-custom-control/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
 	<title>FocusVisualCustomControl</title>

--- a/working-examples/silverlight-focusable-image/index.html
+++ b/working-examples/silverlight-focusable-image/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ImageEquivalent</title>

--- a/working-examples/silverlight-help-text-and-tool-tip/index.html
+++ b/working-examples/silverlight-help-text-and-tool-tip/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>HelpTextAndToolTip</title>

--- a/working-examples/silverlight-high-contrast/index.html
+++ b/working-examples/silverlight-high-contrast/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>HighContrast</title>

--- a/working-examples/silverlight-labels/index.html
+++ b/working-examples/silverlight-labels/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>Labels</title>

--- a/working-examples/silverlight-lang-properties/index.html
+++ b/working-examples/silverlight-lang-properties/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>LangProperties</title>

--- a/working-examples/silverlight-media-element-controls-auto-play/index.html
+++ b/working-examples/silverlight-media-element-controls-auto-play/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>MediaElementControlsAutoPlay</title>

--- a/working-examples/silverlight-media-element-controls/index.html
+++ b/working-examples/silverlight-media-element-controls/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>MediaElementControls</title>

--- a/working-examples/silverlight-media-timeline-markers/index.html
+++ b/working-examples/silverlight-media-timeline-markers/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>MediaTimelineMarkers</title>

--- a/working-examples/silverlight-pause-bouncy-ball/index.html
+++ b/working-examples/silverlight-pause-bouncy-ball/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>PauseBouncyBall</title>

--- a/working-examples/silverlight-programmatic-focus/index.html
+++ b/working-examples/silverlight-programmatic-focus/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ProgrammaticFocus</title>

--- a/working-examples/silverlight-replace-audio-with-transcript/index.html
+++ b/working-examples/silverlight-replace-audio-with-transcript/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>ReplaceAudioWithTranscriptText</title>

--- a/working-examples/silverlight-silver-fish/index.html
+++ b/working-examples/silverlight-silver-fish/index.html
@@ -1,4 +1,4 @@
-﻿ <html xmlns="http://www.w3.org/1999/xhtml" >
+﻿ <html xmlns="http://www.w3.org/1999/xhtml">
  <head runat="server">
     <title>SilverFish</title>
  </head>

--- a/working-examples/silverlight-simple-numeric-up-down/index.html
+++ b/working-examples/silverlight-simple-numeric-up-down/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>KeysNumericUpDown</title>

--- a/working-examples/silverlight-simple-peer-forwarding/index.html
+++ b/working-examples/silverlight-simple-peer-forwarding/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>SimplePeerForwarding</title>

--- a/working-examples/silverlight-stop-animation/index.html
+++ b/working-examples/silverlight-stop-animation/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>StopAnimation</title>

--- a/working-examples/silverlight-style-switcher-font-size/index.html
+++ b/working-examples/silverlight-style-switcher-font-size/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>StyleSwitcherFontSize</title>

--- a/working-examples/silverlight-tab-navigation/index.html
+++ b/working-examples/silverlight-tab-navigation/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabNavigation</title>

--- a/working-examples/silverlight-tab-sequence-enabled/index.html
+++ b/working-examples/silverlight-tab-sequence-enabled/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabSequenceEnabled</title>

--- a/working-examples/silverlight-tab-sequence-tab-index/index.html
+++ b/working-examples/silverlight-tab-sequence-tab-index/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabSequence_TabIndex</title>

--- a/working-examples/silverlight-tab-sequence/index.html
+++ b/working-examples/silverlight-tab-sequence/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>TabSequence</title>

--- a/working-examples/silverlight-visible-focus-template/index.html
+++ b/working-examples/silverlight-visible-focus-template/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" >
+<html xmlns="http://www.w3.org/1999/xhtml">
 <!-- saved from url=(0014)about:internet -->
 <head>
     <title>VisibleFocusTemplate</title>

--- a/working-examples/uri-parameter-choose-stylesheet/index.php
+++ b/working-examples/uri-parameter-choose-stylesheet/index.php
@@ -18,7 +18,7 @@ else
 <title>Using PHP $_GET to apply a different external CSS file</title>
    
 
-  <link rel="stylesheet" type="text/css" media="screen" href="<?php echo($thestyle);?>.css" >
+  <link rel="stylesheet" type="text/css" media="screen" href="<?php echo($thestyle);?>.css">
 
 </head>
 


### PR DESCRIPTION
Code cleanup, nothing normative. Not high priority, of course, but would be good to have clean markup

Closes https://github.com/w3c/wcag/issues/1506