### PR TITLE
Change STR to Ctrl

### DIFF
--- a/techniques/failures/F99.html
+++ b/techniques/failures/F99.html
@@ -33,7 +33,7 @@
     <p>The success criterion does not apply when single key shortcuts are only active when interface elements have the focus, for example, a <code>select</code> element. Here, pressing a letter key is used for fast navigation within the select options.</p>
     <p>Viewing page scripts and searching for typical keyboard event handlers like <code>document.addEventListener('keydown' ...) </code> or the presence of the <code>.keycode</code> attribute
       may establish the presence of scripts that intercept keyboard shortcuts without modification keys like ALT or
-      STR being held down at the same time. As there are several ways of implementing character key events, this
+       Ctrl being held down at the same time. As there are several ways of implementing character key events, this
       method is not considered reliable.</p>
     <p>Some browsers employ single key shortcuts with <kbd>Shift</kbd>. For example, Firefox opens a page search when pressing
       <kbd>Shift</kbd> + <kbd>/</kbd> and a search in page links when pressing <kbd>Shift</kbd> + <kbd>'</kbd>. In these cases, it will be necessary to press <kbd>Esc</kbd> or click an empty part of the page to remove the focus from the browser input.</p>


### PR DESCRIPTION
Change STR to Ctrl (for modification keys). Not entirely sure if this should be even more generic since different languages will likely have different key labels and I am now replacing the (incorrect) German STR with the English Ctrl. But at least it says "modification keys like..." so I guess as an example it is OK.