### PR TITLE
Replace "ACT Rules" with "Test Rules"

### DIFF
--- a/understanding/understanding-act-rules.html
+++ b/understanding/understanding-act-rules.html
@@ -1,38 +1,38 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
-		<title>Understanding ACT Rules</title>
+		<title>Understanding Test Rules for WCAG Success Criteria</title>
 	</head>
 	<body>
-		<h1>Understanding <abbr title="Accessibility Conformance Testing">ACT</abbr> Rules</h1>
+		<h1>Understanding Test Rules for WCAG Success Criteria</h1>
 		
-		<p>Accessibility Conformance Testing (ACT) Rules provide guidance for developers of automated testing tools and manual testing methodologies, to help ensure consistent interpretation of WCAG Success Criteria.</p>
-		<p>W3C's <a href="https://www.w3.org/WAI/standards-guidelines/act/">List of ACT Rules for WCAG 2</a> is updated periodically. They are developed according to the <a href="https://www.w3.org/TR/act-rules-format/">Accessibility Conformance Testing (ACT) Rules Format 1.0</a> standard.</p>
+		<p>Test Rules provide guidance for developers of automated testing tools and manual testing methodologies, to help ensure consistent interpretation of WCAG Success Criteria.</p>
+		<p>W3C's <a href="https://www.w3.org/WAI/standards-guidelines/act/rules/">List of Test Rules for WCAG 2</a> is updated periodically. They are developed according to the <a href="https://www.w3.org/TR/act-rules-format/">Accessibility Conformance Testing (ACT) Rules Format 1.0</a> standard.</p>
 		<p><a href="conformance">Understanding Conformance</a> provides related information, including on <a href="conformance#accessibility-support">understanding accessibility support</a>.</p>
 		
 		<section>
-			<h2>ACT Rules are Informative</h2>
-			<p><em>ACT Rules are informative — that means they are not required for determining conformance. The basis for determining conformance to WCAG is the success criteria from the WCAG standard — not the ACT Rules.</em></p>
-			<p>While W3C's <a href="https://www.w3.org/WAI/standards-guidelines/act/">List of ACT Rules for WCAG 2</a> are reviewed by the W3C Accessibility Guidelines Working Group (AGWG), they are not vetted to the same degree as the W3C Web Content Accessibility Guidelines (WCAG) standard (called <em>W3C Recommendation</em>). The WCAG standard is the normative reference on determining conformance.</p>
+			<h2>Test Rules Rules are Informative</h2>
+			<p><em>Test Rules are informative — that means they are not required for determining conformance. The basis for determining conformance to WCAG is the success criteria from the WCAG standard — not the Test Rules.</em></p>
+			<p>While W3C's <a href="https://www.w3.org/WAI/standards-guidelines/act/rules/">List of Test Rules for WCAG 2</a> are reviewed by the W3C Accessibility Guidelines Working Group (AGWG), they are not vetted to the same degree as the W3C Web Content Accessibility Guidelines (WCAG) standard (called <em>W3C Recommendation</em>). The WCAG standard is the normative reference on determining conformance.</p>
 		</section>
 		
 		<section>
-			<h2>ACT Rules are Partial Checks</h2>
-			<p>ACT Rules typically check specific aspects of WCAG success criteria. For example, that a table cell has a header rather than the entire WCAG 2.2 success criterion 1.3.1 "Info and Relationships", which applies to many more information structures on a web page. In fact, this example rule would not even check the validity of the table header, only if the header exists for a given table cell.</p>
-			<p>ACT Rules are also technology-specific. For example, the aforementioned table header example would be specific to HTML, possibly enriched with WAI-ARIA roles and properties, but not to other formats with tables. WCAG 2.2 success criteria are designed to be technology-agnostic and applicable to all web technologies.</p>
+			<h2>Test Rules are Partial Checks</h2>
+			<p>Test Rules typically check specific aspects of WCAG success criteria. For example, that a table cell has a header rather than the entire WCAG 2.2 success criterion 1.3.1 "Info and Relationships", which applies to many more information structures on a web page. In fact, this example rule would not even check the validity of the table header, only if the header exists for a given table cell.</p>
+			<p>Test Rules are also technology-specific. For example, the aforementioned table header example would be specific to HTML, possibly enriched with WAI-ARIA roles and properties, but not to other formats with tables. WCAG 2.2 success criteria are designed to be technology-agnostic and applicable to all web technologies.</p>
 		</section>
 		
 		<section>
-			<h2>ACT Rules Check for Failures</h2>
-			<p>ACT Rules are designed to check failures in satisfying WCAG success criteria. That is, when content fails ACT Rules, it means that the content does not satisfy the corresponding success criteria. However, when content passes ACT Rules, it means that no corresponding failures were detected — it does not necessarily mean that the content satisfies all aspects of the corresponding success criteria.</p>
-			<p>The reason for this is because WCAG success criteria typically cover several aspects and technologies, while ACT Rules only check specific aspects. Checking that content satisfies all aspects of WCAG success criteria typically requires further verification by human testers.</p>
-			<p class="note"><a href="conformance#cc1">WCAG 2 Conformance Requirement 1</a> allows for "conforming alternate versions". That means that content may still conform to WCAG 2, even when content fails ACT Rules, thus does not satisfy the corresponding success criteria.</p>
+			<h2>Test Rules Check for Failures</h2>
+			<p>Test Rules are designed to check failures in satisfying WCAG success criteria. That is, when content fails Test Rules, it means that the content does not satisfy the corresponding success criteria. However, when content passes Test Rules, it means that no corresponding failures were detected — it does not necessarily mean that the content satisfies all aspects of the corresponding success criteria.</p>
+			<p>The reason for this is because WCAG success criteria typically cover several aspects and technologies, while Test Rules only check specific aspects. Checking that content satisfies all aspects of WCAG success criteria typically requires further verification by human testers.</p>
+			<p class="note"><a href="conformance#cc1">WCAG 2 Conformance Requirement 1</a> allows for "conforming alternate versions". That means that content may still conform to WCAG 2, even when content fails Test Rules, thus does not satisfy the corresponding success criteria.</p>
 		</section>
 		
 		<!-- //
          <section>
-            <h2>ACT Rule Implementations</h2>
-            <p>Implementation of an ACT Rule can be any automated testing tool, manual testing methodology, or other procedure that provides the same expected results for the test cases defined by the ACT Rule. Specifically, when the expected result for a test case is:</p>
+            <h2>Test Rule Implementations</h2>
+            <p>Implementation of an Test Rule can be any automated testing tool, manual testing methodology, or other procedure that provides the same expected results for the test cases defined by the Test Rule. Specifically, when the expected result for a test case is:</p>
             <ul>
                <li><strong>Passed</strong>, the test result generated from the implementation is <strong>passed</strong>, <strong>cantTell</strong>, or <strong>inapplicable</strong></li>
                <li><strong>Failed</strong>, the test result generated from the implementation is <strong>failed</strong> or <strong>cantTell</strong></li>
@@ -42,19 +42,19 @@
          //-->
 		
 		<section>
-			<h2>Structure of ACT Rules</h2>
-			<p>ACT Rules conform to the <a href="https://www.w3.org/TR/act-rules-format/">Accessibility Conformance Testing (ACT) Rules Format 1.0</a> standard. They include the following parts:</p>
+			<h2>Structure of Test Rules</h2>
+			<p>Test Rules conform to the <a href="https://www.w3.org/TR/act-rules-format/">Accessibility Conformance Testing (ACT) Rules Format 1.0</a> standard. They include the following parts:</p>
 			<ul>
-				<li><strong>Descriptive Title</strong> – title for the ACT Rule, which should describe the rule</li>
-				<li><strong>Rule Identifier</strong> – identifier for the ACT Rule; the W3C rules use alphanumeric strings</li>
-				<li><strong>Rule Type</strong> – there are two basic types of ACT Rules, depending on what is being tested:
+				<li><strong>Descriptive Title</strong> – title for the Test Rule, which should describe the rule</li>
+				<li><strong>Rule Identifier</strong> – identifier for the Test Rule; the W3C rules use alphanumeric strings</li>
+				<li><strong>Rule Type</strong> – there are two basic types of Test Rules, depending on what is being tested:
 					<ul>
 						<li><strong>Atomic Rule</strong> – test one specific situation, which may be part of a composite rule</li>
 						<li><strong>Composite Rule</strong> – combine outcome from multiple atomic rules to one outcome</li>
 					</ul>
 				</li>
-				<li><strong>Accessibility Requirements Mapping</strong> – maps the ACT Rule to particular accessibility requirements; in this suite of rules we use Web Content Accessibility Guidelines (WCAG) 2 Success Criteria</li>
-				<li><strong>Rule Input</strong> – describes the scope of input into ACT Rules, which is one of the following:
+				<li><strong>Accessibility Requirements Mapping</strong> – maps the Test Rule to particular accessibility requirements; in this suite of rules we use Web Content Accessibility Guidelines (WCAG) 2 Success Criteria</li>
+				<li><strong>Rule Input</strong> – describes the scope of input into Test Rules, which is one of the following:
 					<ul>
 						<li><strong>Input Aspects</strong> – input into atomic rules, such as DOM Tree and CSS Styling etc.</li>
 						<li><strong>Input Rules</strong> – input into the composite rules, which are the atomic rules in scope</li>
@@ -65,9 +65,9 @@
 				<li><strong>Assumptions</strong> – assumptions made, such as specific interpretations of the requirements</li>
 				<li><strong>Accessibility Support</strong> – known limitations regarding browsers and assistive technology</li>
 				<li><strong>Test Cases</strong> – sample code demonstrating passed, failed, and inapplicable rule conditions</li>
-				<li><strong>Change Log</strong> – history of changes for the ACT Rules, to support backward compatibility</li>
-				<li><strong>Glossary</strong> – list of key terms defined by the ACT Rule or used by the specific ACT Rule</li>
-				<li><strong>Issues List (Optional)</strong> – list of known issues or bugs for the particular ACT Rule, if any</li>
+				<li><strong>Change Log</strong> – history of changes for the Test Rules, to support backward compatibility</li>
+				<li><strong>Glossary</strong> – list of key terms defined by the Test Rule or used by the specific Test Rule</li>
+				<li><strong>Issues List (Optional)</strong> – list of known issues or bugs for the particular Test Rule, if any</li>
 				<li><strong>Background (Optional)</strong> – relevant background, such as additional documentation, if any</li>
 				<li><strong>Acknowledgements (Optional)</strong> – such as rule writers, reviewers, and other contributors</li>
 			</ul>

--- a/xslt/generate-structure-xml.xslt
+++ b/xslt/generate-structure-xml.xslt
@@ -34,7 +34,7 @@
 				<file href="understanding-techniques"/>
 			</understanding>
 			<understanding>
-				<name>Understanding ACT Rules</name>
+				<name>Understanding Test Rules for WCAG Success Criteria</name>
 				<file href="understanding-act-rules"/>
 			</understanding>
 			<xsl:apply-templates select="//html:section[@class='principle']"/>

--- a/xslt/generate-techniques.xslt
+++ b/xslt/generate-techniques.xslt
@@ -390,7 +390,7 @@
 		<xsl:if test="$act.doc//func:array[@key = 'wcagTechniques'][func:string = $meta/@id]">
 			<section id="testing-rules">
 				<h2>Test Rules</h2>
-				<p>The following are Test Rules related certain aspects of this Technique. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="{$loc.understanding}understanding/understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
+				<p>The following are Test Rules related to certain aspects of this Technique. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="{$loc.understanding}understanding/understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
 				<ul>
 					<xsl:for-each select="$act.doc//func:array[@key = 'wcagTechniques']/func:string[. = $meta/@id]">
 						<li><a href="{ancestor::func:map/func:string[@key = 'permalink']}"><xsl:value-of select="ancestor::func:map/func:string[@key = 'title']"/></a></li>

--- a/xslt/generate-techniques.xslt
+++ b/xslt/generate-techniques.xslt
@@ -389,8 +389,8 @@
 		
 		<xsl:if test="$act.doc//func:array[@key = 'wcagTechniques'][func:string = $meta/@id]">
 			<section id="testing-rules">
-				<h2>Testing Rules</h2>
-				<p>The following are testing rules for certain aspects of this Technique. It is not necessary to use these particular rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Accessibility Conformance Testing (ACT) Rules, see <a href="{$loc.understanding}understanding/understanding-act-rules.html">Understanding ACT Rules for WCAG Success Criteria</a>.</p>
+				<h2>Test Rules</h2>
+				<p>The following are Test Rules related certain aspects of this Technique. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="{$loc.understanding}understanding/understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
 				<ul>
 					<xsl:for-each select="$act.doc//func:array[@key = 'wcagTechniques']/func:string[. = $meta/@id]">
 						<li><a href="{ancestor::func:map/func:string[@key = 'permalink']}"><xsl:value-of select="ancestor::func:map/func:string[@key = 'title']"/></a></li>

--- a/xslt/generate-techniques.xslt
+++ b/xslt/generate-techniques.xslt
@@ -390,7 +390,7 @@
 		<xsl:if test="$act.doc//func:array[@key = 'wcagTechniques'][func:string = $meta/@id]">
 			<section id="testing-rules">
 				<h2>Test Rules</h2>
-				<p>The following are Test Rules related to certain aspects of this Technique. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="{$loc.understanding}understanding/understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
+				<p>The following are Test Rules related to this Technique. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="{$loc.understanding}understanding/understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
 				<ul>
 					<xsl:for-each select="$act.doc//func:array[@key = 'wcagTechniques']/func:string[. = $meta/@id]">
 						<li><a href="{ancestor::func:map/func:string[@key = 'permalink']}"><xsl:value-of select="ancestor::func:map/func:string[@key = 'title']"/></a></li>

--- a/xslt/generate-understanding.xslt
+++ b/xslt/generate-understanding.xslt
@@ -213,8 +213,8 @@
 		
 		<xsl:if test="$act.doc//func:array[@key = 'successCriteria'][func:string = $meta/@id]">
 			<section id="testing-rules">
-				<h2>Testing Rules</h2>
-				<p>The following are testing rules for certain aspects of this Success Criterion. It is not necessary to use these particular rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Accessibility Conformance Testing (ACT) Rules, see <a href="understanding-act-rules.html">Understanding ACT Rules for WCAG Success Criteria</a>.</p>
+				<h2>Test Rules</h2>
+				<p>The following are Test Rules for certain aspects of this Success Criterion. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
 				<ul>
 					<xsl:for-each select="$act.doc//func:array[@key = 'successCriteria']/func:string[. = $meta/@id]">
 						<li><a href="{ancestor::func:map/func:string[@key = 'permalink']}"><xsl:value-of select="ancestor::func:map/func:string[@key = 'title']"/></a></li>

--- a/xslt/generate-understanding.xslt
+++ b/xslt/generate-understanding.xslt
@@ -119,7 +119,7 @@
 					<xsl:if test="wcag:section-meaningfully-exists('resources', //html:section[@id = 'resources'])"><li><a href="#resources">Related Resources</a></li></xsl:if>
 					<li><a href="#techniques">Techniques</a></li>
 					<xsl:if test="$act.doc//func:array[@key = 'successCriteria'][func:string = $meta/@id]">
-						<li><a href="#testing-rules">Testing Rules</a></li>
+						<li><a href="#test-rules">Test Rules</a></li>
 					</xsl:if>
 				</xsl:if>
 				<xsl:if test="name($meta) = 'guideline'">
@@ -212,7 +212,7 @@
 		<xsl:param name="meta" tunnel="yes"/>
 		
 		<xsl:if test="$act.doc//func:array[@key = 'successCriteria'][func:string = $meta/@id]">
-			<section id="testing-rules">
+			<section id="test-rules">
 				<h2>Test Rules</h2>
 				<p>The following are Test Rules for certain aspects of this Success Criterion. It is not necessary to use these particular Test Rules to check for conformance with WCAG, but they are defined and approved test methods. For information on using Test Rules, see <a href="understanding-act-rules.html">Understanding Test Rules for WCAG Success Criteria</a>.</p>
 				<ul>


### PR DESCRIPTION
Replace "ACT Rules" with "Test Rules" for easier flow and to match the description in the Techniques that has been agreed on.