### PR TITLE
Reword F23

### DIFF
--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -1,40 +1,64 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Failure of  1.4.2 due to playing a sound longer than 3 seconds where
-                    there is no mechanism to turn it off</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of  1.4.2 due to playing a sound longer than 3 seconds where
-                    there is no mechanism to turn it off</h1><section class="meta"><p class="id">ID: F23</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
+<!DOCTYPE html>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+   <title>Failure of  1.4.2 due to playing a sound longer than 3 seconds where there is no mechanism to turn it off</title>
+   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link>
+</head>
+<body>
+   <h1>Failure of 1.4.2 due to playing a sound longer than 3 seconds where there is no mechanism to turn it off</h1>
+   <section class="meta">
+      <p class="id">ID: F23</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p>
+   </section>
+   <section id="applicability">
+      <h2>When to Use</h2>
       <p> Applies to all technologies except those for voice interaction. </p>
-   </section><section id="description"><h2>Description</h2>
-      <p> This describes a failure condition for Success Criteria involving sound. If sound does not
-                        turn off automatically within 3 seconds and there is no way to turn the
-                        sound off then Success Criterion 1.4.2 would not be met. Sounds that play over 3 seconds
-                        when there is no mechanism to turn off the sound included in the content
-                        would fall within this failure condition. </p>
-   </section><section id="examples"><h2>Examples</h2>
+   </section>
+   <section id="description">
+      <h2>Description</h2>
+      <p>This describes a failure condition for Success Criteria involving sound. If sound does not
+         turn off automatically within 3 seconds and there is no way to turn the
+         sound off, independently from any other audio output, then Success Criterion 1.4.2 would not be met.
+         The sound would fall within this failure condition. </p>
+   </section>
+   <section id="examples">
+      <h2>Examples</h2>
       <section class="example">
          
             <ul>
-               <li> A site that plays continuous background music </li>
+               <li>A site that plays continuous background music </li>
             </ul>
          
       </section>
       <section class="example">
          
             <ul>
-               <li> A site with a narrator that lasts more than 3 seconds before
-                  	stopping, and there is no mechanism to stop it. </li>
+               <li>A site with a narrator that lasts more than 3 seconds before
+                  stopping, and there is no mechanism to stop it. </li>
             </ul>
          
       </section>
-   </section><section id="tests"><h2>Tests</h2>
+   </section
+   ><section id="tests">
+      <h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
-            <li> Check that there is a way in a Web page to turn off any sound that
-                                    plays automatically for more than three seconds.</li>
+            <li>Check that there is a mechanism to turn off any sound that
+               plays automatically for more than three seconds, independently from any other audio output
+               of the user agent or any other applications on the system.</li>
          </ol>
       </section>
-      <section class="results"><h3>Expected Results</h3>
+      <section class="results">
+         <h3>Expected Results</h3>
          <ul>
-            <li> If step #1 is not true then content fails Success Criterion 1.4.2
-                                </li>
+            <li> If step #1 is not true then content fails Success Criterion 1.4.2</li>
          </ul>
       </section>
-   </section><section id="related"><h2>Related Techniques</h2></section><section id="resources"><h2>Resources</h2></section></body></html>
+   </section>
+   <section id="related">
+      <h2>Related Techniques</h2>
+   </section>
+   <section id="resources">
+      <h2>Resources</h2>
+   </section>
+</body>
+</html>

--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -39,7 +39,7 @@
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check that there is a mechanism, independent from the overall system volume control, to turn off any sound that
-               plays automatically for more than three seconds, independently from the overall system volume level.
+               plays automatically for more than three seconds.
             </li>
          </ol>
       </section>

--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -38,7 +38,7 @@
       <h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
-            <li>Check that there is a mechanism to turn off any sound that
+            <li>Check that there is a mechanism, independent from the overall system volume control, to turn off any sound that
                plays automatically for more than three seconds, independently from the overall system volume level.
             </li>
          </ol>

--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -17,7 +17,7 @@
       <h2>Description</h2>
       <p>This describes a failure condition for Success Criteria involving sound. If sound does not
          turn off automatically within 3 seconds and there is no way to turn the
-         sound off, independently from any other audio output, then Success Criterion 1.4.2 would not be met.
+         sound off, independently from the overall system volume level, then Success Criterion 1.4.2 would not be met.
          The sound would fall within this failure condition. </p>
    </section>
    <section id="examples">

--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -44,7 +44,7 @@
          <ol>
             <li>Check that there is a mechanism to turn off any sound that
                plays automatically for more than three seconds, independently from the overall system volume level
-               of the user agent or any other applications on the system.</li>
+          .</li>
          </ol>
       </section>
       <section class="results">

--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -43,7 +43,7 @@
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check that there is a mechanism to turn off any sound that
-               plays automatically for more than three seconds, independently from any other audio output
+               plays automatically for more than three seconds, independently from the overall system volume level
                of the user agent or any other applications on the system.</li>
          </ol>
       </section>

--- a/techniques/failures/F23.html
+++ b/techniques/failures/F23.html
@@ -23,19 +23,15 @@
    <section id="examples">
       <h2>Examples</h2>
       <section class="example">
-         
-            <ul>
-               <li>A site that plays continuous background music </li>
-            </ul>
-         
+         <ul>
+            <li>A site that plays continuous background music </li>
+         </ul>
       </section>
       <section class="example">
-         
-            <ul>
-               <li>A site with a narrator that lasts more than 3 seconds before
-                  stopping, and there is no mechanism to stop it. </li>
-            </ul>
-         
+         <ul>
+            <li>A site with a narrator that lasts more than 3 seconds before
+               stopping, and there is no mechanism to stop it. </li>
+         </ul>
       </section>
    </section
    ><section id="tests">
@@ -43,14 +39,14 @@
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check that there is a mechanism to turn off any sound that
-               plays automatically for more than three seconds, independently from the overall system volume level
-          .</li>
+               plays automatically for more than three seconds, independently from the overall system volume level.
+            </li>
          </ol>
       </section>
       <section class="results">
          <h3>Expected Results</h3>
          <ul>
-            <li> If step #1 is not true then content fails Success Criterion 1.4.2</li>
+            <li>If step #1 is not true then content fails Success Criterion 1.4.2</li>
          </ul>
       </section>
    </section>


### PR DESCRIPTION
in line with the proposed clarification for 1.4.2 https://github.com/w3c/wcag/pull/1825 this clarifies that a *mechanism* needs to be available. the mechanism can actually be provided by the UA/system, not necessarily by the Web page. Key here is that it must be possible to turn off the sound *independently* from any other audio output.

Closes https://github.com/w3c/wcag/issues/1543

~Only makes sense to merge if https://github.com/w3c/wcag/pull/1825 (or an equivalent/modified version of the PR) is also merged~ (Completed)