### PR TITLE
altering bullet to make components persistent

### DIFF
--- a/guidelines/sc/22/visible-controls.html
+++ b/guidelines/sc/22/visible-controls.html
@@ -9,7 +9,7 @@
     <ul>
         <li>The information needed to identify the user interface components is available through an equivalent component that is visible on the same page or on a different step in a multi-step process without requiring pointer hover or keyboard focus;</li>
         <li>The component is provided specifically to enhance the experience for keyboard navigation;</li>
-        <li>A mechanism is available to make the information persistently visible;</li>
+        <li>A mechanism is available to make the components persistently visible;</li>
         <li>Hiding the information needed to identify the component is <a>essential</a>.</li>
     </ul>
     <p class="note">User interface components can be available through other visible components such as sub-menus, edit buttons, tabs, or thumbnails of media.</p>

--- a/understanding/22/visible-controls.html
+++ b/understanding/22/visible-controls.html
@@ -25,7 +25,7 @@
          <ul>
             <li>The information needed to identify the user interface components is available through an equivalent component that is visible on the same page or on a different step in a multi-step process without requiring pointer hover or keyboard focus;</li>
             <li>The component is provided specifically to enhance the experience for keyboard navigation;</li>
-            <li>A mechanism is available to make the information persistently visible;</li>
+            <li>A mechanism is available to make the components persistently visible;</li>
             <li>Hiding the information needed to identify the component is <a>essential</a>.</li>
          </ul>
          <p class="note">User interface components can be available through other visible components such as sub-menus, edit buttons, tabs, or thumbnails of media.</p>
@@ -60,7 +60,7 @@
       <ul>
          <li>If controls are provided in multiple locations on a page or at multiple points within a process, at least one of the instances of the control must be visible without hover interaction or keyboard focus. For example, on an email listing page some controls such as trash may be visible using pointer hover in the inbox list view. Those controls are always visible on the email page so they do not need to be persistently visible on the inbox view.</li>
          <li>If the control is to enhance keyboard navigation. For example, a link that skips from the top of the page to the navigation could become visible only on focus.</li>
-         <li>If there is a mechanism to make the indicators persistently visible. For example, a button at the top of the page could make all the hidden controls visible without needing to hover over them.</li>
+         <li>If there is a mechanism to make the components persistently visible. For example, a button at the top of the page could make all the hidden controls visible without needing to hover over them.</li>
          <li>If hiding the information needed to identify the component is essential. For example, a memory game hides the controls for selecting a card to flip over.</li>
       </ul>
 


### PR DESCRIPTION
This PR changes occurrences of 'make the information persistent' into 'make the component persistent'. It stems from an issue noticed in #1877 

The reason this change is needed is that the persistent _information_ is already a given in the SC wording. It is the persistent _control_ that is the desired outcome. There are already several examples in the Understanding document talking about making the component (not information) persistent, which support this change:

> Those controls are always visible on the email page so they do not need to be persistently visible on the inbox view.

> For example, a button at the top of the page could make all the hidden controls visible without needing to hover over them.

> Some users may still struggle if video controls are not persistently visible, so there is benefit to providing a mechanism that allows users to have the controls persistently visible.

> When an email has been selected the same controls are persistently visible.

> G222 Provide persistently visible controls