### PR TITLE
Understanding 1.4.2: fix link to 1.4.7

### DIFF
--- a/understanding/20/audio-control.html
+++ b/understanding/20/audio-control.html
@@ -36,7 +36,7 @@
       </div>
       
       <p>See also 
-         <a href="low-or-no-background-audio">1.4.2: Low or No Background Audio</a>.
+         <a href="low-or-no-background-audio">1.4.7: Low or No Background Audio</a>.
       </p>
       
       


### PR DESCRIPTION
From Ginger Claassen on the wai-ig mailing list

> I was just looking at WCAG2.1 on the W3C website and when one opens understanding 1.4.2 there is a comment see also 1.4.2 no or low background audio which has to be 1.4.7.

https://www.w3.org/WAI/WCAG21/Understanding/audio-control

An issue was just opened about the same thing, so this also closes #3581 