### PR TITLE
update to make links correct (issue #788)

### DIFF
--- a/techniques/index.html
+++ b/techniques/index.html
@@ -19,8 +19,8 @@
 			<ul id="masthead">
 				<li><strong>Authors:</strong> <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a></li>
 				<li><strong>Editors:</strong> <a href="mailto:group-ag-chairs@w3.org">Alastair Campbell, Michael Cooper, Andrew Kirkpatrick</a></li>
-				<li><strong>Editors' Draft:</strong> <a href="https://w3c.github.io/wcag/understanding/">https://w3c.github.io/wcag/techniques/</a></li>
-				<li><strong>Official Version:</strong> <a href="https://www.w3.org/WAI/WCAG22/Understanding/">https://www.w3.org/WAI/WCAG22/techniques/</a></li>
+				<li><strong>Editors' Draft:</strong> <a href="https://w3c.github.io/wcag/techniques/">https://w3c.github.io/wcag/techniques/</a></li>
+				<li><strong>Official Version:</strong> <a href="https://www.w3.org/WAI/WCAG22/techniques/">https://www.w3.org/WAI/WCAG22/techniques/</a></li>
 				<li><strong>File Issues</strong>: <a href="https://github.com/w3c/wcag/issues/">https://github.com/w3c/wcag/issues/</a></li>
 			</ul>
 			


### PR DESCRIPTION
- Editors Draft and Official Version URLs didn't match the visible link text