### PR TITLE
fix broken link, fix duplicate id attribute

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -144,7 +144,7 @@
 					</figcaption>
 				</figure>
 
-				<figure id="figure-focus-inner-green">
+				<figure id="figure-focus-inner-white">
 					<img src="img/ntc-focus-inner-white.png" alt="Three blue buttons with a black border on a white background, the center button has a white border inside, adjacent to the inner background and black border." width="400" />
 					<figcaption>
 						An inner border of white contrasts with the black border and the blue component background, therefore <strong>passes</strong> non-text contrast.
@@ -156,7 +156,7 @@
 				<figure id="figure-focus-background">
 					<img src="img/ntc-focus-background.png" alt="Three blue buttons, the center button is a lighter blue than the others." width="400" />
 					<figcaption>
-						The change of background within the component is not in scope of non-text contrast. However, this would not pass <a href="../20/use-of-color.html">Use of color</a>.
+						The change of background within the component is not in scope of non-text contrast. However, this would not pass <a href="use-of-color.html">Use of color</a>.
 					</figcaption>
 				</figure>
 


### PR DESCRIPTION
1. A link to Use Of Color was 404ing.
2. There was a duplicate id attribute that I remediated