### PR TITLE
Fix link to GitHub "commit history to WCAG 2.2" in Guidelines

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -754,7 +754,7 @@
     	<section class="appendix" id="changelog">
     		<h2>Change Log</h2>
     		<p>This section shows substantive changes made in WCAG 2.2 since WCAG 2.1. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
-    		<p>The full <a href="https://github.com/w3c/wcag/commits/master/guidelines">commit history to WCAG 2.2</a> is available.</p>
+    		<p>The full <a href="https://github.com/w3c/wcag/commits/main/guidelines">commit history to WCAG 2.2</a> is available.</p>
     		<ul>
     			<li>2019-11-10: Promoted <a href="#focus-visible">Focus Visible</a> from Level AA to Level A.</li>
     			<li>2020-01-14: Added <q>Focus Visible (Enhanced)</q>, later renamed to <a href="#focus-appearance-enhanced">Focus Appearance (Enhanced)</a>.</li>


### PR DESCRIPTION
Move from "master" branch to "main" branch.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OwenEdwards/wcag/pull/1812.html" title="Last updated on May 18, 2021, 3:29 AM UTC (08939d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/1812/c9e2cfc...OwenEdwards:08939d4.html" title="Last updated on May 18, 2021, 3:29 AM UTC (08939d4)">Diff</a>