### PR TITLE
Fix typos in Understanding WCAG 2.2

### DIFF
--- a/understanding/index.html
+++ b/understanding/index.html
@@ -51,7 +51,7 @@
 		</section>
 		<section class="informative introductory" id="intro">
 			<h2>Introduction</h2>
-			<p>Understanding WCAG 2.2 is a  guide to understanding and using <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines 2.2</a> [[WCAG22]] Although the normative definition and requirements for WCAG 2.2 can all be found in the WCAG 2.2 document itself, the concepts and provisions may be new to some people. Understanding WCAG 2.2 provides a non-normative extended commentary on each guideline and each Success Criterion to help readers better understand the intent and how the guidelines and Success Criteria work together. It also provides examples of techniques or combinations of techniques that the Working Group has identified as being sufficient to meet each Success Criterion. Links are then provided to write-ups for each of the techniques.</p>
+			<p>Understanding WCAG 2.2 is a guide to understanding and using <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines 2.2</a> [[WCAG22]] Although the normative definition and requirements for WCAG 2.2 can all be found in the WCAG 2.2 document itself, the concepts and provisions may be new to some people. Understanding WCAG 2.2 provides a non-normative extended commentary on each guideline and each Success Criterion to help readers better understand the intent and how the guidelines and Success Criteria work together. It also provides examples of techniques or combinations of techniques that the Working Group has identified as being sufficient to meet each Success Criterion. Links are then provided to write-ups for each of the techniques.</p>
 			<section>
 				<h3>Relationship to Understanding WCAG 2.0</h3>
 				<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a> [[UNDERSTANDING-WCAG20]] is a substantial resource to support <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0</a> [[WCAG20]]. Understanding WCAG 2.2 is a parallel resource that supports the new success criteria in WCAG 2.2. At this stage, it only includes content related to new features of WCAG 2.0. Future versions <em>may</em> include content relevant to WCAG 2.0, depending on how WCAG 2.2 evolves and what structure is determined to provide optimal support.</p>
@@ -95,7 +95,7 @@
 			</section>
 			<section>
 				<h3>Techniques for WCAG 2.2</h3>
-				<p>Techniques specific to WCAG 2.2 are added to the the techniques for WCAG 2.0, it is one set. The <a href="../techniques/#changelog">Techniques change log</a> lists the new techniques added since WCAG 2.2 was published.</p>
+				<p>Techniques specific to WCAG 2.2 are added to the techniques for WCAG 2.0, it is one set. The <a href="../techniques/#changelog">Techniques change log</a> lists the new techniques added since WCAG 2.2 was published.</p>
 			</section>
 
 		</section>


### PR DESCRIPTION
Line 98: delete extra “the”
Techniques specific to WCAG 2.2 are added to the the techniques for WCAG 2.0,

Should be: 
Techniques specific to WCAG 2.2 are added to the  techniques for WCAG 2.0

Line 54: Delete space
Understanding WCAG 2.2 is a  guide to 

Should be: 
Understanding WCAG 2.2 is a guide to