### PR TITLE
typo in introduction section adds space after link

### DIFF
--- a/techniques/index.html
+++ b/techniques/index.html
@@ -52,7 +52,7 @@
 		</section>
 		<section id="introduction">
 			<h2>Introduction to Techniques for WCAG 2.2</h2>
-			<p>This <em>Techniques for WCAG 2.2</em> document provides guidance for web content authors and evaluators on meeting <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a>success criteria. It is part of a series of documents published by the W3C Web Accessibility Initiative (WAI) to support WCAG 2.2. For an introduction to WCAG, supporting technical documents, and educational material, see <a href="https://www.w3.org/WAI/intro/wcag">Web Content Accessibility Guidelines (WCAG) Overview</a>.</p>
+			<p>This <em>Techniques for WCAG 2.2</em> document provides guidance for web content authors and evaluators on meeting <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a> success criteria. It is part of a series of documents published by the W3C Web Accessibility Initiative (WAI) to support WCAG 2.2. For an introduction to WCAG, supporting technical documents, and educational material, see <a href="https://www.w3.org/WAI/intro/wcag">Web Content Accessibility Guidelines (WCAG) Overview</a>.</p>
 			<p>WCAG 2.2 itself is a stable document that does not change. This <em>Techniques for WCAG 2.2</em> document is updated periodically to cover more current best practices and changes in technologies and tools.</p>
 			<p>Techniques are informative—that means they are not required. The basis for determining conformance to WCAG 2.2 is the success criteria from the <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2 standard</a>—not the techniques.</p>
 			<div class="note">


### PR DESCRIPTION
There's missing a space after the [Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG22/) link in the introductions section on the [techniques page](https://www.w3.org/WAI/WCAG22/Techniques/#introduction).

![image](https://user-images.githubusercontent.com/2575266/144665230-b5c33fe1-e6ef-4d51-b59b-0eaa502f8889.png)
