### PR TITLE
target size of obscured targets

### DIFF
--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -64,8 +64,7 @@
         <li>activating a button displays a modal dialog</li>
         <li>The page displayas a cookie banner after page load</li>
         <li>The page displays a "Take a survey" dialog after some period of user inactivity</li>
-      </ul>
-          
+      </ul>    
       <p>The requirement does however apply to targets in any new content that appears on top of other content.</p>
       
       <p>While the Success Criterion primarily helps touch users by providing target sizing to prevent accidental triggering of adjacent targets, it is also useful for mouse or pen users. It reduces the chances of erroneous activation due to either a tremor or reduced precision, whether because of reduced fine motor control or input imprecision.</p>

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -62,8 +62,8 @@
       <ul>
         <li>interacting with a combobox shows a dropdown list of suggestions</li>
         <li>activating a button displays a modal dialog</li>
-        <li>Content displays a cookie banner after page load</li>
-        <li>Content displays a "Take a survey" dialog after some period of user inactivity</li>
+        <li>content displays a cookie banner after page load</li>
+        <li>content displays a "Take a survey" dialog after some period of user inactivity</li>
       </ul>    
       <p>The requirement does however apply to targets in any new content that appears on top of other content.</p>
       

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -57,8 +57,18 @@
         </ol>
 
         <p>The requirement is independent of the zoom factor of the page; when users zoom in the CSS pixel size of elements does not change. This means that authors cannot meet it by claiming that the target will have enough spacing or sufficient size if the user zooms into the page.</p>
-
-        <p>While the Success Criterion primarily helps touch users by providing target sizing to prevent accidental triggering of adjacent targets, it is also useful for mouse or pen users. It reduces the chances of erroneous activation due to either a tremor or reduced precision, whether because of reduced fine motor control or input imprecision.</p>
+      
+      <p>The requirement does not apply to targets while they are fully or partly obsured by content displayed as a result of a user interaction or scripted behaviour of content, for example:</p>
+      <ul>
+        <li>interacting with a combobox shows a dropdown list of suggestions</li>
+        <li>activating a button displays a modal dialog</li>
+        <li>The page displayas a cookie banner after page load</li>
+        <li>The page displays a "Take a survey" dialog after some period of user inactivity</li>
+      </ul>
+          
+      <p>The requirement does however apply to targets in any new content that appears on top of other content.</p>
+      
+      <p>While the Success Criterion primarily helps touch users by providing target sizing to prevent accidental triggering of adjacent targets, it is also useful for mouse or pen users. It reduces the chances of erroneous activation due to either a tremor or reduced precision, whether because of reduced fine motor control or input imprecision.</p>
            <h3>Spacing versus size</h3>
         <p>Spacing, alone and in conjunction with size, can improve user experience. There is less chance of accidentally activating a neighboring target if a target is not immediately adjacent to another. Touchscreen devices and user agents generally have internal heuristics to identify which link or control is closest to a user's touch interaction - this means that sufficient spacing around a target can work as effectively as a larger target size itself.</p>
         <p>The following illustrate a variety of situations using size and spacing of targets. In the top line of icons, the dimensions of each icon target are 44 by 44 CSS pixels with no space in between. This amply passes this Success Criterion and is actually sufficient to meet the AAA requirement for <a href="../21/target-size-enhanced.html">Target Size (Enhanced)</a>. In the next row, the dimensions of each icon target are 24 by 24 CSS pixels with no space in between, passing this Success Criterion. In the third row, the the same icon targets are only 20 by 20 CSS pixels but they have a 4 CSS pixel space in between, passing this Success Criterion via the spacing exception. In the last row, the the same icon targets are only 20 by 20 CSS pixels and have no space in between, failing this Success Criterion.</p>

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -62,8 +62,8 @@
       <ul>
         <li>interacting with a combobox shows a dropdown list of suggestions</li>
         <li>activating a button displays a modal dialog</li>
-        <li>The page displayas a cookie banner after page load</li>
-        <li>The page displays a "Take a survey" dialog after some period of user inactivity</li>
+        <li>Content displays a cookie banner after page load</li>
+        <li>Content displays a "Take a survey" dialog after some period of user inactivity</li>
       </ul>    
       <p>The requirement does however apply to targets in any new content that appears on top of other content.</p>
       

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -58,7 +58,7 @@
 
         <p>The requirement is independent of the zoom factor of the page; when users zoom in the CSS pixel size of elements does not change. This means that authors cannot meet it by claiming that the target will have enough spacing or sufficient size if the user zooms into the page.</p>
       
-      <p>The requirement does not apply to targets while they are fully or partially obsured by content displayed as a result of a user interaction or scripted behaviour of content, for example:</p>
+      <p>The requirement does not apply to targets while they are obscured by content displayed as a result of a user interaction or scripted behavior of content, for example:</p>
       <ul>
         <li>interacting with a combobox shows a dropdown list of suggestions</li>
         <li>activating a button displays a modal dialog</li>

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -58,7 +58,7 @@
 
         <p>The requirement is independent of the zoom factor of the page; when users zoom in the CSS pixel size of elements does not change. This means that authors cannot meet it by claiming that the target will have enough spacing or sufficient size if the user zooms into the page.</p>
       
-      <p>The requirement does not apply to targets while they are fully or partly obsured by content displayed as a result of a user interaction or scripted behaviour of content, for example:</p>
+      <p>The requirement does not apply to targets while they are fully or partially obsured by content displayed as a result of a user interaction or scripted behaviour of content, for example:</p>
       <ul>
         <li>interacting with a combobox shows a dropdown list of suggestions</li>
         <li>activating a button displays a modal dialog</li>


### PR DESCRIPTION
Addressing #1872 asking for clarification regarding dynamic content that obscures other targets
- Requirement does not apply to targets while they are fully or partly obsured by dynamic content
- Requirement does however apply to additional targets brought up by interaction

An issue potentially still to be discussed is if this exception equally holds for content that appears not as a result of user interaction but as a result of scripted behaviour of the content (think "Take a survey now" dialogs or cookie banners). Such content will often violate other SCs already (such as 2.4.3 Focus Order and 2.2.1 Timing Ajustable). My hunch is that both types of dynamic content should be treated the same in terms of the target size requirement.