### PR TITLE
Issue 1932 Gramatical rewrite of visible controls

### DIFF
--- a/guidelines/sc/22/visible-controls.html
+++ b/guidelines/sc/22/visible-controls.html
@@ -5,7 +5,7 @@
     <p class="conformance-level">AA</p>
 	<p class="change">New</p>
     
-    <p>Where receiving pointer hover or keyboard focus triggers <a>user interface components</a> to be visible, information needed to identify that user interface components are available is visible, except when:</p>
+  <p>Where <a>user interface components</a> become visible as a result of pointer hover or keyboard focus, information needed to identify that such components are available is provided visually, except when:</p>
     <ul>
         <li>The information needed to identify the user interface components is available through an equivalent component that is visible on the same page or on a different step in a multi-step process without requiring pointer hover or keyboard focus;</li>
         <li>The component is provided specifically to enhance the experience for keyboard navigation;</li>

--- a/understanding/22/visible-controls.html
+++ b/understanding/22/visible-controls.html
@@ -98,10 +98,10 @@
   <h3>Question: Does this Success Criteria apply  to an e-reader that allows the user to <b>select</b> some text and then pops up some buttons to allow the user to interact in different ways with that texts.     </h3>
       <p> Answer: No, the success criteria only applies where controls become visible on hover or keyboard focus</p>
      
-     <h3> Does this success criteria apply to controls that become visible upon scrolling such as a button at the bottom of Terms and Conditions modal?</h3>
-     <p>It depends. If the scroll bar is visible then it would pass (the scrollbar would also need to be keyboard operable as per success criteria 2.1). However, if the scrollbar only becomes visible on hover or focus then there would need to be some sort of visual indicator that there is an interactive control in the scroll area that is not currently visible. Regarding a scrollbar that becomes visible only on hover or focus, in that case there would need to be some sort of visual indicator that the the scroll bar is there. The best way would be for it to be consistently visible, but if not, a border around the scrollable area may serve as such an indicator.</p>
+     <h3>Question: Does this success criteria apply to controls that become visible upon scrolling such as a button at the bottom of Terms and Conditions modal?</h3>
+     <p>Answer: It depends. If the scrollbar is visible then it would pass (the scrollbar would also need to be keyboard operable as per success criteria 2.1). However, if the scrollbar only becomes visible on hover or focus then there would need to be some sort of visual indicator that there is an interactive control in the scroll area that is not currently visible. Regarding a scrollbar that becomes visible only on hover or focus, in that case there would need to be some sort of visual indicator that the the scrollbar is there. The best way would be for it to be consistently visible, but if not, a border around the scrollable area may serve as such an indicator.</p>
        <h3> Does this success criteria apply to where  table column sort controls only appear on hover/focus, but the user needs to use them in order to find the information they're looking for in the table?</h3>
-     <p>This would be in scope. Therefore therenwould need to be an indicator that there are sort controls, more than just the text in the table header cell, such as a up/down arrow. </p>
+     <p>This would be in scope. Therefore there would need to be an indicator that there are sort controls, more than just the text in the table header cell, such as a up/down arrow. </p>
    </section>
 
    

--- a/understanding/22/visible-controls.html
+++ b/understanding/22/visible-controls.html
@@ -91,17 +91,6 @@
       </ul>
       <p class="note">Other success criteria apply to the requirement for controls being “visible." Visibility is not limited to appearing graphically on the screen, but also includes following a meaningful sequence, not relying on sensory characteristics, and all other requirements under <a href="../../understanding/distinguishable">1.4: Distinguishable</a>.</p>
       
-     <h2> Questions and Answers about when this applies</h2>
-       <h3>Question:  Does this success critierion apply to cases where more options/fields become visible because of a <b>selection</b> elsewhere on the form such as filling out an address and the City field is not visible until the State is selected?</h3>     <p>
-     <p> Answer: No, the success criteria only applies where controls become visible on hover or keyboard focus</p>
-     
-  <h3>Question: Does this Success Criteria apply  to an e-reader that allows the user to <b>select</b> some text and then pops up some buttons to allow the user to interact in different ways with that texts.     </h3>
-      <p> Answer: No, the success criteria only applies where controls become visible on hover or keyboard focus</p>
-     
-     <h3>Question: Does this success criteria apply to controls that become visible upon scrolling such as a button at the bottom of Terms and Conditions modal?</h3>
-     <p>Answer: It depends. If the scrollbar is visible then it would pass (the scrollbar would also need to be keyboard operable as per success criteria 2.1). However, if the scrollbar only becomes visible on hover or focus then there would need to be some sort of visual indicator that there is an interactive control in the scroll area that is not currently visible. Regarding a scrollbar that becomes visible only on hover or focus, in that case there would need to be some sort of visual indicator that the the scrollbar is there. The best way would be for it to be consistently visible, but if not, a border around the scrollable area may serve as such an indicator.</p>
-       <h3> Does this success criteria apply to where  table column sort controls only appear on hover/focus, but the user needs to use them in order to find the information they're looking for in the table?</h3>
-     <p>This would be in scope. Therefore there would need to be an indicator that there are sort controls, more than just the text in the table header cell, such as a up/down arrow. </p>
    </section>
 
    

--- a/understanding/22/visible-controls.html
+++ b/understanding/22/visible-controls.html
@@ -60,6 +60,8 @@
 
 		<p>In some cases, controls are provided in multiple locations on a page or at multiple points within a process. In these cases, at least one of the instances of the control must be visible without hover interaction or keyboard focus. For example, on an email listing page some controls such as trash may be visible using pointer hover in the inbox list view. However, those controls are always visible on the email page. Because the controls are persistently visible on the email view, they do not need to be persistently visible on the inbox view.</p>
 
+        
+
 		<h3>Embedded Controls</h3>
 		
       <p>Information needed to identify user interface components is usually the component itself; however, there are situations where controls are not visible. Complex components such as video players and carousels often include controls that are visible on hover. The presence of the complex component — for example, the carousel component or the video image — provides the “Information needed to identify the user interface components.” For a carousel, controls displayed on hover should also be displayed when the carousel is activated. For a video player, activating the video image should launch the video (sometimes in a new window), at which point more video player controls, including controls displayed previously on hover, should be visible. Some users may still struggle if video controls are not persistently visible, so there is benefit to providing a mechanism that allows users to have the controls persistently visible.</p>
@@ -89,6 +91,17 @@
       </ul>
       <p class="note">Other success criteria apply to the requirement for controls being “visible." Visibility is not limited to appearing graphically on the screen, but also includes following a meaningful sequence, not relying on sensory characteristics, and all other requirements under <a href="../../understanding/distinguishable">1.4: Distinguishable</a>.</p>
       
+     <h2> Questions and Answers about when this applies</h2>
+       <h3>Question:  Does this success critierion apply to cases where more options/fields become visible because of a <b>selection</b> elsewhere on the form such as filling out an address and the City field is not visible until the State is selected?</h3>     <p>
+     <p> Answer: No, the success criteria only applies where controls become visible on hover or keyboard focus</p>
+     
+  <h3>Question: Does this Success Criteria apply  to an e-reader that allows the user to <b>select</b> some text and then pops up some buttons to allow the user to interact in different ways with that texts.     </h3>
+      <p> Answer: No, the success criteria only applies where controls become visible on hover or keyboard focus</p>
+     
+     <h3> Does this success criteria apply to controls that become visible upon scrolling such as a button at the bottom of Terms and Conditions modal?</h3>
+     <p>It depends. If the scroll bar is visible then it would pass (the scrollbar would also need to be keyboard operable as per success criteria 2.1). However, if the scrollbar only becomes visible on hover or focus then there would need to be some sort of visual indicator that there is an interactive control in the scroll area that is not currently visible. Regarding a scrollbar that becomes visible only on hover or focus, in that case there would need to be some sort of visual indicator that the the scroll bar is there. The best way would be for it to be consistently visible, but if not, a border around the scrollable area may serve as such an indicator.</p>
+       <h3> Does this success criteria apply to where  table column sort controls only appear on hover/focus, but the user needs to use them in order to find the information they're looking for in the table?</h3>
+     <p>This would be in scope. Therefore therenwould need to be an indicator that there are sort controls, more than just the text in the table header cell, such as a up/down arrow. </p>
    </section>
 
    


### PR DESCRIPTION
We also have a few options instead of "such"

- use "these components"
- use the full term "user interface components"
- after the first appearance of "user interface components (UIC)" and then use UIC the second time.

NOTE: I still feel a bit awkward with "identify that ..." but I"m not sure there is a fix.

I also added to the Understanding doc with an FAQ section about when the SC does not apply.

Closes #1932