### PR TITLE
Focus Visible should also apply when there is only one control

### DIFF
--- a/understanding/20/focus-visible.html
+++ b/understanding/20/focus-visible.html
@@ -17,8 +17,6 @@
          keyboard focus.
       </p>
       
-      <p>It must be possible for a person to know which element among multiple elements has the keyboard focus. If there is only one keyboard actionable control on the screen, the success criterion would be met because the visual design presents only one keyboard actionable item.</p>
-
       <p>“Mode of operation” accounts for user agents which may not always show a focus indicator, or only show the focus indicator when the keyboard is used. User agents may optimise when the focus indicator is shown, such as only showing it when a keyboard is used. Authors are responsible for providing at least one mode of operation where the focus is visible. In most cases there is only one mode of operation so this success criterion applies. The focus indicator must not be time limited, when the keyboard focus is shown it must remain.</p>
       
    	<p>Note that a keyboard focus indicator can take different forms.<span class="wcag22"> This criterion does not specify what the form is, but <a href="focus-appearance-minimum">Focus Appearance (Minimum)</a> does define how visible the indicator should be. Passing <a href="focus-appearance-minimum">Focus Appearance (Minimum)</a> would pass this success criterion.</span></p>


### PR DESCRIPTION
The current understanding document of 2.4.7 Focus Visible suggests there is an exception for when there is only one focusable element on the page. The actual SC text does not mention any such exception though, and so suggesting it's allowed in the understanding document seems out of place.

This case was discussed by the ACT Task Force, who is currently evaluating a rule which has this [one-component exception](https://www.w3.org/WAI/standards-guidelines/act/rules/oj04fd/proposed/#applicability). However none of the testers who looked at it considered this a valid exception, and would fail pages with a single control if it did not have a visible focus. We would propose removing this exception from the understanding document.

While rare, this type of issue can exist on for example redirect pages; A page that informs the visitor content is moved, and includes a single link to the new location.