### PR TITLE
Alternative rewording of the normative text for 1.4.2 Audio control

### DIFF
--- a/guidelines/sc/20/audio-control.html
+++ b/guidelines/sc/20/audio-control.html
@@ -5,10 +5,12 @@
    <p class="conformance-level">A</p>
    
    <p>If any audio on a Web page plays automatically for more than 3 seconds, at least one of the following is true:</p>
-   <ul>
-     <li>a <a>mechanism</a> is available to pause or stop the audio</li>
-     <li>a <a>mechanism</a> is available to control the audio volume, independently from any other audio output of the user agent and the overall system.</li>
-   </ul>
+   <dl>
+     <dt>Pause or Stop</dt>
+     <dd>A <a>mechanism</a> is available to pause or stop the audio.</dd>
+     <dt>Volume Control</dt>
+     <dd>A <a>mechanism</a> is available to control the audio volume, independently from any other audio output of the user agent and the overall system.</dd>
+   </dl>
    
    <p class="note">Since any content that does not meet this success criterion can interfere with a user's
       ability to use the whole page, all content on the Web page (whether or not it is used

--- a/guidelines/sc/20/audio-control.html
+++ b/guidelines/sc/20/audio-control.html
@@ -4,8 +4,11 @@
    
    <p class="conformance-level">A</p>
    
-   <p>If any audio on a Web page plays automatically for more than 3 seconds, either a <a>mechanism</a> is available to pause or stop the audio, or a
-      mechanism is available to control the audio volume, independently from any other audio output of the user agent and the overall system.</p>
+   <p>If any audio on a Web page plays automatically for more than 3 seconds, at least one of the following is true:</p>
+   <ul>
+     <li>a <a>mechanism</a> is available to pause or stop the audio</li>
+     <li>a <a>mechanism</a> is available to control the audio volume, independently from any other audio output of the user agent and the overall system.</li>
+   </ul>
    
    <p class="note">Since any content that does not meet this success criterion can interfere with a user's
       ability to use the whole page, all content on the Web page (whether or not it is used

--- a/guidelines/sc/20/audio-control.html
+++ b/guidelines/sc/20/audio-control.html
@@ -4,11 +4,8 @@
    
    <p class="conformance-level">A</p>
    
-   <p>For any audio on a Web page that (1) plays automatically, and (2) last for more than 3 seconds, at least one of the following is true:</p>
-   <dl>
-      <dt>Pause or Stop</dt><dd>A mechanism is available to pause or stop the audio, independently from any other audio output.</dd>
-      <dt>Volume Control</dt><dd>A mechanism is available to control audio volume independently from the overall system volume level.</dd>
-   </dl>
+   <p>If any audio on a Web page plays automatically for more than 3 seconds, either a <a>mechanism</a> is available to pause or stop the audio, or a
+      mechanism is available to control the audio volume, independently from any other audio output of the user agent and the overall system.</p>
    
    <p class="note">Since any content that does not meet this success criterion can interfere with a user's
       ability to use the whole page, all content on the Web page (whether or not it is used
@@ -16,7 +13,7 @@
    </p>
 
    <p class="note">A user agent's ability to disable auto-playing media and/or mute a specific sound source (independently from any other audio
-      output, e.g. muting a browser allowing to mute the audio playing in a specific tab) are acceptable mechanisms to stop or control the volume of
-   auto-playing audio content. However, not all user agents may have the capability to disable auto-playing media or mute specific windows or tabs.</p>
+      output, e.g. a browser allowing to mute the audio playing in a specific tab) are acceptable mechanisms to stop or control the volume of
+   auto-playing audio content. However, not all user agents may have this capability.</p>
    
 </section>

--- a/guidelines/sc/20/audio-control.html
+++ b/guidelines/sc/20/audio-control.html
@@ -4,9 +4,11 @@
    
    <p class="conformance-level">A</p>
    
-   <p>If any audio on a Web page plays automatically for more than 3 seconds, either a <a>mechanism</a> is available to pause or stop the audio, or a mechanism is available to control audio
-      volume independently from the overall system volume level.
-   </p>
+   <p>For any audio on a Web page that (1) plays automatically, and (2) last for more than 3 seconds, at least one of the following is true:</p>
+   <dl>
+      <dt>Pause or Stop</dt><dd>A mechanism is available to pause or stop the audio, independently from any other audio output.</dd>
+      <dt>Volume Control</dt><dd>A mechanism is available to control audio volume independently from the overall system volume level.</dd>
+   </dl>
    
    <p class="note">Since any content that does not meet this success criterion can interfere with a user's
       ability to use the whole page, all content on the Web page (whether or not it is used

--- a/guidelines/sc/20/audio-control.html
+++ b/guidelines/sc/20/audio-control.html
@@ -14,5 +14,9 @@
       ability to use the whole page, all content on the Web page (whether or not it is used
       to meet other success criteria) must meet this success criterion. See <a href="#cc5">Conformance Requirement 5: Non-Interference</a>.
    </p>
+
+   <p class="note">A user agent's ability to disable auto-playing media and/or mute a specific sound source (independently from any other audio
+      output, e.g. muting a browser allowing to mute the audio playing in a specific tab) are acceptable mechanisms to stop or control the volume of
+   auto-playing audio content. However, not all user agents may have the capability to disable auto-playing media or mute specific windows or tabs.</p>
    
 </section>


### PR DESCRIPTION
In contrast to https://github.com/w3c/wcag/pull/1824 this rewording accepts that the mechanism does not necessarily have to be implemented by the web page itself, but - per the definition of mechanism - can also be provided by the user agent/system. What this change does implement though is the clarification for the pause/stop clause that the pausing/stopping must be *independent* from any other audio output (which does address @jake-abma's original concern that a system wide general mute/audio off would automatically satisfy the SC, which is not the intended outcome https://github.com/w3c/wcag/issues/1533

while a normative change, I don't believe this actually changes the meaning as intended at the time.

Closes https://github.com/w3c/wcag/issues/1533