### PR TITLE
Expand 3.3.2 Labels or Instructions understanding

### DIFF
--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -45,8 +45,8 @@
          and therefore pass Success Criterion 4.1.2, but to still fail this Success Criterion (if the labels or instructions
          aren't presented to all users, not just those using assistive technologies).
       </p>
-      <p>Lastly, this Success Criterion does not apply to links or other controls (such as controls for disclosure widgets
-         or similar interactive components) that are not associated with data entry.
+      <p>This Success Criterion does not apply to links or other controls (such as an expand/collapse widget, or similar
+         interactive components) that are not associated with data entry.
       </p>
       <p>While this Success Criterion requires that controls and inputs for data entry and submission have labels, whether or not
          these labels are sufficiently clear or descriptive is covered separately by

--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -16,8 +16,7 @@
          or labels that identify the controls in a form so that users know what input data
          is expected. In the case of radio buttons, checkboxes, comboboxes, or similar controls
          that provide users with options, each option must have an appropriate label so that
-         users know what they are actually selecting. Lastly, controls that submit the user input,
-         or proceed to the next step in a multi-step process, must also provide a label.
+         users know what they are actually selecting. 
          Instructions or labels may also specify data formats for data entry fields, especially
          if they are out of the customary formats or if there are specific rules for correct
          input. Content authors may also choose to make such instructions available to users

--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -14,7 +14,11 @@
       
       <p>The intent of this Success Criterion is to have content authors present instructions
          or labels that identify the controls in a form so that users know what input data
-         is expected. Instructions or labels may also specify data formats for fields especially
+         is expected. In the case of radio buttons, checkboxes, comboboxes, or similar controls
+         that provide users with options, each option must have an appropriate label so that
+         users know what they are actually selecting. Lastly, controls that submit the user input,
+         or proceed to the next step in a multi-step process, must also provide a label.
+         Instructions or labels may also specify data formats for data entry fields, especially
          if they are out of the customary formats or if there are specific rules for correct
          input. Content authors may also choose to make such instructions available to users
          only when the individual control has focus especially when instructions are long and
@@ -41,7 +45,10 @@
          and therefore pass Success Criterion 4.1.2, but to still fail this Success Criterion (if the labels or instructions
          aren't presented to all users, not just those using assistive technologies).
       </p>
-      <p>While this Success Criterion requires that controls and inputs have labels, whether or not
+      <p>Lastly, this Success Criterion does not apply to links or other controls (such as controls for disclosure widgets
+         or similar interactive components) that are not associated with data entry.
+      </p>
+      <p>While this Success Criterion requires that controls and inputs for data entry and submission have labels, whether or not
          these labels are sufficiently clear or descriptive is covered separately by
          <a href="headings-and-labels">2.4.6: Headings and Labels</a>.
       </p> 


### PR DESCRIPTION
Based on discussion in https://github.com/w3c/wcag/issues/985#issuecomment-562504332 this expands the intent given for 3.3.2 to cover buttons involved in form submission/proceeding to the next step. It also covers radio buttons, checkboxes, selects etc which previously weren't clearly covered (though I believe in practice people considered those as part of 3.3.2).
Includes an explanation that links and "immediate action" type buttons like disclosure widget buttons don't necessarily represent "user input" (though this seems to be a controversial point?)