### PR TITLE
clarifying name, role, value

### DIFF
--- a/understanding/20/name-role-value.html
+++ b/understanding/20/name-role-value.html
@@ -14,18 +14,18 @@
       
       
       <p>The intent of this Success Criterion is to ensure that Assistive Technologies (AT)
-         can gather information about, activate(or set) and keep up to date on the status of
+         can gather accurate information about, activate (or set) and keep up to date on the status of
          user interface controls in the content.
       </p>
       
       <p>When standard controls from accessible technologies are used, this process is straightforward.
          If the user interface elements are used according to specification the conditions
-         of this provision will be met. (See examples  of Success Criterion 4.1.2 below)
+         of this provision will be met. (See examples of Success Criterion 4.1.2 below)
       </p>
       
       <p>If custom controls are created, however, or interface elements are programmed (in
          code or script) to have a different role and/or function than usual, then additional
-         measures need to be taken to ensure that the controls provide important information
+         measures need to be taken to ensure that the controls provide important and accurate information
          to assistive technologies and allow themselves to be controlled by assistive technologies.
       </p>
       
@@ -35,7 +35,7 @@
          of user interface control state are whether or not a checkbox or radio button has
          been selected, or whether or not a collapsible tree or list node is expanded or collapsed.
       </p>
-      
+     
       <div class="note">
          
          <p>Success Criterion 4.1.2 requires a programmatically determinable name for all user


### PR DESCRIPTION
closes #2142

In an attempt to add clarity that it's not just that a name, role and value are exposed but the **correct** name role and value are exposed, I have simply added the word "accurate" to two sentences.  This will help imply that it's not just "information" that needs to be exposed to AT, but "accurate information" about what the control represents.

If more modifications are necessary here, please let me know and I can make those changes, or the editors can make changes as they see fit.