### PR TITLE
Page Break Nav terminology clarity

### DIFF
--- a/guidelines/terms/22/page-break-locators.html
+++ b/guidelines/terms/22/page-break-locators.html
@@ -2,7 +2,7 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-	<p>programmatically determinable anchors or destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+  <p><a>programmatically determinable</a> anchors or destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
 	<p>Examples would be:</p>
 	<ul>
 	   <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>

--- a/guidelines/terms/22/page-break-locators.html
+++ b/guidelines/terms/22/page-break-locators.html
@@ -2,7 +2,7 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-  <p><a>programmatically determinable</a> anchors or destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+  <p><a>programmatically determinable</a> destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
 	<p>Examples would be:</p>
 	<ul>
 	   <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>

--- a/guidelines/terms/22/page-break-locators.html
+++ b/guidelines/terms/22/page-break-locators.html
@@ -2,7 +2,7 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-	<p>programmatically determinable anchors or destinations that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+	<p>programmatically determinable anchors or destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
 	<p>Examples would be:</p>
 	<ul>
 	   <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>

--- a/guidelines/terms/22/page-break-locators.html
+++ b/guidelines/terms/22/page-break-locators.html
@@ -2,7 +2,7 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-	<p>programmatic markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+	<p>programmatically determinable anchors or destinations that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
 	<p>Examples would be:</p>
 	<ul>
 	   <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>

--- a/understanding/22/page-break-navigation.html
+++ b/understanding/22/page-break-navigation.html
@@ -24,7 +24,7 @@
       </blockquote>
 
       <h3>Definitions:</h3>
-      <p><strong>page break locators</strong> programmatic markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+      <p><strong>page break locators</strong> programmatically determinable anchors or destinations that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
       <p>Examples would be:</p>
       <ul>
          <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>

--- a/understanding/22/page-break-navigation.html
+++ b/understanding/22/page-break-navigation.html
@@ -24,7 +24,7 @@
       </blockquote>
 
       <h3>Definitions:</h3>
-      <p><strong>page break locators</strong> programmatically determinable anchors or destinations that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+      <p><strong>page break locators</strong> programmatically determinable anchors or destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
       <p>Examples would be:</p>
       <ul>
          <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>

--- a/understanding/22/page-break-navigation.html
+++ b/understanding/22/page-break-navigation.html
@@ -24,7 +24,7 @@
       </blockquote>
 
       <h3>Definitions:</h3>
-      <p><strong>page break locators</strong> programmatically determinable anchors or destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
+      <p><strong>page break locators</strong> programmatically determinable destination markers that are arranged in a meaningful sequence to determine the location of a page in relation to others in the set.</p>
       <p>Examples would be:</p>
       <ul>
          <li>A digital version of an ebook that has a print version, it includes the page break locators to align with the print edition.</li>


### PR DESCRIPTION
Updated content to better define the term 'programmatic markers'
<hr>
Related to Issue: Page Break Navigation uses undefined term to define a term, and needs to clarify #1927