### PR TITLE
Target size minimum: conforming alternate version

### DIFF
--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -63,7 +63,7 @@
       
       <h3>Alternatives for targets on the same page</h3>
       
-      <p>Where functionality can be executed via activating a target and an equivalent pointer-operable option to execute the same underlying function is available, this option counts as a <a>conforming alternate version</a> on the same page. An example is an `input type="number"` where the arrow icons for increasing/decreasing the value do not meet this Success Criterion. However, users can also enter the value via the associated text field and a keyboard (for pointer users, via an onscreen keyboard).</p> 
+      <p>Where functionality can be executed via activating a target and an equivalent pointer-operable option to execute the same underlying function is available, this option counts as a <a>conforming alternate version</a> on the same page. An example is an `input type="number"` where the arrow icons for increasing/decreasing the value do not meet this Success Criterion. However, users can also enter the value via the associated text field and a keyboard (for pointer users, via an on-screen keyboard).</p> 
 
         <figure id="pointer-target-24x24">
             <img src="img/pointer-target-example1-full.png" alt="Four rows of icons with measurements, the first three passing,the last failing the requirement." />

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -63,7 +63,7 @@
       
       <h3>Alternatives for targets on the same page</h3>
       
-      <p>Where functionality can be executed via activating a target and an equivalent pointer-operable option to execute the same underlying function is available, this option counts as a <a>conforming alternate version</a> on the same page. An example is an `input type="number"` where the arrow icons for increasing/decreasing the value do not meet the Target Size (Minimum) Success Criterion. However, users can also enter the value via the associated text field and a keyboard (for pointer users, via an onscreen keyboard).</p> 
+      <p>Where functionality can be executed via activating a target and an equivalent pointer-operable option to execute the same underlying function is available, this option counts as a <a>conforming alternate version</a> on the same page. An example is an `input type="number"` where the arrow icons for increasing/decreasing the value do not meet this Success Criterion. However, users can also enter the value via the associated text field and a keyboard (for pointer users, via an onscreen keyboard).</p> 
 
         <figure id="pointer-target-24x24">
             <img src="img/pointer-target-example1-full.png" alt="Four rows of icons with measurements, the first three passing,the last failing the requirement." />

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -60,6 +60,10 @@
            <h3>Spacing versus size</h3>
         <p>Spacing, alone and in conjunction with size, can improve user experience. There is less chance of accidentally activating a neighboring target if a target is not immediately adjacent to another. The value of spacing around targets is enhanced by touchscreen devices and user agents, which generally have internal heuristics to identify which link or control is closest to a user's touch interaction.</p>
         <p>The following illustrate a variety of situations using size and spacing of targets. In the top line of icons, the dimensions of each icon target are 44 by 44 CSS pixels with no space in between. This amply passes this Success Criterion and is actually sufficient to meet the AAA requirement for <a href="../21/target-size-enhanced.html">Target Size (Enhanced)</a>. In the next row, the dimensions of each icon target are 24 by 24 CSS pixels with no space in between, passing this Success Criterion. In the third row, the the same icon targets are only 20 by 20 CSS pixels but they have a 4 CSS pixel space in between, passing this Success Criterion via the spacing exception. In the last row, the the same icon targets are only 20 by 20 CSS pixels and have no space in between, failing this Success Criterion.</p>
+      
+      <h3>Alternatives for targets on the same page</h3>
+      
+      <p>Where functionality can be executed via activating a target and an equivalent pointer-operable option to execute the same underlying function is available, this option counts as a <a>conforming alternate version</a> on the same page. An example is an `input type="number"` where the arrow icons for increasing/decreasing the value do not meet the Target Size (Minimum) Success Criterion. However, users can also enter the value via the associated text field and a keyboard (for pointer users, via an onscreen keyboard).</p> 
 
         <figure id="pointer-target-24x24">
             <img src="img/pointer-target-example1-full.png" alt="Four rows of icons with measurements, the first three passing,the last failing the requirement." />


### PR DESCRIPTION
Adding a paragraph about meeting Target Size (Minimum) via conforming alternate versions, taking input type=number as an example (following discussion in the WCAG issues meeting today). I do not feel particularly happy about it, partly because it uses input type=number as an example. This feels odd for two reasons: 

1. native input type=number would fall under the user agent exception, so not need a conforming alternate version for that reason;
2. input and the arrows generated in some UA are essentially one control so it feels odd treating this control as two separate things, the field being treated as an alterate version to the arrows. Alternate versions would usually be distinct (like a number field below a custom slider that is not keyboard accessible).

Since the in-page conforming alternate version is potentially an option for many different things anyway, and one we would not usually want to encourage, it stands to reason that it sends the wrong signal to explicitly include this Understanding text.