### PR TITLE
Issue 2505: re-title H54 to use "term" instead of "word"

### DIFF
--- a/techniques/html/H54.html
+++ b/techniques/html/H54.html
@@ -1,47 +1,76 @@
-<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using the dfn element to identify the defining instance of a word</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Using the <code class="el">dfn</code> element to identify the defining instance of a word</h1><section class="meta"><p class="id">ID: H54</p><p class="technology">Technology: html</p><p class="type">Type: Technique</p></section><section id="applicability"><h2>When to Use</h2>
-      <p>HTML and XHTML</p>
-   </section><section id="description"><h2>Description</h2>
-      <p>The objective of this technique is to use the <code class="el">dfn</code> to mark the use of a
+<!DOCTYPE html>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <title>Using the dfn element to identify the defining instance of a term</title>
+      <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove"></link>
+   </head>
+   <body>
+      <h1>Using the <code class="el">dfn</code> element to identify the defining instance of a term</h1>
+      <section class="meta">
+         <p class="id">ID: H54</p>
+         <p class="technology">Technology: html</p>
+         <p class="type">Type: Technique</p>
+      </section>
+      <section id="applicability">
+         <h2>When to Use</h2>
+         <p>HTML</p>
+      </section>
+      <section id="description">
+         <h2>Description</h2>
+         <p>The objective of this technique is to use the <code class="el">dfn</code> to mark the use of a
             word or phrase where it is defined. The <code class="el">dfn</code> element is used to indicate the
             defining instance of the enclosed term. In other words, it marks the occurrence of the
             term where the term is defined. Note that it encloses the term, not the definition. This
-            technique would be used in combination with <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G112">Using
-              inline definitions</a> to provide the definition.</p>
-   </section><section id="examples"><h2>Examples</h2>
-      <section class="example">
+            technique would be used in combination with <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G112">Using inline definitions</a> to provide the definition.</p>
+         </section>
+         <section id="examples">
+            <h2>Examples</h2>
+            <section class="example">
          
             <p>The following code snippet demonstrates the use of the <code class="el">dfn</code>
               element.</p>
-         
-         <pre xml:space="preserve">&lt;p&gt;The Web Content Accessibility Guidelines require that non-text content
+
+              <pre xml:space="preserve">&lt;p&gt;The Web Content Accessibility Guidelines require that non-text content
 has a text alternative. &lt;dfn&gt;Non-text content&lt;/dfn&gt; is content that is not a sequence
 of characters that can be programmatically determined or where the sequence is
-not expressing something in human language; this includes ASCII Art (which is a
-pattern of characters), emoticons, leetspeak (which is character substitution), and
-images representing text .&lt;/p&gt; </pre>
-      </section>
-   </section><section id="tests"><h2>Tests</h2>
-      <section class="procedure"><h3>Procedure</h3>
-         <ol>
-            <li>Identify all words that are defined inline in the text, that is, where the
+not expressing something in human language; this includes 
+&lt;dfn&gt;&lt;abbr title="American Standard Code for Information Interchange"&gt;ASCII&lt;/abbr&gt;
+Art&lt;/dfn&gt; (which is a pattern of characters), emoticons, &lt;dfn&gt;leetspeak&lt;/dfn&gt;
+(which is character substitution), and images representing text.&lt;/p&gt; </pre>
+            </section>
+         </section>
+         <section id="tests">
+            <h2>Tests</h2>
+            <section class="procedure">
+               <h3>Procedure</h3>
+               <ol>
+                  <li>Identify all words that are defined inline in the text, that is, where the
                   definition occurs in a sentence near an occurrence of the word. </li>
-            <li>Check that each word that is defined inline is contained in a <code class="el">dfn</code>
-                  element. </li>
-         </ol>
+                  <li>Check that each word that is defined inline is contained in a <code class="el">dfn</code>
+                  element.</li>
+               </ol>
       </section>
-      <section class="results"><h3>Expected Results</h3>
+      <section class="results">
+         <h3>Expected Results</h3>
          <ul>
             <li>Check #2 is true.</li>
          </ul>
       </section>
-   </section><section id="related"><h2>Related Techniques</h2><ul>
-      <li><a href="../general/G112">G112</a></li>
-   </ul></section><section id="resources"><h2>Resources</h2>
-      
+   </section>
+   <section id="related">
+      <h2>Related Techniques</h2>
+      <ul>
+         <li>
+            <a href="../general/G112">G112</a>
+         </li>
+      </ul>
+   </section>
+   <section id="resources">
+      <h2>Resources</h2>
          <ul>
-            <li>HTML 4.01 <a href="https://www.w3.org/TR/html4/struct/text.html#edef-DFN">DFN
-                    Element</a>
-								       </li>
+            <li>
+               <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element">HTML - the <code class="el">def</code> element</a>.
+            </li>
          </ul>
       
    </section></body></html>

--- a/techniques/toc.html
+++ b/techniques/toc.html
@@ -522,7 +522,7 @@
       <li><a href="html/H49">H49: Using semantic markup to mark emphasized or special text</a></li>
       <li><a href="html/H51">H51: Using table markup to present tabular information</a></li>
       <li><a href="html/H53">H53: Using the body of the object element</a></li>
-      <li><a href="html/H54">H54: Using the dfn element to identify the defining instance of a word</a></li>
+      <li><a href="html/H54">H54: Using the dfn element to identify the defining instance of a term</a></li>
       <li><a href="html/H56">H56: Using the dir attribute on an inline element to resolve problems with nested directional
             runs</a></li>
       <li><a href="html/H57">H57: Using the language attribute on the HTML element</a></li>

--- a/understanding/20/unusual-words.html
+++ b/understanding/20/unusual-words.html
@@ -208,7 +208,7 @@
                            
                            <li>
                               														                   
-                              <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H54" class="html">Using the dfn element to identify the defining instance of a word</a>
+                              <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H54" class="html">Using the dfn element to identify the defining instance of a term</a>
                               													                 
                            </li>
                            
@@ -334,7 +334,7 @@
                            
                            <li>
                               														                   
-                              <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H54" class="html">Using the dfn element to identify the defining instance of a word</a>
+                              <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H54" class="html">Using the dfn element to identify the defining instance of a term</a>
                               													                 
                            </li>
                            


### PR DESCRIPTION
Closes #2505 

Also:
1. Update TOC page.
2. Update Unusual Words.
3. Update Resources link from HTML 4.01 to HTML Living Standard.
4. Update code example to define more terms that were in it.