### PR TITLE
Fix a link to the "Visible Controls" SC in the Change Log of the Guidelines

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -763,7 +763,7 @@
     			<li>2020-07-19: Added <q>Findable Help</q> (later renamed to <a href="#consistent-help">Consistent Help</a>), <q>Fixed Reference Points</q> (<a href="#page-break-navigation">Page Break Navigation</a>), <q>Hidden Controls</q> (later renamed <a href="#visible-controls">Visible Controls</a>), <q>Pointer Target Spacing</q> (later renamed <a href="#target-size-minimum">Target Size (Minimum)</a>), <a href="#redundant-entry">Redundant Entry</a>.</li>
     			<li>2020-08-04: Added <a href="#focus-appearance-minimum">Focus Appearance (Minimum)</a> and renamed <q>Focus Visible (Enhanced)</q> to <q>Focus Appearance (Enhanced)</q>.</li>
     			<li>2020-11-02: Renamed <q>Dragging</q> to <q>Dragging Movements</q>.</li>
-    			<li>2020-12-08: Renamed <q>Hidden Controls</q> to <a>Visible Controls</a></li>
+    			<li>2020-12-08: Renamed <q>Hidden Controls</q> to <a href="#visible-controls">Visible Controls</a></li>
     			<li>2020-03-10: Renamed <q>Pointer Target Spacing</q> to <q>Target Size (Minimum)</q></li>
     		</ul>
     	</section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OwenEdwards/wcag/pull/1811.html" title="Last updated on May 18, 2021, 3:24 AM UTC (d94e605)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/1811/c9e2cfc...OwenEdwards:d94e605.html" title="Last updated on May 18, 2021, 3:24 AM UTC (d94e605)">Diff</a>