### PR TITLE
update resource links in G15

### DIFF
--- a/techniques/general/G15.html
+++ b/techniques/general/G15.html
@@ -37,10 +37,10 @@
       
          <ul>
             <li>
-                  <a href="http://www.hardingfpa.com/">Harding FPA Web Site</a>
+                  <a href="https://www.hardingfpa.com/">Harding FPA Web Site</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
+                  <a href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
                 </li>
          </ul>
       


### PR DESCRIPTION
In https://www.w3.org/WAI/WCAG21/Techniques/general/G15.html, the Trace Center link was not resolving.  

This PR updates the link to a URL that works.  Also updated the Harding FPA link to from using http a https