### PR TITLE
Ignore output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,10 @@ pip-log.txt
 #############
 
 build.properties
+
+#############
+## Output
+#############
+
+/output
+/output.html


### PR DESCRIPTION
When one generates all pages using `ant all`, a file named `output.html` and a folder names `output` are generated.

These are not committed into this repository. To make it easier to not commit them, I'd like to propose we add them to the `.gitignore` file.