### PR TITLE
Errata/clarification of 2.2.1 Timing Adjustable extension (counterproposal)

### DIFF
--- a/guidelines/sc/20/timing-adjustable.html
+++ b/guidelines/sc/20/timing-adjustable.html
@@ -32,7 +32,8 @@
          
          <p>The user is warned before time expires and given at least 20 seconds to extend the
             time limit with a simple action (for example, "press the space bar"), and the user
-            is allowed to extend the time limit at least ten times; or
+            is given ten opportunities to extend the time limit (with each extension having the
+            same duration as the original time limit); or
          </p>
          
       </dd>


### PR DESCRIPTION
A counterproposal to https://github.com/w3c/wcag/pull/1040 that aims to keep backwards-compatibility with the 2.0/2.1 version which some are arguing did in fact intend the "ten times" in the extend bullet to refer just to the number of opportunities to extend).

In the original, there is no clarification of how long each extension should be, which opens this particular bullet up for being completely gamed by authors (and lead to paradoxical situations where a site that passes this by virtue of offering 10 really short extensions still doesn't actually help real-world users that need more time, not in the same way that the other bullets do).
For backwards-compatibility, this keeps the idea of 10 opportunities (if that was indeed the original intent), but adds a further clause about the length of the extensions (and yes, technically this would only need 9 opportunities to be on par with the "adjust" bullet, but for backwards-compatibility this keeps the "ten").

This would then make the bullet more useful (it actually does enforce providing users with more time, rather than being gameable), and be backwards-compatible (while being stricter).