### PR TITLE
Issue 628 - update many broken links

### DIFF
--- a/understanding/20/audio-only-live.html
+++ b/understanding/20/audio-only-live.html
@@ -80,13 +80,7 @@
          
          <li>
             								       
-            <a href="http://www.captioningandsubtitling.com.au/work/internet/">Captioning and Subtitling International</a>
-            							     
-         </li>
-         
-         <li>
-            								       
-            <a href="http://webaim.org/techniques/captions/realtime">WebAIM Real time captioning resource</a>
+            <a href="https://webaim.org/techniques/captions/realtime">WebAIM Real time captioning resource</a>
             							     
          </li>
          

--- a/understanding/20/consistent-navigation.html
+++ b/understanding/20/consistent-navigation.html
@@ -94,7 +94,7 @@
             
             <p>A navigation menu includes a list of seven items with links to the main sections of
                a site.
-               When a user selects one of these items, a list of subnavigation items is inserted
+               When a user selects one of these items, a list of sub-navigation items is inserted
                into the top-level navigation menu.
                
             </p>
@@ -148,7 +148,7 @@
          
          <li> 
             
-            <a href="http://www-03.ibm.com/able/access_ibm/disability.html">Understanding disability issues when designing Web sites</a>.
+            <a href="https://www.ibm.com/able/toolkit/design/ux/navigation/">IBM: User experience design - Navigation</a>.
          </li>
          
       </ul>

--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -232,31 +232,25 @@
          
          <li>
             								       
-            <a href="https://www.paciellogroup.com/resources/contrastanalyser/">Contrast Analyser – Application</a>
+            <a href="https://www.tpgi.com/color-contrast-checker/">Colour Contrast Analyser application</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
+            <a href="https://juicystudio.com/services/luminositycontrastratio.php">Luminosity Colour Contrast Ratio Analyser</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
+            <a href="https://snook.ca/technical/colour_contrast/colour.html">Colour Contrast Check</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://snook.ca/technical/colour_contrast/colour.html">Colour Contrast Check</a>
-            							     
-         </li>
-         
-         <li>
-            								       
-            <a href="http://www.msfw.com/accessibility/tools/contrastratiocalculator.aspx">Contrast Ratio Calculator</a>
+            <a href="https://www.msfw.com/Services/ContrastRatioCalculator">Contrast Ratio Calculator</a>
             							     
          </li>
          
@@ -280,25 +274,13 @@
          
          <li>
             
-            <a href="http://uxmovement.com/content/6-surprising-bad-practices-that-hurt-dyslexic-users/">6 Surprising Bad Practices That Hurt Dyslexic Users</a>
+            <a href="https://www.iansyst.co.uk/fonts/">Reading with Dyslexia &mdash; Fonts that can help alleviate visual stress.</a>
             
          </li>
          
          <li>
             
-            <a href="http://accessites.org/site/2006/11/designing-for-dyslexics-part-3-of-3">Design for Dyslexics</a>
-            
-         </li>
-         
-         <li>
-            
-            <a href="http://www.iansyst.co.uk/articles/article/articles/2012/10/18/fonts-for-dyslexia">Typefaces for Dyslexia</a>
-            
-         </li>
-         
-         <li>
-            
-            <a href="http://www.dyslexia.com/library/webdesign.htm">Web Design for Dyslexia</a>
+            <a href="https://blog.dyslexia.com/good-fonts-for-dyslexia-an-experimental-study/">Good Fonts for Dyslexia &mdash; An Experimental Study</a>
             
          </li>
          

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -298,31 +298,25 @@
          
          <li>
             								       
-            <a href="https://www.paciellogroup.com/resources/contrastanalyser/">Contrast Analyser – Application</a>
+            <a href="https://www.tpgi.com/color-contrast-checker/">Colour Contrast Analyser application</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
+            <a href="https://juicystudio.com/services/luminositycontrastratio.php">Luminosity Colour Contrast Ratio Analyser</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
+            <a href="https://snook.ca/technical/colour_contrast/colour.html">Colour Contrast Check</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://snook.ca/technical/colour_contrast/colour.html">Colour Contrast Check</a>
-            							     
-         </li>
-         
-         <li>
-            								       
-            <a href="http://www.msfw.com/accessibility/tools/contrastratiocalculator.aspx">Contrast Ratio Calculator</a>
+            <a href="https://www.msfw.com/Services/ContrastRatioCalculator">Contrast Ratio Calculator</a>
             							     
          </li>
          
@@ -346,26 +340,24 @@
          
          <li>
             								       
-            <a href="http://www.vischeck.com/daltonize/runDaltonize.php">Tool to convert images based on color loss so that contrast is restored as luminance
-               contrast when there was only color contrast (that was lost due to color deficiency)
-            </a>
-            							     
+            <a href="https://www.vischeck.com/daltonize/runDaltonize.php">Tool to convert images based on color loss</a> so that contrast is restored as luminance contrast when there was only color contrast (that was lost due to color deficiency)
+         							     
          </li>
          
          <li>
             								       
-            <a href="http://www.456bereastreet.com/archive/200709/10_colour_contrast_checking_tools_to_improve_the_accessibility_of_your_design/">List of color contrast tools</a>
+            <a href="https://www.456bereastreet.com/archive/200709/10_colour_contrast_checking_tools_to_improve_the_accessibility_of_your_design/">List of color contrast tools</a>
             							     
          </li>
 
          <li>
          	
-         	<a href="https://www.aph.org/research/design-guidelines/">The American Printing House for the Blind Guidelines for Large Printing</a>
+         	<a href="https://www.aph.org/resources/large-print-guidelines/">The American Printing House for the Blind Guidelines for Large Printing</a>
          </li>
 
          <li>
          	
-         	<a href="https://www.loc.gov/nlsold/reference/guides/largeprint.html">National Library Service for the Blind and Physically Handicapped (NLS), The Library of Congress Guidelines for Large Print</a>
+         	<a href="https://www.loc.gov/nls/resources/general-resources-on-disabilities/large-print-materials/">National Library Service for the Blind and Physically Handicapped (NLS), The Library of Congress reference guide on large print materials</a>
          </li>
          
       </ul>

--- a/understanding/20/navigable.html
+++ b/understanding/20/navigable.html
@@ -28,9 +28,7 @@
          
       </p>
       
-      <p>As described in The 
-         <a href="http://www.motive.co.nz/glossary/navigation.php">Motive Web Design Glossary</a>, navigation has two main functions:
-      </p>
+      <p>Navigation has two main functions:</p>
       
       <ul>
          

--- a/understanding/20/page-titled.html
+++ b/understanding/20/page-titled.html
@@ -155,16 +155,16 @@
          
          <li> 
             
-            <a href="http://www.socialpatterns.com/search-engine-optimization/writing-better-web-page-titles/">Writing Better Web Page Titles</a> How to write titles for Web pages that will enhance search engine effectiveness.
+            <a href="https://socialpatterns.com/writing-better-titles/">Writing Better Web Page Titles</a>. How to write titles for Web pages that will enhance search engine effectiveness.
          </li>
          
          <li> 
             
-            <a href="http://redish.net/images/stories/PDF/interactions.html">Guidelines for Accessible and Usable Web Sites: Observing Users Who Work With Screen
-               Readers
+            <a href="https://redish.net/wp-content/uploads/Theorfanos_Redish_InteractionsPaperAuthorsVer.pdf">Guidelines for Accessible and Usable Web Sites: Observing Users Who Work With Screen
+               Readers (PDF)
             </a>. Theofanos, M.F., and Redish, J. (2003).  Interactions, Volume X, Issue 6, November-December
             2003, pages 38-51, 
-            <a href="http://dl.acm.org/citation.cfm?doid=947226.947227">http://dl.acm.org/citation.cfm?doid=947226.947227</a>
+            <a href="https://dl.acm.org/doi/10.1145/947226.947227">https://dl.acm.org/doi/10.1145/947226.947227</a>
             							     
          </li>
          

--- a/understanding/20/reading-level.html
+++ b/understanding/20/reading-level.html
@@ -282,77 +282,56 @@
       
       <ul>
          
-         <li>The Plain Language Association INternational (PLAIN) Web site provides many useful
-            resources to help writers produce documents that communicate clearly in a variety
-            of cultural and rhetorical contexts. Refer to: 
-            <a href="http://plainlanguagenetwork.org/">http://plainlanguagenetwork.org/</a>.
+         <li>The <a href="https://plainlanguagenetwork.org/">Plain Language Association International</a> (PLAIN) Web site provides many useful resources to help writers produce documents that communicate clearly in a variety of cultural and rhetorical contexts.
             
          </li>
          
          <li> 
             
-            <a href="http://www.plainlanguage.gov ">The US Government's plain language Web site</a> provides general information about plain language as well as information about use
+            <a href="https://www.plainlanguage.gov/">The US Government's plain language Web site</a> provides general information about plain language as well as information about use
             of plain language in US Government documents, including legal requirements
          </li>
          
          <li> 
             
-            <a href="http://www.plainenglish.co.uk/">The Plain English Campaign Web site</a> provides useful information and guidance for authors writing in English. 
+            <a href="https://www.plainenglish.co.uk/">The Plain English Campaign Web site</a> provides useful information and guidance for authors writing in English. 
          </li>
          
          <li> 
             
-            <a href="http://juicystudio.com/services/readability.php">Juicy Studio's Readability Test</a> analyzes the readability of all rendered content. 
+            <a href="https://juicystudio.com/services/readability.php">Juicy Studio's Readability Test</a> analyzes the readability of all rendered content. 
             
             
          </li>
          
          <li>
             								       
-            <a href="http://dublincore.org/documents/usageguide/qualifiers.shtml">Entry for Audience Education Level. Using Dublin Core – Dublin Core Qualifiers</a>
+            <a href="https://www.dublincore.org/specifications/dublin-core/usageguide/qualifiers/">Entry for Audience Education Level. Using Dublin Core – Dublin Core Qualifiers</a>
             							     
          </li>
          
          <li>
             								       
-            <a href="http://www.imsglobal.org/profiles/lipinfo01.html#tab6.3">IMS Learner Information Packaging Model Information Specification, Table 6.3  "accessibility"
+            <a href="https://www.imsglobal.org/profiles/lipinfo01.html#tab6.3">IMS Learner Information Packaging Model Information Specification, Table 6.3  "accessibility"
                learner information data structure detailed description
             </a>
             							     
          </li>
          
-         <li> 
-            
-            <a href="http://www.textquest.de/pages/en/analysis-of-texts/readability-analysis.php">TextQuest.de</a> lists references for readability formulas for different languages, including English,
-            German, Spanish, Dutch, French, and Swedish.
-         </li>
-         
-         <li> 
-            
-            <a href="http://taalunieversum.org/publicaties/geletterd_in_de_lage_landen/richtlijnen.php">
-               Richtlijnen Keurmerk Makkelijk Lezen
-               
-            </a> are the guidelines used by the Stichting Makkelijk Lezen (Easy Reading Foundation). 
-            
-            
-         </li>
-         
          <li>
             
-            <a href="http://www.leesbaarnederlands.nl/">
-               Leesbaar Nederlands
+            <a href="https://www.leesbaarnederlands.nl/">
+               <span lang="nl">Leesbaar Nederlands</span>
                
             </a> ("Readable Dutch") contains guidelines for writing text that is accessible for people
             with a reading disability. These guidelines address language, content and design.
-            
-            
             
          </li>
          
          
          <li>
             								       
-            <a href="http://inclusion-europe.eu/">European Easy-to-Read Guidelines</a>
+            <a href="https://www.inclusion-europe.eu/">European Easy-to-Read Guidelines</a>
             							     
          </li>
          

--- a/understanding/20/three-flashes-or-below-threshold.html
+++ b/understanding/20/three-flashes-or-below-threshold.html
@@ -126,7 +126,7 @@
          
          <li>
             								       
-            <a href="http://www.hardingfpa.com/">Harding FPA Web Site</a>
+            <a href="https://www.hardingfpa.com/">Harding FPA Web Site</a>
             							     
          </li>
          
@@ -150,16 +150,10 @@
          
          <li>
             	
-            <a href="http://www.epilepsy.com/learn/triggers-seizures/photosensitivity-and-seizures">Epilepsy Foundation</a>
+            <a href="http://www.epilepsy.com/learn/triggers-seizures/photosensitivity-and-seizures">Epilepsy Foundation &mdash; Photosensitivity and Seizures</a>
             							     
          </li>
-         
-         <li>
-            								       
-            <a href="http://www.ofcom.org.uk/static/archive/itc/itc_publications/codes_guidance/flashing_images/index.asp.html">ITC Guidance Note for Licensees on Flashing Images and Regular Patterns in Television</a>
-            							     
-         </li>
-         
+      
       </ul>
       
    </section>

--- a/understanding/20/three-flashes.html
+++ b/understanding/20/three-flashes.html
@@ -89,7 +89,7 @@
          
          <li>
             								       
-            <a href="http://www.hardingfpa.com/">Harding FPA Web Site</a>
+            <a href="https://www.hardingfpa.com/">Harding FPA Web Site</a>
             							     
          </li>
          
@@ -113,13 +113,7 @@
          
          <li>
             	
-            <a href="http://www.epilepsy.com/learn/triggers-seizures/photosensitivity-and-seizures">Epilepsy Foundation</a>
-            							     
-         </li>
-         
-         <li>
-            								       
-            <a href="http://www.ofcom.org.uk/static/archive/itc/itc_publications/codes_guidance/flashing_images/index.asp.html">ITC Guidance Note for Licensees on Flashing Images and Regular Patterns in Television</a>
+            <a href="http://www.epilepsy.com/learn/triggers-seizures/photosensitivity-and-seizures">Epilepsy Foundation &mdash; Photosensitivity and Seizures</a>
             							     
          </li>
          

--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -162,7 +162,7 @@
          
          <li>
             								       
-            <a href="http://www.vischeck.com/">Vischeck</a>
+            <a href="https://www.vischeck.com/">Vischeck</a>
             							     
          </li>
          
@@ -180,7 +180,7 @@
          
          <li>
             								       
-            <a href="https://msdn.microsoft.com/en-us/library/bb263953.aspx">Microsoft: Can Color-Blind Users See Your Site?</a>
+            <a href="https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness">Microsoft: Verify that a page is usable by people with color blindness</a>
             							     
          </li>
          
@@ -192,7 +192,7 @@
          
          <li>
             								       
-            <a href="http://jfly.iam.u-tokyo.ac.jp/color/">How to make figures and presentations that are friendly to Colorblind people</a>
+            <a href="https://jfly.uni-koeln.de/color/">How to make figures and presentations that are friendly to Colorblind people</a>
             							     
          </li>
          


### PR DESCRIPTION
closes #628.

## Notes
1. I checked every resource link rather than just the ones reported. Many more links had become broken since issue 628 was opened in 2019.
2. Where sites have updated to https, those links have been updated.
4. Some sites have gone offline completely and some products have become unavailable.
5. The only page that wasn't just updated URLs was the update to "navigable". This is because the link in question was part of the page's main content. There are so many definitions of "navigation" that I made the decision to remove the link rather than find a new definition and make edits to the page's content. If this is an issue, that can be re-visited.
6. It would be really good to have a rule that says "please don't just report a broken link, please also supply an updated one".