### PR TITLE
Additions/tweaks to 1.4.3 understanding

### DIFF
--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -37,11 +37,21 @@
          enough to require a lower contrast ratio. (See The American Printing House for the
          Blind Guidelines for Large Printing and The Library of Congress Guidelines for Large
          Print under 
-         <a href="#resources">Resources</a>). "18 point" and "bold" can both have different meanings in different fonts but,
-         except for very thin or unusual fonts, they should be sufficient. Since there are
-         so many different fonts, the general measures are used and a note regarding fancy
-         or thin fonts is included.
+         <a href="#resources">Resources</a>). Since there are so many different fonts,
+         "18 point" and "bold" only provide very general measures, and in practice there will
+         be notable differences in the actual size and weight of the rendered text depending
+         on the specific font used. However, for most common fonts, these measures provide
+         a reasonable approximation for situations where the required contrast ratios are sufficient.
       </p>
+ 
+      <div class="note">
+         <p>Fonts with very thin strokes, comparatively small x-height, or unusual features and
+            characteristics that reduce the familiarity of their letter form, can be harder to read,
+            especially at lower contrast levels. In these cases authors may choose to exceed the,
+            recommended minimum contrast ratio in order to compensate for this, regardless of their
+            nominal point size or weight.
+         </p>
+      </div>
       
       <div class="note">
          


### PR DESCRIPTION
* reorganises the sentence about 18points/bold having different meanings. currently, that part alludes to "a note regarding fancy or thin fonts is included", but that note doesn't actually exist anymore. This turns the sentence around to be self-contained - no need to foreshadow "there's a note somewhere" for this bit.
* adds back an actual note on what authors are encouraged to do with unusually thin/fancy fonts.

Salvages one tiny aspect that I thought was worth having from this old and rejected pull request https://github.com/w3c/wcag/pull/184 - giving actual actionable advice to authors, rather than just mentioning that there's potentially thin/fancy fonts...and then not following through with what the repercussions for that are.