### PR TITLE
Update G220 for bug fixes, additional example

### DIFF
--- a/techniques/general/G220.html
+++ b/techniques/general/G220.html
@@ -23,12 +23,19 @@
 		<section id="examples">
 			<h2>Examples</h2>
 			<section class="example">
-				<h3> A link at the top of the page</h3>
+				<h3>A link at the top of the page</h3>
 				<p>An on-line job application asks for many types of information from the user, such as their identification number, but they may have several and not know which one to enter. They may need more information from someone that can answer their question when the contextual help provided does not meet their needs. One of the first links that the user reaches when tabbing through the page is titled "Contact Us". This link is also visually in the same location on each page. Activating the link brings the user to the contact details page. The contact details page has an email address for a company representative or general information inbox which is then shared with appropriate personnel.</p>
 			</section>
 			<section class="example">
 				<h3>A link in the footer region</h3>
-				<p>A Web page’s footer region contains links repeated on every page in a set of web pages. The visual and programmatic order are consistent when viewed in the same size display. One of the first links in the footer region is labeled visually and programmatically “Contact Us.” A user activates the link and is brought to the contact details page. The contact details page has an email address for a company representative or general information inbox which is then shared with appropriate personnel.</p>
+				<p>A Web page's footer region contains links repeated on every page in a set of web pages. The visual and programmatic order are consistent when viewed in the same size display. One of the first links in the footer region is labeled visually and programmatically "Contact Us". A user activates the link and is brought to the contact details page. The contact details page has an email address for a company representative or general information inbox which is then shared with appropriate personnel.</p>
+			</section>
+			<section class="example">
+				<h3>A link sometimes in a disclosure widget</h3>
+				<p>On some pages in a set of web pages, there is a link to a help mechanism directly on the page. On one or more other pages in the set, the link is within a disclosure widget which is in the same relative order as the link that is directly on the page.</p>
+        <div class="note">
+          <p>Although this example passes the Success Criterion, it creates an inconsistent user experience and is less preferable than consistently placing a link directly on the page.
+        </div>
 			</section>
 		</section>
 		<section id="tests">
@@ -36,7 +43,7 @@
 			<section class="test-procedure">
 				<h3>Procedure</h3>
 				<ol>			
-					<li>Determine if this is a single page app or a set of web pages, with blocks of content that are repeated on multiple web pages.</li>
+					<li>Determine if this is a set of web pages with blocks of content that are repeated on multiple pages.</li>
 					<li>Determine if at least one of the following is included or linked in a consistent location:
 						<ul>
 							<li>Human contact details</li>
@@ -45,7 +52,7 @@
 							<li>A fully automated mechanism</li>
 						</ul>
 					</li>
-					<li>Without changing the viewport size, check that the identified help is present on all other web pages within that set of web pages. </li>
+					<li>Without changing the viewport size, check that the identified help is present on all other web pages within that set of web pages.</li>
 				</ol>		
 			</section>
 		</section>

--- a/techniques/general/G220.html
+++ b/techniques/general/G220.html
@@ -34,7 +34,7 @@
 				<h3>A link sometimes in a disclosure widget</h3>
 				<p>On some pages in a set of web pages, there is a link to a help mechanism directly on the page. On one or more other pages in the set, the link is within a disclosure widget which is in the same relative order as the link that is directly on the page.</p>
         <div class="note">
-          <p>Although this example passes the Success Criterion, it creates an inconsistent user experience and is less preferable than consistently placing a link directly on the page.
+          <p>Although this example technically passes the Success Criterion, it creates a less consistent user experience and is less preferable than consistently placing a link directly on the page.</p>
         </div>
 			</section>
 		</section>


### PR DESCRIPTION
1. Edited punctuation that is possibly the cause of the <a href="https://w3c.github.io/wcag/techniques/general/G220">current rendered version of this page</a> ending after Example 2.
2. Removed reference to single-page apps.
3. Added an example that hopefully addresses comments in #2303

Closes #2303