### PR TITLE
Removing 'sometimes' from statement of partial conformance

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -509,7 +509,7 @@
 
             <section id="conformance-partial">
                 <h2>Statement of Partial Conformance - Third Party Content</h2>
-                <p>Web pages that will later have additional content added to them may wish to use a 'statement of partial conformance'. For example, an email program, a blog, an article that allows users to add comments, or applications supporting user-contributed content. Another example would be a page, such as a portal or news site, composed of content aggregated from multiple contributors, or sites that automatically insert content from other sources over time, such as when advertisements are inserted dynamically.</p>
+                <p>Web pages that will later have additional content added can use a 'statement of partial conformance'. For example, an email program, a blog, an article that allows users to add comments, or applications supporting user-contributed content. Another example would be a page, such as a portal or news site, composed of content aggregated from multiple contributors, or sites that automatically insert content from other sources over time, such as when advertisements are inserted dynamically.</p>
                 <p>In these cases, it is not possible to know at the time of original posting what the uncontrolled content of the pages will be. It is important to note that the uncontrolled content can affect the accessibility of the controlled content as well. Two options are available:</p>
                 <ol>
                     <li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -509,7 +509,7 @@
 
             <section id="conformance-partial">
                 <h2>Statement of Partial Conformance - Third Party Content</h2>
-                <p>Sometimes, Web pages are created that will later have additional content added to them. For example, an email program, a blog, an article that allows users to add comments, or applications supporting user-contributed content. Another example would be a page, such as a portal or news site, composed of content aggregated from multiple contributors, or sites that automatically insert content from other sources over time, such as when advertisements are inserted dynamically.</p>
+                <p>Web pages that will later have additional content added to them may wish to use a 'statement of partial conformance'. For example, an email program, a blog, an article that allows users to add comments, or applications supporting user-contributed content. Another example would be a page, such as a portal or news site, composed of content aggregated from multiple contributors, or sites that automatically insert content from other sources over time, such as when advertisements are inserted dynamically.</p>
                 <p>In these cases, it is not possible to know at the time of original posting what the uncontrolled content of the pages will be. It is important to note that the uncontrolled content can affect the accessibility of the controlled content as well. Two options are available:</p>
                 <ol>
                     <li>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/2658.html" title="Last updated on Sep 1, 2022, 7:30 AM UTC (b6ee0c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/2658/8bc1e06...b6ee0c2.html" title="Last updated on Sep 1, 2022, 7:30 AM UTC (b6ee0c2)">Diff</a>