### PR TITLE
Tweak section headings understanding wording

### DIFF
--- a/understanding/20/section-headings.html
+++ b/understanding/20/section-headings.html
@@ -15,9 +15,8 @@
       
       <p>The intent of this Success Criterion is to provide headings for sections of a Web
          page, when the page is organized into sections. For instance, long documents are often
-         divided into a variety of chapters, chapters have subtopics and subtopics are divided
-         into various sections, sections into paragraphs, etc. When such sections exist, they
-         need to have headings that introduce them. This clearly indicates the organization
+         divided into a variety of chapters, chapters have subtopics, etc. When such sections exist,
+         they need to have headings that introduce them. This clearly indicates the organization
          of the content, facilitates navigation within the content, and provides mental "handles"
          that aid in comprehension of the content. Other page elements may complement headings
          to improve presentation (e.g., horizontal rules and boxes), but visual presentation


### PR DESCRIPTION
Remove ambiguous use of `sections`.

Closes https://github.com/w3c/wcag/issues/2035