### PR TITLE
[Supporting docs redesign] Change contribution info

### DIFF
--- a/xslt/base.xslt
+++ b/xslt/base.xslt
@@ -347,7 +347,7 @@
 		<footer id="wai-site-footer" class="page-footer default-grid" aria-label="Page">
     	<div class="inner" style="grid-column: 2 / 8">
       	<p><strong>Date:</strong> Updated <xsl:value-of select="format-date(current-date(), '[D] [MNn] [Y]')"/>. First published @@@</p> <p><strong>Developed by</strong><xsl:text> </xsl:text><a href="https://www.w3.org/groups/wg/ag/participants">Accessibility Guidelines Working Group (AG WG) Participants</a> (Co-Chairs: Alastair Campbell, Charles Adams, Rachael Bradley Montgomery. W3C Staff Contact: Michael Cooper).</p>
-				<p>The content was developed as part of the <a href="https://www.w3.org/WAI/about/projects/#us">WAI-Core projects</a> funded by U.S. Federal funds. The user interface was developed by Hidde de Vries with contributions from Shadi Abou-Zahra and Shawn Lawton Henry, as part of the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project, co-funded by the European Commission..</p>
+				<p>The content was developed as part of the <a href="https://www.w3.org/WAI/about/projects/#us">WAI-Core projects</a> funded by U.S. Federal funds. The user interface was developed with contributions Shadi Abou-Zahra and Shawn Lawton Henry, as part of the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project, co-funded by the European Commission.</p>
 			</div>
   	</footer>	
 	</xsl:template>


### PR DESCRIPTION
Hi, with the recent changes to the UI updates, I no longer feel comfortable having myself credited. With these changes, some of the main points of the redesign are no longer intact and to me, it no longer feels coherent between different types of guidance (eg Techniques, Understanding vs COGA, ACT).

These UI updates in more detail:

- the one sentence concept is gone (“Understanding documents are [etc]”, this was an important aspect, as it would help people understand the set of documents better, in a way that works for all sets of documents that use this UI, this was a key user need that arised from the user research
- the heading 'About this page' was a key wayfinding pattern, which was designed to work across all the different types of documents, again, to help understand context better
- the box that was meant to explain the page now contains page contents and navigation with visual style that doesn't distinguish between internal and external links, which feels quite confusing, and a visual style that is almost like the one we had in the previous docs 

Please merge this before merging https://github.com/w3c/wcag/pull/2012