### PR TITLE
Minor 1.4.11 understanding tweaks

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -77,7 +77,7 @@
 				<figure id="figure-two-star-ratings-failing">
 					<img src="img/star-examples-fail.png" alt="Two star ratings, the first uses 5 stars with a black outline and a yellow or white fill, where yellow indicates checked. The second uses only pale yellow stars on white." width="300" />
 					<figcaption>
-						Two examples which fail a success criterion, the first fails the Use of color criterion due to relying on yellow and white hues. The second example fails the Non-text contrast criterion due to the yellow (#fff000) to white contrast ratio of 1.2:1.
+						Two examples which fail a success criterion, the first fails the Use of color criterion due to relying on yellow and white hues. The second example fails the Non-text contrast criterion due to the yellow (#FFF000) to white contrast ratio of 1.2:1.
 					</figcaption>
 				</figure>
 
@@ -123,7 +123,7 @@
 						</tr>
 						<tr>
 							<th>Text input</th>
-							<td>Where a text-input has an indicator such as a complete border (#76766), that indicator must meet 3:1 contrast ratio.</td>
+							<td>Where a text-input has an indicator such as a complete border (#767676), that indicator must meet 3:1 contrast ratio.</td>
 							<td>
 								<img src="img/text-input-default.png" alt="A label with a text input shown by a complete border." />
 							</td>
@@ -218,7 +218,7 @@
 					<tbody>
 						<tr>
 							<td><img src="img/contrast-phone.png" alt="An orange circle with a white telephone icon in the middle." width="40" /></td>
-							<td><p>The phone icon is a simple shape within the orange (#E3660E)circle. The meaning can be understood from that icon alone, the background behind the circle is irrelevant. The orange background and the white icon have a contrast ration greater than 3:1, which passes.</p>
+							<td><p>The phone icon is a simple shape within the orange (#E3660E) circle. The meaning can be understood from that icon alone, the background behind the circle is irrelevant. The orange background and the white icon have a contrast ration greater than 3:1, which passes.</p>
 							<p>The graphical object is the white phone icon.</p>
 							</td>
 						</tr>


### PR DESCRIPTION
* typo in hex colour - closes https://github.com/w3c/wcag/issues/1766
* missing space after parenthesis
* for consistency, use uppercase for `#FFF000`