### PR TITLE
fix opening in new window link for G200

### DIFF
--- a/techniques/general/G200.html
+++ b/techniques/general/G200.html
@@ -32,7 +32,7 @@
    </ul></section><section id="resources"><h2>Resources</h2>
       
          <p>
-              <a href="http://www.webcredible.com/blog/beware-opening-links-new-window/">Beware of opening links in a new window</a>
+              <a href="https://www.sitepoint.com/beware-opening-links-new-window/">Beware of opening links in a new window</a>
             </p>
       
       


### PR DESCRIPTION
On [this page](https://www.w3.org/TR/WCAG20-TECHS/G200.html), the link in the resource section for "Beware of opening links in a new window"  was broken. I found a new link with similar content. https://www.sitepoint.com/beware-opening-links-new-window/