### PR TITLE
Corrected wrong URLs in Understanding Text Alternatives and definition of Structure

### DIFF
--- a/guidelines/terms/20/structure.html
+++ b/guidelines/terms/20/structure.html
@@ -6,7 +6,7 @@
       <li>The way the parts of a <a>Web page</a> are organized in relation to each other; and
       </li>
       
-      <li>The way a collection of <a>Web pages</a> is organized
+      <li>The way a <a>set of Web pages</a> is organized
       </li>
       
    </ol>

--- a/guidelines/terms/20/text-alternative.html
+++ b/guidelines/terms/20/text-alternative.html
@@ -10,7 +10,7 @@
       text alternative for the chart indicates that a description follows.
    </p>
    
-   <p class="note">Refer to <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding Text Alternatives</a> for more information.
+   <p class="note">Refer to <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv.html">Understanding Text Alternatives</a> for more information.
    </p>
    
 </dd>


### PR DESCRIPTION
original href points to Conformance section which is wrong