### PR TITLE
Correct filename for 1.4.12 understanding

### DIFF
--- a/understanding/21/text-spacing.html
+++ b/understanding/21/text-spacing.html
@@ -40,12 +40,12 @@
          <p>The bottom portion of the words &quot;Your Needs&quot; is cut off in a heading making that text unreadable in Figure 1. It should read  &quot;We Provide a Mobile Application Service to Meet Your Needs.&quot;</p>
          <figure id="figure-text-cut">
             <figcaption>Vertical text cut off is a failure.</figcaption>
-            <img src="img/pacing_cutoff_fail_vertical.png" alt="Heading text truncated vertically." width="420" height="190" />         
+            <img src="img/spacing_cutoff_fail_vertical.png" alt="Heading text truncated vertically." width="420" height="190" />         
          </figure>
          <p>In Figure 2 the last portion of text is cut off in 3 side-by-side  headings. The 1st heading should read &quot;A cog in the wheel.&quot; But it reads &quot;A cog in the whe&quot;. Only half of the second &quot;e&quot; is visible and the letter &quot;l&quot; is completely missing. The  2nd heading should read &quot;A penny for your thoughts&quot;. But it reads &quot;A penny for your&quot;. The 3rd should read &quot;Back to the drawing board.&quot; But it reads &quot;Back to the drawi&quot;. </p>
          <figure id="figure-horiz-text-cut">
             <figcaption>Horizontal text cut off is a failure.</figcaption>
-            <img src="img/pacing_cutoff_fail_horizontal.png" alt="3 side-by-side headings with truncated text." width="509" height="184" />         
+            <img src="img/spacing_cutoff_fail_horizontal.png" alt="3 side-by-side headings with truncated text." width="509" height="184" />         
          </figure>
       		</section>
       		<section>


### PR DESCRIPTION
late follow-up to https://github.com/w3c/wcag/pull/1549 which seems to have dropped the leading `s` on the filenames

closes #2564