### PR TITLE
Update links for old trace.wisc.edu resources

### DIFF
--- a/techniques/general/G145.html
+++ b/techniques/general/G145.html
@@ -160,7 +160,7 @@
                   <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</a>
+                  <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>
                   <a href="https://www.w3.org/Graphics/atypical-color-response">Atypical colour response</a>

--- a/techniques/general/G148.html
+++ b/techniques/general/G148.html
@@ -47,7 +47,7 @@
                   <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</a>
+                  <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>
                   <a href="https://www.w3.org/Graphics/atypical-color-response">Atypical colour response</a>

--- a/techniques/general/G17.html
+++ b/techniques/general/G17.html
@@ -164,7 +164,7 @@
                   <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</a>
+                  <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>
                   <a href="https://www.w3.org/Graphics/atypical-color-response">Atypical colour response</a>

--- a/techniques/general/G176.html
+++ b/techniques/general/G176.html
@@ -79,10 +79,10 @@
                   <a href="http://www.hardingfpa.com/">Harding FPA Web Site</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
+                  <a href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/peat/photosensitive.php">Information about Photosensitive Seizure Disorders</a>
+                  <a href="https://trace.umd.edu/information-about-photosensitive-seizure-disorders/">Information about Photosensitive Seizure Disorders</a>
                 </li>
             <li>
                   <a href="https://www.epilepsy.org.uk/">Epilepsy Action</a>

--- a/techniques/general/G18.html
+++ b/techniques/general/G18.html
@@ -166,7 +166,7 @@
                   <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
                 </li>
             <li>
-                  <a href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</a>
+                  <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>
                   <a href="https://www.w3.org/Graphics/atypical-color-response">Atypical colour response</a>

--- a/techniques/general/G19.html
+++ b/techniques/general/G19.html
@@ -35,7 +35,7 @@
       
          <ul>
             <li>
-                  <a href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
+                  <a href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
                 </li>
          </ul>
       

--- a/techniques/general/G56.html
+++ b/techniques/general/G56.html
@@ -6,7 +6,8 @@
       <p>The objective of this technique is to allow authors to include sound behind
             speech without making it too hard for people with hearing problems to
             understand the speech. Making sure that the foreground speech is 20 db louder than the
-            backgound sound makes the speech 4 times louder than the background audio.</p>
+            backgound sound makes the speech 4 times louder than the background audio. For information on Decibels (dB), refer to
+            <a href="https://ds.gpii.net/content/about-decibels-db">About Decibels</a>.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>An announcer speaking over a riot scene</h3>

--- a/techniques/general/G56.html
+++ b/techniques/general/G56.html
@@ -6,9 +6,7 @@
       <p>The objective of this technique is to allow authors to include sound behind
             speech without making it too hard for people with hearing problems to
             understand the speech. Making sure that the foreground speech is 20 db louder than the
-            backgound sound makes the speech 4 times louder than the background audio.
-            For information on Decibels (dB), refer to
-            <a href="http://trace.wisc.edu/docs/2004-About-dB/index.htm">About Decibels</a>.</p>
+            backgound sound makes the speech 4 times louder than the background audio.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>An announcer speaking over a riot scene</h3>
@@ -74,12 +72,8 @@
       
          <ul>
             <li>
-                  <a href="http://trace.wisc.edu/docs/2004-About-dB/">About
-                    Decibels</a>
-                  by Gregg Vanderheiden</li>
-            <li>
-                  <a href="http://www.eramp.com/david/audio_contrast_general_techs.htm">Audio creation / contrast tutorial</a>
-                </li>
+               <a href="http://www.eramp.com/david/audio_contrast_general_techs.htm">Audio creation / contrast tutorial</a>
+            </li>
          </ul>
       
    </section></body></html>

--- a/understanding/20/low-or-no-background-audio.html
+++ b/understanding/20/low-or-no-background-audio.html
@@ -48,6 +48,22 @@
       
    </section>
    
+  <section id="resources">
+      <h2>Resources for Low or No Background Audio</h2>
+
+
+      <ul>
+
+         <li>
+
+            <a href="https://ds.gpii.net/content/about-decibels-db">About Decibels</a>
+
+         </li>
+
+      </ul>
+
+   </section>
+  
    <section id="techniques">
       <h2>Techniques for Low or No Background Audio</h2>
       

--- a/understanding/20/low-or-no-background-audio.html
+++ b/understanding/20/low-or-no-background-audio.html
@@ -48,22 +48,6 @@
       
    </section>
    
-   <section id="resources">
-      <h2>Resources for Low or No Background Audio</h2>
-      
-      
-      <ul>
-         
-         <li>
-            								       
-            <a href="http://trace.wisc.edu/docs/2004-About-dB/index.htm">About Decibels</a>
-            							     
-         </li>
-         
-      </ul>
-      
-   </section>
-   
    <section id="techniques">
       <h2>Techniques for Low or No Background Audio</h2>
       

--- a/understanding/20/three-flashes-or-below-threshold.html
+++ b/understanding/20/three-flashes-or-below-threshold.html
@@ -129,13 +129,13 @@
          
          <li>
             								       
-            <a href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
+            <a href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://trace.wisc.edu/peat/photosensitive.php">Information about Photosensitive Seizure Disorders</a>
+            <a href="https://trace.umd.edu/information-about-photosensitive-seizure-disorders/">Information about Photosensitive Seizure Disorders</a>
             							     
          </li>
          

--- a/understanding/20/three-flashes.html
+++ b/understanding/20/three-flashes.html
@@ -95,13 +95,13 @@
          
          <li>
             								       
-            <a href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
+            <a href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://trace.wisc.edu/peat/photosensitive.php">Information about Photosensitive Seizure Disorders</a>
+            <a href="https://trace.umd.edu/information-about-photosensitive-seizure-disorders/">Information about Photosensitive Seizure Disorders</a>
             							     
          </li>
          

--- a/wcag20/sources/techniques/general/G145.xml
+++ b/wcag20/sources/techniques/general/G145.xml
@@ -63,7 +63,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</loc>
+                       href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</loc>
                 </p>
             </item>
             <item>

--- a/wcag20/sources/techniques/general/G148.xml
+++ b/wcag20/sources/techniques/general/G148.xml
@@ -54,7 +54,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</loc>
+                       href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</loc>
                 </p>
             </item>
             <item>

--- a/wcag20/sources/techniques/general/G15.xml
+++ b/wcag20/sources/techniques/general/G15.xml
@@ -47,7 +47,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
+                       href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
                 </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/general/G17.xml
+++ b/wcag20/sources/techniques/general/G17.xml
@@ -68,7 +68,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</loc>
+                       href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</loc>
                 </p>
             </item>
             <item>

--- a/wcag20/sources/techniques/general/G176.xml
+++ b/wcag20/sources/techniques/general/G176.xml
@@ -92,13 +92,13 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
+                       href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
                 </p>
             </item>
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/peat/photosensitive.php">Information about Photosensitive Seizure Disorders</loc>
+                       href="https://trace.umd.edu/information-about-photosensitive-seizure-disorders/">Information about Photosensitive Seizure Disorders</loc>
                 </p>
             </item>
             <item>

--- a/wcag20/sources/techniques/general/G18.xml
+++ b/wcag20/sources/techniques/general/G18.xml
@@ -72,7 +72,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</loc>
+                       href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</loc>
                 </p>
             </item>
             <item>

--- a/wcag20/sources/techniques/general/G19.xml
+++ b/wcag20/sources/techniques/general/G19.xml
@@ -41,7 +41,7 @@
             <item>
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                       href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
+                       href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
                 </p>
             </item>
          </ulist>

--- a/wcag20/sources/techniques/general/G56.xml
+++ b/wcag20/sources/techniques/general/G56.xml
@@ -14,10 +14,7 @@
       <p>The objective of this technique is to allow authors to include sound behind
             speech without making it too hard for people with hearing problems to
             understand the speech. Making sure that the foreground speech is 20 db louder than the
-            backgound sound makes the speech 4 times louder than the background audio.
-            For information on Decibels (dB), refer to
-            <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-              href="http://trace.wisc.edu/docs/2004-About-dB/index.htm">About Decibels</loc>.</p>
+            backgound sound makes the speech 4 times louder than the background audio.</p>
    </description>
    <examples>
       <eg-group>

--- a/wcag20/sources/techniques/general/G56.xml
+++ b/wcag20/sources/techniques/general/G56.xml
@@ -14,7 +14,7 @@
       <p>The objective of this technique is to allow authors to include sound behind
             speech without making it too hard for people with hearing problems to
             understand the speech. Making sure that the foreground speech is 20 db louder than the
-            backgound sound makes the speech 4 times louder than the background audio.</p>
+            backgound sound makes the speech 4 times louder than the background audio. For information on Decibels (dB), refer to <a href="https://ds.gpii.net/content/about-decibels-db">About Decibels</a>.</p>
    </description>
    <examples>
       <eg-group>

--- a/wcag20/sources/understanding/seizure-does-not-violate.xml
+++ b/wcag20/sources/understanding/seizure-does-not-violate.xml
@@ -60,12 +60,12 @@
          </item>
          <item>
             <p>
-								       <loc href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
+								       <loc href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
 							     </p>
          </item>
          <item>
             <p>
-								       <loc href="http://trace.wisc.edu/peat/photosensitive.php">Information about Photosensitive Seizure Disorders</loc>
+								       <loc href="https://trace.umd.edu/information-about-photosensitive-seizure-disorders/">Information about Photosensitive Seizure Disorders</loc>
 							     </p>
          </item>
          <item>

--- a/wcag20/sources/understanding/seizure-three-times.xml
+++ b/wcag20/sources/understanding/seizure-three-times.xml
@@ -41,12 +41,12 @@
          </item>
          <item>
             <p>
-								       <loc href="http://trace.wisc.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
+								       <loc href="https://trace.umd.edu/peat/">Trace Center Photosensitive Epilepsy Analysis Tool (PEAT)</loc>
 							     </p>
          </item>
          <item>
             <p>
-								       <loc href="http://trace.wisc.edu/peat/photosensitive.php">Information about Photosensitive Seizure Disorders</loc>
+								       <loc href="https://trace.umd.edu/information-about-photosensitive-seizure-disorders/">Information about Photosensitive Seizure Disorders</loc>
 							     </p>
          </item>
          <item>

--- a/wcag20/sources/understanding/visual-audio-contrast-contrast.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast-contrast.xml
@@ -105,7 +105,7 @@
          </item>
          <item>
             <p>
-								       <loc href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</loc>
+								       <loc href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</loc>
 							     </p>
          </item>
          <item>

--- a/wcag20/sources/understanding/visual-audio-contrast-noaudio.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast-noaudio.xml
@@ -19,19 +19,6 @@
          </ulist>
       </div4>
    </div3>
-   <div3 role="examples">
-      <head>Examples of this Success Criterion</head>
-   </div3>
-   <div3 role="resources">
-      <head/>
-      <ulist>
-         <item>
-            <p>
-								       <loc href="http://trace.wisc.edu/docs/2004-About-dB/index.htm">About Decibels</loc>
-							     </p>
-         </item>
-      </ulist>
-   </div3>
    <div3 role="techniques">
       <head>Techniques for Addressing Success Criterion 1.4.4</head>
       <div4 role="sufficient">

--- a/wcag20/sources/understanding/visual-audio-contrast7.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast7.xml
@@ -93,7 +93,7 @@ images of text (text that has been rendered into pixels and then stored in an im
          </item>
          <item>
             <p>
-								       <loc href="http://trace.wisc.edu/contrast-ratio-examples/">Color Contrast Samples</loc>
+								       <loc href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</loc>
 							     </p>
          </item>
          <item>


### PR DESCRIPTION
* point to new sources for PEAT and "Information about Photosensitive Seizure Disorders" on trace.umd.edu
* point to archive.org stored versions of the contrast ratio examples
* remove links to the "About Decibels" article

Note that this still leaves lots of links too trace.wisc.edu/wcag_wiki which I can't seem to locate a new location for