### PR TITLE
mark up changes of language in 3.1.2 Understanding document

### DIFF
--- a/understanding/20/language-of-parts.html
+++ b/understanding/20/language-of-parts.html
@@ -134,8 +134,7 @@
                <strong>Alternative language links</strong>							     
             </p>
             <p>An HTML Web page includes links to versions of the page in other languages (e.g.,
-               <span lang="de">Deutsch</span>, <span lang="fr">Français</span>, <span lang="nl">Nederlands</span>, <span lang="es">Castellano</span>, etc.). The text of each link is the name
-               of the language, in that language. The language of each link is indicated via a <code class="att">lang</code> attribute.
+               <span lang="de">Deutsch</span>, <span lang="fr">Français</span>, <span lang="nl">Nederlands</span>, <span lang="ca">Catalan</span>, etc.). The text of each link is the name of the language, in that language. The language of each link is indicated via a <code class="att">lang</code> attribute.
             </p>
          </li>
          <li>
@@ -143,9 +142,7 @@
                <strong>"Podcast" used in a French sentence.</strong>							     
             </p>
             <p>Because "podcast" is part of the vernacular of the immediately surrounding text in
-               the following excerpt, "<span lang="fr">À l'occasion de l'exposition "Energie éternelle. 1500 ans d'art indien", le Palais
-               des Beaux-Arts de Bruxelles a lancé son premier podcast. Vous pouvez télécharger ce
-               podcast au format M4A et MP3</span>", no indication of language change is required.
+               the following excerpt, "<span lang="fr">À l'occasion de l'exposition "Energie éternelle. 1500 ans d'art indien", le Palais des Beaux-Arts de Bruxelles a lancé son premier podcast. Vous pouvez télécharger ce podcast au format M4A et MP3</span>", no indication of language change is required.
             </p>
          </li>
       </ol>
@@ -153,7 +150,7 @@
    
    <section id="resources">
       <h2>Resources for Language of Parts</h2>
-      
+
       <ul>
          <li>
             <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">HTML - The <code class="att">lang</code> and <codec class="att">xml:lang</code> attributes</a>.

--- a/understanding/20/language-of-parts.html
+++ b/understanding/20/language-of-parts.html
@@ -7,8 +7,7 @@
 </head>
 <body>
    <h1>Understanding Language of Parts</h1>
-   
-   
+
    <section id="intent">
       <h2>Intent of Language of Parts</h2>
       
@@ -31,8 +30,7 @@
       </p>
       
       <p>When no other language has been specified for a phrase or passage of text, its human
-         language is the default human language of the Web page (see Success Criterion 3.1.1).
-         So the human language of all content in single language documents can be programmatically
+         language is the default human language of the Web page (see <a href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html">Success Criterion 3.1.1</a>). So the human language of all content in single language documents can be programmatically
          determined. 
       </p>
       
@@ -48,7 +46,6 @@
          whether a change in language is intended, consider whether the word would be pronounced
          the same (except for accent or intonation) in the language of the immediately surrounding
          text.
-         
       </p>
       
       <p>Most professions require frequent use of technical terms which may originate from
@@ -60,9 +57,7 @@
          and habeas corpus.
       </p>
       
-      <p>Identifying changes in language is important for a number of reasons:
-         	
-      </p>
+      <p>Identifying changes in language is important for a number of reasons:</p>
       
       <ul>
          
@@ -74,8 +69,8 @@
          <li>Speech synthesizers that support multiple languages will be able to speak the text
             in the appropriate accent with proper pronunciation. If changes are not marked, the
             synthesizer will try its best to speak the words in the  default language it works
-            in. Thus, the French word for car, "voiture" would be pronounced "voyture" by a speech
-            synthesizer that uses English as its  default language. 
+            in. Thus, the French word for car, "<span lang="fr">voiture</span>" would be pronounced "voyture" by a speech
+            synthesizer that uses English as its default language. 
          </li>
          
          <li>Marking changes in language can benefit future developments in technology, for example
@@ -94,11 +89,9 @@
    <section id="benefits">
       <h2>Benefits of Language of Parts</h2>
       
-      
       <p>This Success Criterion helps:</p>
       
       <ul>
-         
          <li>people who use screen readers or other technologies that convert text into synthetic
             speech;
          </li>
@@ -124,80 +117,53 @@
    <section id="examples">
       <h2>Examples of Language of Parts</h2>
       
-      
-      <ol>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A German phrase in an English sentence. </strong>
-               							     
+      <ol>   
+         <li>  
+            <p>  								       
+               <strong>A German phrase in an English sentence.</strong>							     
             </p>
-            
             <p>In the sentence, "He maintained that the DDR (German Democratic Republic) was just
-               a 'Treppenwitz der Weltgeschichte'," the German phrase 'Treppenwitz der Weltgeschichte' is marked as German. Depending on the markup language, English may either be marked
+               a '<span lang="de">Treppenwitz der Weltgeschichte</span>'," the German phrase '<span lang="de">Treppenwitz der Weltgeschichte</span>' is marked as German. Depending on the markup language, English may either be marked
                as the language for the entire document except where specified, or marked at the paragraph
                level. When a screen reader encounters the German phrase, it changes pronunciation
                rules from English to German to pronounce the word correctly.
             </p>
-            
          </li>
-         
          <li>
-            
-            <p>
-               								       
-               <strong>Alternative language links</strong>
-               							     
+            <p>  								       
+               <strong>Alternative language links</strong>							     
             </p>
-            
             <p>An HTML Web page includes links to versions of the page in other languages (e.g.,
-               Deutsch, Français, Nederlands, Castellano, etc.). The text of each link is the name
-               of the language, in that language. The language of each link is indicated via a lang attribute.
-               
+               <span lang="de">Deutsch</span>, <span lang="fr">Français</span>, <span lang="nl">Nederlands</span>, <span lang="es">Castellano</span>, etc.). The text of each link is the name
+               of the language, in that language. The language of each link is indicated via a <code class="att">lang</code> attribute.
             </p>
-            
          </li>
-         
          <li>
-            
-            <p>
-               								       
-               <strong>"Podcast" used in a French sentence.</strong>
-               							     
+            <p>  								       
+               <strong>"Podcast" used in a French sentence.</strong>							     
             </p>
-            
             <p>Because "podcast" is part of the vernacular of the immediately surrounding text in
-               the following excerpt, "À l'occasion de l'exposition "Energie éternelle. 1500 ans d'art indien", le Palais
+               the following excerpt, "<span lang="fr">À l'occasion de l'exposition "Energie éternelle. 1500 ans d'art indien", le Palais
                des Beaux-Arts de Bruxelles a lancé son premier podcast. Vous pouvez télécharger ce
-               podcast au format M4A et MP3," no indication of language change is required.
+               podcast au format M4A et MP3</span>", no indication of language change is required.
             </p>
-            
          </li>
-         
       </ol>
-      
    </section>
    
    <section id="resources">
       <h2>Resources for Language of Parts</h2>
       
-      
       <ul>
-         
-         <li> 
-            
-            <a href="https://www.w3.org/International/articles/language-tags/Overview.en.php">Language tags in HTML and XML</a> - W3C Internationalization Working Group
-         </li>
-         
          <li>
-            								       
-            <a href="https://www.w3.org/TR/i18n-html-tech-lang/">Internationalization Best Practices: Specifying Language in XHTML &amp; HTML Content</a>
-            							     
+            <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">HTML - The <code class="att">lang</code> and <codec class="att">xml:lang</code> attributes</a>.
+            </li>
+         <li>
+            <a href="https://www.w3.org/International/articles/language-tags/index.en">Language tags in HTML and XML</a>.
          </li>
-         
-         
+         <li>							       
+            <a href="https://www.w3.org/TR/i18n-html-tech-lang/">Authoring HTML: Language declarations</a>.							     
+         </li>
       </ul>
       
    </section>
@@ -205,25 +171,16 @@
    <section id="techniques">
       <h2>Techniques for Language of Parts</h2>
       
-      
       <section id="sufficient">
          <h3>Sufficient Techniques for Language of Parts</h3>
-         
-         
-         <ol>
-            
-            <li>
-               									         
-               <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H58" class="html">Using the lang attribute to identify changes in the human language</a>
-               								       
+      
+         <ol> 
+            <li>  									         
+               <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H58" class="html">Using the lang attribute to identify changes in the human language</a>.	       
             </li>
-            
             <li>
-               
-               <a href="https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF19" class="pdf"></a>
-               
+               <a href="https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF19" class="pdf">Specifying the language for a passage or phrase with the Lang entry in PDF documents</a>.
             </li>
-            
          </ol>
          
       </section>


### PR DESCRIPTION
Marked up changes of language.

Also:
1. Updated Resources links to add a link to the current HTML spec and update W3C document titles.
2. Added a link to the existing text telling the user to reference that document.

Closes #2497