### PR TITLE
Updating defintitions for focus appearance

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -591,6 +591,8 @@
 				
                 <dt data-include="terms/20/emergency.html" data-include-replace="true"></dt>
 
+                <dt data-include="terms/22/encloses.html" data-include-replace="true"></dt>
+
               	<dt data-include="terms/20/essential.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/extended-audio-description.html" data-include-replace="true"></dt>

--- a/guidelines/terms/22/encloses.html
+++ b/guidelines/terms/22/encloses.html
@@ -1,0 +1,7 @@
+<dt class="new"><dfn data-lt="enclose">encloses</dfn></dt>
+<dd class="new">
+	<p class="change">New</p>
+   					
+   <p>Solidly bounds or surrounds</p>
+   				
+</dd>

--- a/guidelines/terms/22/encompasses.html
+++ b/guidelines/terms/22/encompasses.html
@@ -1,7 +1,0 @@
-<dt class="new"><dfn data-lt="Focus">focus</dfn></dt>
-<dd class="new">
-	<p class="change">New</p>
-   					
-   <p>Continuously surrounds, bounds or includes the whole of</p>
-   				
-</dd>

--- a/guidelines/terms/22/minimum-bounding-box.html
+++ b/guidelines/terms/22/minimum-bounding-box.html
@@ -1,6 +1,6 @@
 <dt class="new"><dfn>minimum bounding box</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>	
-   <p>the smallest enclosing box within which all the points of a shape lie. Where a component consists of disconnected parts, such as a link that wraps onto multiple lines, each part is considered to have its own bounding box.</p>
+   <p>the smallest enclosing rectangle aligned to the horizontal axis within which all the points of a shape lie. Where a component consists of disconnected parts, such as a link that wraps onto multiple lines, each part is considered to have its own bounding box.</p>
 </dd>
 


### PR DESCRIPTION
The understanding doc versions were up to date, but needed transferring to the published versions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 28, 2022, 6:07 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwcag%2Ff7aaf32b32579b64fce76a83d343d146ffe921e1%2Fguidelines%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/4gbUwi?isPreview=true&publishDate=2022-04-28
ReSpec version: 32.1.4
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 28802ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:244:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wcag%232334.)._
</details>
