### PR TITLE
Correct F99 expected results

### DIFF
--- a/techniques/failures/F99.html
+++ b/techniques/failures/F99.html
@@ -59,7 +59,7 @@
     </section>
     <section class="test-results">
       <h3>Expected Results</h3>
-	  <p>If step #4 is false then this failure condition applies and the content fails the Success Criterion.</p>
+	  <p>If step #4 is true then this failure condition applies and the content fails the Success Criterion.</p>
 
     </section>
   </section>


### PR DESCRIPTION
As spotted by @joe-watkins

> Howdy all! Can someone help my mind parse Expected Results for [F99](https://www.w3.org/WAI/WCAG21/Techniques/failures/F99) 2.1.4: Character Key Shortcuts? I swear the expected result for the failure is backwards or I'm not understanding the logic of #4.
> > If step #4 is false then this failure condition applies and the content fails the Success Criterion.
>
> To me, I'd think it should read "If step #4 is true then this failure condition..." meaning - a function was fired by pressing the key making #4 (Check whether a function has been triggered by pressing the keys) true. ?

Indeed, the expected result should say if #4 is *true*, not *false*