### PR TITLE
Correct a citation under Themes from Research

### DIFF
--- a/conformance-challenges/index.html
+++ b/conformance-challenges/index.html
@@ -352,10 +352,9 @@ and software.
                             </ul>
                         </li>
                         <li>Specific success criteria for failure - 1.1.1 , 2.2., 4.1.2 (Keith et al., 2012)</li>
-			<li><q>Reliably Human Testable,</q> <q>not reliably testable</q> (Brajnick et al., 2012) average agreement was at the 70-75% mark, while the error rate was around 29%.
+			<li><q>Reliably Human Testable,</q> <q>not reliably testable</q> (<q>Is accessibility conformance an elusive property? A study of validity and reliability of WCAG 2.0</q>, <a href="http://www.researchgate.net/publication/235339930_Is_accessibility_conformance_an_elusive_property_A_study_of_validity_and_reliability_of_WCAG_20">Brajnik et al., 2012</a>) average agreement was at the 70-75% mark, while the error rate was around 29%.
                             <ul>
                                 <li>Expertise appears to improve (by 19%) the ability to avoid false positives. Finally, pooling the results of two independent experienced evaluators would be the best option, capturing at most 76% of the true problems and producing only 24% of false positives. Any other independent combination of audits would achieve worse results.</li>
-                                <li>This means that an 80% target for agreement, when audits are conducted without communication between evaluators, is not attainable, even with experienced evaluators.</li>
                             </ul>
                         </li>
                         <li>Challenges and Recommendations (Alonso et al., 2010)                                                       


### PR DESCRIPTION
- Brajnick -> Brajnik
- added link
- deleted last bullet item: This means that an 80% target for agreement, when audits are conducted without communication between evaluators, is not attainable, even with experienced evaluators.