### PR TITLE
Update pseudo-elements

### DIFF
--- a/techniques/css/C22.html
+++ b/techniques/css/C22.html
@@ -22,9 +22,9 @@
          <li>The text-transform property is used to control the case of letters in text.</li>
          <li>The letter-spacing property is used to control the spacing of letters in text.</li>
          <li>The background-image property can be used to display text on a non-text background.</li>
-         <li>The first-line pseudo class can be used to modify the presentation of the first line in a block of text.</li>
-         <li>The :first-letter pseudo class can be used to modify the presentation of the first letter in a block of text.</li>
-         <li>The :before and :after pseudo classes can be used to insert decorative non-text content before or after blocks of text.</li>
+         <li>The <code>:first-line</code> pseudo-element can be used to modify the presentation of the first line in a block of text.</li>
+         <li>The <code>::first-letter</code> pseudo-element can be used to modify the presentation of the first letter in a block of text.</li>
+         <li>The <code>::before</code> and <code>::after</code> pseudo-elements can be used to insert decorative non-text content before or after blocks of text.</li>
       </ul>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
@@ -249,7 +249,7 @@ p { line-height:2em; }
       <section class="example">
          <h3>Using CSS first-line to control the presentation of the first line of text</h3>
          
-            <p>The CSS :first-line pseudo class is used to display the first line of text in a larger, red font.</p>
+            <p>The CSS <code>::first-line</code> pseudo-element is used to display the first line of text in a larger, red font.</p>
             <p>The XHTML component:</p>
          
          <pre xml:space="preserve">
@@ -260,13 +260,13 @@ p { line-height:2em; }
             <p>The CSS component:</p>
          
          <pre xml:space="preserve">
-.startline:first-line { font-size:2em; color:#990000; }
+.startline::first-line { font-size:2em; color:#990000; }
 </pre>
       </section>
       <section class="example">
          <h3> Using CSS first-letter to control the presentation of the first letter of text</h3>
          
-            <p>The CSS :first-letter pseudo class is used to display the first letter in a larger font size, red and vertically aligned in the middle.</p>
+            <p>The CSS <code>::first-letter</code> pseudo-element is used to display the first letter in a larger font size, red and vertically aligned in the middle.</p>
             <p>The XHTML component:</p>
          
          <pre xml:space="preserve">
@@ -276,7 +276,7 @@ p { line-height:2em; }
             <p>The CSS component:</p>
          
          <pre xml:space="preserve">
-.startletter:first-letter { font-size:2em; color:#990000; vertical-align:middle; }
+.startletter::first-letter { font-size:2em; color:#990000; vertical-align:middle; }
 </pre>
       </section>
    </section><section id="tests"><h2>Tests</h2>

--- a/techniques/css/C9.html
+++ b/techniques/css/C9.html
@@ -15,8 +15,8 @@
          <li> 
                background-image, </li>
          <li>
-								       content, combined with the :before and
-                                    :after pseudo-elements, </li>
+								       content, combined with the <code>::before</code> and
+                                    <code>::after</code> pseudo-elements, </li>
          <li> 
                list-style-image. </li>
       </ul>

--- a/techniques/failures/F87.html
+++ b/techniques/failures/F87.html
@@ -60,7 +60,7 @@ q::after  { content: close-quote }</pre>
       
          <ul>
             <li>
-                  <a href="https://www.w3.org/TR/CSS21/generate.html">CSS 2.1: Generated content, automatic numbering, and lists</a>
+                  <a href="https://www.w3.org/TR/selectors-3/#pseudo-elements">Selectors Level 3: 7. Pseudo-elements</a>
                </li>
          </ul>
       

--- a/techniques/failures/F87.html
+++ b/techniques/failures/F87.html
@@ -1,20 +1,20 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Failure of Success Criterion 1.3.1 due to inserting non-decorative content by using :before and :after pseudo-elements and the 'content' property in CSS</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 1.3.1 due to inserting non-decorative content by using :before and :after pseudo-elements and the 'content' property in CSS</h1><section class="meta"><p class="id">ID: F87</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
+<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Failure of Success Criterion 1.3.1 due to inserting non-decorative content by using ::before and ::after pseudo-elements and the 'content' property in CSS</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 1.3.1 due to inserting non-decorative content by using ::before and ::after pseudo-elements and the 'content' property in CSS</h1><section class="meta"><p class="id">ID: F87</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies that support CSS.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>The CSS :before and :after pseudo-elements specify the location of content before and after an element's document tree content. The content property, in conjunction with these pseudo-elements, specifies what is inserted. For users who need to customize style information in order to view content according to their needs, they may not be able to access the information that is inserted using CSS. Therefore, it is a failure to use these properties to insert non-decorative content.</p>
+      <p>The CSS <code>::before</code> and <code>::after</code> pseudo-elements specify the location of content before and after an element's document tree content. The content property, in conjunction with these pseudo-elements, specifies what is inserted. For users who need to customize style information in order to view content according to their needs, they may not be able to access the information that is inserted using CSS. Therefore, it is a failure to use these properties to insert non-decorative content.</p>
   <p class="note">A common way to test this critieria is to disable CSS styles to view whether content added using pseudo-elements remains visible.</p>
   
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          
-            <p>In the following example, :before and :after are used to indicate speaker changes and to insert quotation marks in a screenplay.</p>
+            <p>In the following example, <code>::before</code> and <code>::after</code> are used to indicate speaker changes and to insert quotation marks in a screenplay.</p>
             <p>The CSS contains:</p>
          
-         <pre xml:space="preserve"> p.jim:before {	content: "Jim: " }
-p.mary:before { content: "Mary: " }
+         <pre xml:space="preserve"> p.jim::before {	content: "Jim: " }
+p.mary::before { content: "Mary: " }
 
-q:before { content: open-quote }
-q:after  { content: close-quote }</pre>
+q::before { content: open-quote }
+q::after  { content: close-quote }</pre>
          
             <p>It is used in this excerpt:</p>
          
@@ -44,7 +44,7 @@ q:after  { content: close-quote }</pre>
       </section>
    </section><section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
-  <p>For each instance of content inserted through use of the :before and :after pseudo-elements and the content property:</p>
+  <p>For each instance of content inserted through use of the <code>::before</code> and <code>::after</code> pseudo-elements and the content property:</p>
         <ol>
             <li>Check that non-decorative information presented by the generated content is available when styles are overridden.</li>
          </ol>

--- a/techniques/toc.html
+++ b/techniques/toc.html
@@ -241,7 +241,7 @@
       <li><a href="failures/F86">F86: Failure of Success Criterion 4.1.2 due to not providing names for each part of a multi-part
             form field, such as a US telephone number</a></li>
       <li><a href="failures/F87">F87: Failure of Success Criterion 1.3.1 due to inserting non-decorative content by using
-            :before and :after pseudo-elements and the 'content' property in CSS</a></li>
+            ::before and ::after pseudo-elements and the 'content' property in CSS</a></li>
       <li><a href="failures/F88">F88: Failure of Success Criterion 1.4.8 due to using text that is justified (aligned to
             both the left and the right margins)</a></li>
       <li><a href="failures/F89">F89: Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible


### PR DESCRIPTION
Double colons (::) should be used instead of a single colon (:).

See also: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements