### PR TITLE
Changes to 1.4.1 Use of Color understanding

### DIFF
--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -29,11 +29,12 @@
          only in color.
       </p>
       
-      <p>Examples of information conveyed by color differences: “required fields are red",
-         “error is shown in red", and “Mary's sales are in red, Tom's are in blue". Examples
-         of indications of an action include: using color to indicate that a link will open
-         in a new window or that a database entry has been updated successfully. An example
-         of prompting a response would be: using highlighting on form fields to indicate that
+      <p>Examples of information conveyed by color differences: required fields are only identified
+         by changing their border to a red color; sales figures for different employees are only
+         visually distinguished by using different foreground colors( e.g. Mary's sales are in red,
+         Tom's are in blue). Examples of indications of an action include: using color to indicate
+         that a link will open in a new window or that a database entry has been updated successfully.
+         An example of prompting a response would be: using highlighting on form fields to indicate that
          a required field had been left blank. Examples of distinguishing a visual element:
          for a series of toggle buttons, the pressed/activated buttons are only visually indicated
          by a difference in color; the interactive element that currently has focus is only

--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -29,20 +29,26 @@
          only in color.
       </p>
       
-      <p>Examples of information conveyed by color differences: required fields are only identified
+      <p>Examples of common failures include:</p>
+      <ul>
+        <li><strong>Information conveyed by color differences:</strong> required fields are only identified
          by changing their border to a red color; sales figures for different employees are only
          visually distinguished by using different foreground colors( e.g. Mary's sales are in red,
-         Tom's are in blue). Examples of indications of an action include: using color to indicate
-         that a link will open in a new window or that a database entry has been updated successfully.
-         An example of prompting a response would be: using highlighting on form fields to indicate that
-         a required field had been left blank. Examples of distinguishing a visual element:
-         for a series of toggle buttons, the pressed/activated buttons are only visually indicated
-         by a difference in color; the interactive element that currently has focus is only
-         distinguished by changing the color of the element's <em>existing</em> background or
-         border - however, if focus indication introduces a new visual element that was not previously
-         present, this does not count as a change in color, since the indicator was not presentation
-         to begin with.
-      </p>
+         Tom's are in blue).</li>
+        <li><strong>Indicating an action:</strong> using color to indicate
+         that a link will open in a new window or that a database entry has been updated successfully.</li>
+        <li><strong>Prompting a response:</strong> using highlighting on form fields to indicate that
+         a required field had been left blank.</li>
+        <li><strong>Distinguishing a visual element:</strong> links are only distinguished from surrounding text
+         using a subtle color difference (with a contrast difference that is less than 3:1); for a series of toggle
+         buttons, the pressed/activated buttons are only visually indicated by a difference in color;
+         the interactive element that currently has focus is only distinguished by changing the color
+         of the element's existing background or border. However, particularly in the case of state/focus
+         indication, note that if the visual indicator was not previously present, this does not count as
+         a change in color. For instance, if a focused element has a new border, or a new solid background
+         color, that was not there in its unfocused state, this does not count as a change of color alone,
+         since the indicator was not presentation to begin with.</li>
+      </ul>
 
       <div class="note">
          

--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -98,13 +98,7 @@
             in other visual ways.
          </li>
          
-         <li>People using limited color monochrome displays may be unable to access
-            color-dependent information.
-         </li>
-         
-         <li>Users who have problems distinguishing between colors can look or listen for text
-            cues.
-         </li>
+         <li>Users who have problems distinguishing between colors can look for other visual cues.</li>
          
       </ul>
       

--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -34,7 +34,13 @@
          of indications of an action include: using color to indicate that a link will open
          in a new window or that a database entry has been updated successfully. An example
          of prompting a response would be: using highlighting on form fields to indicate that
-         a required field had been left blank.
+         a required field had been left blank. Examples of distinguishing a visual element:
+         for a series of toggle buttons, the pressed/activated buttons are only visually indicated
+         by a difference in color; the interactive element that currently has focus is only
+         distinguished by changing the color of the element's <em>existing</em> background or
+         border - however, if focus indication introduces a new visual element that was not previously
+         present, this does not count as a change in color, since the indicator was not presentation
+         to begin with.
       </p>
 
       <div class="note">
@@ -131,7 +137,7 @@
             
             <p>
                								       
-               <strong> An examination.</strong>
+               <strong>An examination</strong>
                							     
             </p>
             
@@ -142,6 +148,33 @@
                the numbers.
             </p>
             
+         </li>
+
+         <li>
+            <p>
+               <strong>A series of toggle buttons</strong>
+            </p>
+            <p>Users are presented with a series of toggle buttons that can be turned on or off. Visually,
+               when a toggle button is turned on, it not only has a different background color, but is
+               also styled to appear "pressed", with a distinctive inner shadow. Alternatively, toggles that
+               are turned on could have an extra "ticked" icon to distinguish them from toggles that are
+               turned off.
+            </p>
+         </li>
+
+         <li>
+            <p>
+               <strong>Focus indication</strong>
+            </p>
+            <p>When an interactive control (like a button, toggle, or checkbox) receives focus, its background color
+               changes. In addition to this, an additional outline (which was not present in the control's unfocused state)
+               appears around the control.
+            </p>
+            <p>Note that when it comes to focus indication, there are additional criteria
+               that apply. For instance, in this case, the additional outline will pass this criterion - as it provides
+               another visual cue to distinguish the focused element - but the outline itself will still need to pass 
+               <a href="#non-text-contrast">1.4.11 Non-text Contrast</a>. 
+            </p>
          </li>
          
       </ul>


### PR DESCRIPTION
Various tweaks/additions to the 1.4.1 understanding doc, as this seems to still cause some confusion (mainly due to its overlap with other SCs present and future - see #1775)

* Remove benefit mentioning monochrome displays - this situation may not be helped by the "using a difference in contrast/brightness, not just *hue*" way of addressing this SC.
* Change the last benefit, as it only applies if something else like extra visible/announced text is added. And the "listen" part implies that this is intended to help AT users, which for this SC is not the case (that's a 1.3.1 / 4.1.2 issue)
* Add two more examples - toggles whose state (on or off) is only distinguished by a color change, and controls whose focused state is only conveyed by a color change.
* Reword first examples for information conveyed by color differences so they don't sound like instructions/descriptions - currently, these examples sound far more like 1.3.3 Sensory Characteristics related instructions
* restructure the examples as a more readable/scannable list
* add an explicit example of links versus static text 

Closes https://github.com/w3c/wcag/issues/1775