### PR TITLE
copy relative luminance to understanding

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -251,6 +251,7 @@
 		<copy file="css/base.css" todir="output/understanding/"/>
 		<copy file="understanding/understanding.css" todir="output/understanding/"/>
 		<copy file="css/slicenav.css" todir="output/understanding/"/>
+		<copy file="guidelines/relative-luminance.xml" todir="output/understanding/"/>
 		<copy todir="output/understanding/img/" flatten="true">
 			<fileset dir="understanding">
 				<patternset includes="*/img/*"/>


### PR DESCRIPTION
fixes #2014

I took the approach of copying the relative luminance file to the Understanding output. An alternate approach is updating the link to point to version sitting in TR space, but it would have been a special case. Collating into the Understanding resource seemed like a better option.

This will need to be merged into the WCAG-2.1 branch as well.