### PR TITLE
Tweak bypass blocks understanding

### DIFF
--- a/understanding/20/bypass-blocks.html
+++ b/understanding/20/bypass-blocks.html
@@ -16,17 +16,16 @@
       <p>The intent of this Success Criterion is to allow people who navigate sequentially
          through content more direct access to the primary content of the Web page. Web pages
          and applications often have content that appears on other pages or screens. Examples
-         of repeated blocks of content include but are not limited to navigation links, heading
-         graphics, and advertising frames. Small repeated sections such as individual words,
+         of repeated blocks of content include but are not limited to navigation links, header
+         content, and advertising frames. Small repeated sections such as individual words,
          phrases or single links are not considered blocks for the purposes of this provision.
-         
-         
       </p>
       
-      <p>This is in contrast to a sighted user's ability to ignore the repeated material either
-         by focusing on the center of the screen (where main content usually appears) or a
-         mouse user's ability to select a link with a single mouse click rather than encountering
-         every link or form control that comes before the item they want.
+      <p>User who navigate sequentially through content will generally have to navigate through
+         repeated content on each page. This is in contrast to a sighted user's ability to ignore
+         the repeated material either by focusing on the center of the screen (where main content
+         usually appears) or a mouse user's ability to select a link with a single mouse click
+         rather than encountering every link or form control that comes before the item they want.
       </p>
       
       <p>It is not the intent of this Success Criterion to require authors to provide methods
@@ -49,7 +48,7 @@
       <p>Although the success criterion does not specifically use the term “within a set of
          web pages”, the concept of the pages belonging to a set is implied.  An author would
          not be expected to avoid any possible duplication of content in any two pages that
-         are not in some way related to each other;  that are not "Web pages that share a common
+         are not in some way related to each other, and are not "Web pages that share a common
          purpose and that are created by the same author, group or organization” (the definition
          of set of web pages).
       </p>
@@ -74,7 +73,7 @@
 
          
          <li>Screen reader users who visit several pages on the same site can avoid having to hear
-            all heading graphics and dozens of navigation links on every page before the main
+            all header content and dozens of navigation links on every page before the main
             content is spoken.
          </li>
          
@@ -85,8 +84,8 @@
             
          </li>
          
-         <li>People who use screen magnifiers do not have to search through the same headings or
-            other blocks of information to find where the content begins each time they enter
+         <li>People who use screen magnifiers do not have to search through the same header content or
+            other blocks of information to find where the main content begins each time they enter
             a new page.
          </li>
          

--- a/understanding/20/bypass-blocks.html
+++ b/understanding/20/bypass-blocks.html
@@ -21,7 +21,7 @@
          phrases or single links are not considered blocks for the purposes of this provision.
       </p>
       
-      <p>User who navigate sequentially through content will generally have to navigate through
+      <p>Users who navigate sequentially through content will generally have to navigate through
          repeated content on each page. This is in contrast to a sighted user's ability to ignore
          the repeated material either by focusing on the center of the screen (where main content
          usually appears) or a mouse user's ability to select a link with a single mouse click


### PR DESCRIPTION
- the use of "heading graphics" and "headings" in the benefits is confusing, and - unless I'm mistaken - there to signify more broadly "header content". current use of "headings" is in apparent contrast with techniques that then talk about using headings - see https://github.com/w3c/wcag/issues/1712
- in the intent, the "This is in contrast" section is missing the first bit...the part that explains how users that navigate sequentially actually have to go through all the stuff first. and THEN that sets up what "This is in contrast" to.

I believe this is an editorial change only.