### PR TITLE
Update labels-or-instructions.html

### DIFF
--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -23,6 +23,8 @@
          only when the individual control has focus especially when instructions are long and
          verbose.
       </p>
+     <p>Visible labels must remain present when users interact with a form control. Text provided on fields via the placeholder attribute disappears once users enter text. The placeholder text may provide helpful examples of the type of content expected, but is not sufficent on its own as a visible label.</p>
+     <p>A select must generally have a separate label to identify the category of options included. Thus, the label "City" may describe the category under which all possible options (names of cities) fall. Depending on the context, users may not be able to infer the category (and the meaning of the select)  if only the option is presented. The default option is generally not sufficient as visible label unless the context of the form makes its meaning visually obvious for all options that the user may select.</p>
       
       <p>The intent of this Success Criterion is not to clutter the page with unnecessary information
          but to provide important cues and instructions that will benefit people with disabilities.
@@ -78,7 +80,6 @@
       
       
       <ul>
-         
          <li>A field which requires the user to enter the two character abbreviation for a US state
             has a link next to it which will popup an alphabetized list of state names and the
             correct abbreviation.


### PR DESCRIPTION
In response to #2509 I have tried to revise the current [Understanding text of 3.3.2 Labels and instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html), section Intent, adding the reqirement that the label should be permanently available. 

- `placeholder` (not sufficient as label since it disappears)
- default `option` of `select` (generally not sufficient as visible label unless the context of the form makes its meaning obvious)

I can think of cases where mandating an extra visible label for `select` might be wrong, as in cases where selects are embedded in inline texts. This may happen in language tests or probably other contexts (say, "It was `<select><option>wonderful</option><option>so, so</option><option>horrific</option></select>` to meet so many new people.") Maybe not a good example, but you get the idea.  I would shy away from mandating an explicit visible label for `select` in all possible cases. 

I would add examples to underpin these additions once there is a bit of feedback on the proposed changes, and it appears the changes makes sense to other WG members.