### PR TITLE
Technique G183: expand example 2 to actually illustrate the technique's point

### DIFF
--- a/techniques/general/G183.html
+++ b/techniques/general/G183.html
@@ -24,7 +24,7 @@
       </section>
       <section class="example">
          
-            <p>The hypertext links in a document are medium-light blue (#3366CC) and the regular text is black (#000000). Because the blue text is light enough, it has a contrast of 3.9:1 with the surrounding text and can be identified as being different than the surrounding text by people with all types of color blindness, including those individuals who cannot see color at all.</p>
+            <p>The hypertext links in a document are medium-light blue (<code>#3366CC</code>) and the regular text is black (<code>#000000</code>). Beyond the difference in color, the links have no other styles differences compared with the regular text. Because the blue text is light enough, it has a contrast of 3.9:1 with the surrounding text and can be identified as being different from the surrounding text by people with all types of color blindness, including those individuals who cannot see color at all. In addition, the links have <code>:focus</code> and <code>:hover</code> styles that reintroduce the underline when the links receive keyboard focus or when a mouse pointer hovers over them.</p>
          
       </section>
    </section><section id="tests"><h2>Tests</h2>

--- a/techniques/general/G183.html
+++ b/techniques/general/G183.html
@@ -24,7 +24,7 @@
       </section>
       <section class="example">
          
-            <p>The hypertext links in a document are medium-light blue (<code>#3366CC</code>) and the regular text is black (<code>#000000</code>). Beyond the difference in color, the links have no other styles differences compared with the regular text. Because the blue text is light enough, it has a contrast of 3.9:1 with the surrounding text and can be identified as being different from the surrounding text by people with all types of color blindness, including those individuals who cannot see color at all. In addition, the links have <code>:focus</code> and <code>:hover</code> styles that reintroduce the underline when the links receive keyboard focus or when a mouse pointer hovers over them.</p>
+            <p>The hypertext links in a document are medium-light blue (<code>#3366CC</code>) and the regular text is black (<code>#000000</code>). Beyond the difference in color, the links have no other styles differences compared with the regular text. Because the blue text is light enough, it has a contrast of 3.9:1 with the surrounding text and can be identified as being different from the surrounding text by people with all types of color blindness, including those individuals who cannot see color at all. In addition to the contrast difference, the links have <code>:focus</code> and <code>:hover</code> styles that reintroduce the underline when the links receive keyboard focus or when a mouse pointer hovers over them. Hover or focus style changes alone are not sufficient to meet the criterion.</p>
          
       </section>
    </section><section id="tests"><h2>Tests</h2>


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/2243

Note that, in addition, the links to the glossary definition `<a>relative luminance</a>` are broken / not correctly converted https://www.w3.org/WAI/WCAG21/Techniques/general/G183 - they just end up pointing to https://www.w3.org/TR/WCAG21/#
However, I suspect this is an issue for @michael-n-cooper to look into (rather than trying to hardcode a url to the correct term definition https://www.w3.org/TR/WCAG21/#dfn-relative-luminance)