### PR TITLE
Change order and organization of New Features in WCAG 2.2

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -91,7 +91,7 @@
 					<p>WCAG 2.2 extends WCAG 2.1 by adding new success criteria, definitions to support them, and guidelines to organize the additions. This additive approach helps to make it clear that sites which conform to WCAG 2.2 also conform to WCAG 2.1. The Accessibility Guidelines Working Group recommends that sites adopt WCAG 2.2 as their new conformance target, even if formal obligations mention previous versions, to provide improved accessibility and to anticipate future policy changes.</p>
 					<p>The following Success Criteria are new in WCAG 2.2:</p>
 					<ul>
-						<li>2.4.11<a href="#focus-appearance">Focus Appearance</a> (AA)</li>
+						<li>2.4.11 <a href="#focus-appearance">Focus Appearance</a> (AA)</li>
 						<li>2.4.12 <a href="#focus-not-obscured-minimum">Focus Not Obscured</a> (AA)</li>
 						<li>2.4.13 <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a> (AAA)</li>
 						<li>3.2.6 <a href="#consistent-help">Consistent Help</a> (A)</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -27,7 +27,7 @@
 				<h3>Background on WCAG 2</h3>
 				<p>Web Content Accessibility Guidelines (WCAG) 2.2 defines how to make Web content more accessible to people with disabilities. Accessibility involves a wide range of disabilities, including visual, auditory, physical, speech, cognitive, language, learning, and neurological disabilities. Although these guidelines cover a wide range of issues, they are not able to address the needs of people with all types, degrees, and combinations of disability. These guidelines also make Web content more usable by older individuals with changing abilities due to aging and often improve usability for users in general.</p>
 				<p>WCAG 2.2 is developed through the <a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/">W3C process</a> in cooperation with individuals and organizations around the world, with a goal of providing a shared standard for Web content accessibility that meets the needs of individuals, organizations, and governments internationally. WCAG 2.2 builds on WCAG 2.0 [[WCAG20]] and WCAG 2.1 [[WCAG21]], which in turn built on WCAG 1.0 [[WAI-WEBCONTENT]] and is designed to apply broadly to different Web technologies now and in the future, and to be testable with a combination of automated testing and human evaluation. For an introduction to WCAG, see the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a>.</p>
-                
+
 				<p>Significant challenges were encountered in defining additional criteria to address cognitive, language, and learning disabilities, including a short timeline for development as well as challenges in reaching consensus on testability, implementability, and international considerations of proposals. Work will carry on in this area in future versions of WCAG. We encourage authors to refer to our supplemental guidance on <a href="https://www.w3.org/WAI/standards-guidelines/wcag/#supplement">improving inclusion for people with disabilities, including learning and cognitive disabilities, people with low-vision, and more</a>.</p>
 
 				<p>Web accessibility depends not only on accessible content but also on accessible Web browsers and other user agents. Authoring tools also have an important role in Web accessibility. For an overview of how these components of Web development and interaction work together, see:</p>
@@ -91,15 +91,15 @@
 					<p>WCAG 2.2 extends WCAG 2.1 by adding new success criteria, definitions to support them, and guidelines to organize the additions. This additive approach helps to make it clear that sites which conform to WCAG 2.2 also conform to WCAG 2.1. The Accessibility Guidelines Working Group recommends that sites adopt WCAG 2.2 as their new conformance target, even if formal obligations mention previous versions, to provide improved accessibility and to anticipate future policy changes.</p>
 					<p>The following Success Criteria are new in WCAG 2.2:</p>
 					<ul>
-                        <li><a href="#accessible-authentication">Accessible Authentication</a></li>
-                        <li><a href="#accessible-authentication-no-exception">Accessible Authentication (No Exception)</a></li>
-                        <li><a href="#consistent-help">Consistent Help</a></li>
-                        <li><a href="#dragging-movements">Dragging Movements</a></li>
-                        <li><a href="#focus-appearance">Focus Appearance</a></li>
-                        <li><a href="#focus-not-obscured-minimum">Focus Not Obscured</a></li>
-                        <li><a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a></li>
-                        <li><a href="#redundant-entry">Redundant Entry</a></li>    
-                        <li><a href="#target-size-minimum">Target Size (Minimum)</a></li> 
+						<li>2.4.11<a href="#focus-appearance">Focus Appearance</a> (AA)</li>
+						<li>2.4.12 <a href="#focus-not-obscured-minimum">Focus Not Obscured</a> (AA)</li>
+						<li>2.4.13 <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a> (AAA)</li>
+						<li>3.2.6 <a href="#consistent-help">Consistent Help</a> (A)</li>
+						<li>3.3.7 <a href="#accessible-authentication">Accessible Authentication</a> (AA)</li>
+						<li>3.3.8 <a href="#accessible-authentication-no-exception">Accessible Authentication (No Exception)</a> (AAA)</li>
+						<li>3.3.9 <a href="#redundant-entry">Redundant Entry</a> (A)</li>
+						<li>3.5.7 <a href="#dragging-movements">Dragging Movements</a> (AA)</li>
+						<li>3.5.8 <a href="#target-size-minimum">Target Size (Minimum)</a> (AA)</li>
 					</ul>
 					<p>The new success criteria may reference new terms that have also been added to the glossary and form part of the normative requirements of the success criteria.</p>
 					<p>In addition to the above new Success Criteria, <a href="#focus-visible">Focus Visible</a> has been promoted from Level AA to Level A.</p>
@@ -165,7 +165,7 @@
                 <section data-include="sc/21/orientation.html" data-include-replace="true"></section>
 
                 <section data-include="sc/21/identify-input-purpose.html" data-include-replace="true"></section>
-              
+
                 <section data-include="sc/21/identify-purpose.html" data-include-replace="true"></section>
 
           </section>
@@ -216,9 +216,9 @@
                 <section data-include="sc/20/no-keyboard-trap.html" data-include-replace="true"></section>
 
                 <section data-include="sc/20/keyboard-no-exception.html" data-include-replace="true"></section>
-              
+
                 <section data-include="sc/21/character-key-shortcuts.html" data-include-replace="true"></section>
-                
+
             </section>
 
             <section class="guideline">
@@ -235,7 +235,7 @@
 
                 <section data-include="sc/20/re-authenticating.html" data-include-replace="true"></section>
 
-                <section data-include="sc/21/timeouts.html" data-include-replace="true"></section> 
+                <section data-include="sc/21/timeouts.html" data-include-replace="true"></section>
 
             </section>
 
@@ -246,7 +246,7 @@
                 <section data-include="sc/20/three-flashes-or-below-threshold.html" data-include-replace="true"></section>
 
                 <section data-include="sc/20/three-flashes.html" data-include-replace="true"></section>
-                
+
                 <section data-include="sc/21/animation-from-interactions.html" data-include-replace="true"></section>
 
             </section>
@@ -292,7 +292,7 @@
                 <section data-include="sc/21/pointer-cancellation.html" data-include-replace="true"></section>
 
               	<section data-include="sc/21/label-in-name.html" data-include-replace="true"></section>
-            	
+
                 <section data-include="sc/21/motion-actuation.html" data-include-replace="true"></section>
 
                 <section data-include="sc/21/target-size-enhanced.html" data-include-replace="true"></section>
@@ -302,7 +302,7 @@
                 <section data-include="sc/22/dragging-movements.html" data-include-replace="true"></section>
 
                 <section data-include="sc/22/target-size-minimum.html" data-include-replace="true"></section>
-              
+
             </section>
 
         </section>
@@ -341,7 +341,7 @@
                 <section data-include="sc/20/consistent-identification.html" data-include-replace="true"></section>
 
                 <section data-include="sc/20/change-on-request.html" data-include-replace="true"></section>
-				
+
 				<section data-include="sc/22/consistent-help.html" data-include-replace="true"></section>
 
             </section>
@@ -365,9 +365,9 @@
                 <section data-include="sc/22/accessible-authentication.html" data-include-replace="true"></section>
 
                 <section data-include="sc/22/accessible-authentication-no-exception.html" data-include-replace="true"></section>
-              
+
                 <section data-include="sc/22/redundant-entry.html" data-include-replace="true"></section>
-              
+
             </section>
 
         </section>
@@ -382,9 +382,9 @@
                 <section data-include="sc/20/parsing.html" data-include-replace="true"></section>
 
                 <section data-include="sc/20/name-role-value.html" data-include-replace="true"></section>
-                
+
                 <section data-include="sc/21/status-messages.html" data-include-replace="true"></section>
-                
+
            </section>
 
         </section>
@@ -392,10 +392,10 @@
             <h1>Conformance</h1>
 
             <p>This section lists requirements for <a>conformance</a> to WCAG 2.2. It also gives information about how to make conformance claims, which are optional. Finally, it describes what it means to be <a>accessibility supported</a>, since only accessibility-supported ways of using technologies can be <a>relied upon</a> for conformance. <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance">Understanding Conformance</a> includes further explanation of the accessibility-supported concept.</p>
-        	
+
         	<section>
         		<h2>Interpreting Normative Requirements</h2>
-        		
+
         		<p>The main content of WCAG 2.2 is <a>normative</a> and defines requirements that impact conformance claims. Introductory material, appendices, sections marked as "non-normative", diagrams, examples, and notes are <a>informative</a> (non-normative). Non-normative material provides advisory information to help interpret the guidelines but does not create requirements that impact a conformance claim.</p>
         		<p>The key words MAY, MUST, MUST NOT, NOT RECOMMENDED, RECOMMENDED, SHOULD, and SHOULD NOT are to be interpreted as described in [[RFC2119]].</p>
         	</section>
@@ -537,7 +537,7 @@
             <dl id="terms">
 
                 <dt data-include="terms/20/abbreviation.html" data-include-replace="true"></dt>
-            	
+
                 <dt data-include="terms/20/accessibility-supported.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/alternative-for-time-based-media.html" data-include-replace="true"></dt>
@@ -551,7 +551,7 @@
                 <dt data-include="terms/20/audio.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/audio-description.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/audio-only.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/blinking.html" data-include-replace="true"></dt>
@@ -561,11 +561,11 @@
                 <dt data-include="terms/20/captcha.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/captions.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/changes-of-context.html" data-include-replace="true"></dt>
-              
+
                 <dt data-include="terms/22/cognitive-function-test.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/conformance.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/conforming-alternate-version.html" data-include-replace="true"></dt>
@@ -575,15 +575,15 @@
                 <dt data-include="terms/20/context-sensitive-help.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/contrast-ratio.html" data-include-replace="true"></dt>
-            	
+
                 <dt data-include="terms/20/correct-reading-sequence.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/21/css-pixel.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/21/down-event.html" data-include-replace="true"></dt>
-				
+
                 <dt data-include="terms/22/dragging-movement.html" data-include-replace="true"></dt>
-				
+
                 <dt data-include="terms/20/emergency.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/22/encloses.html" data-include-replace="true"></dt>
@@ -595,7 +595,7 @@
                 <dt data-include="terms/20/flash.html" data-include-replace="true"></dt>
 
             	<dt data-include="terms/22/focus-indicator.html" data-include-replace="true"></dt>
-            	
+
             	<dt data-include="terms/20/functionality.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/general-flash-and-red-flash-thresholds.html" data-include-replace="true"></dt>
@@ -615,7 +615,7 @@
                 <dt data-include="terms/20/keyboard-interface.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/21/keyboard-shortcut.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/label.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/large-scale.html" data-include-replace="true"></dt>
@@ -641,7 +641,7 @@
                 <dt data-include="terms/20/navigated-sequentially.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/non-text-content.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/normative.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/on-a-full-screen-window.html" data-include-replace="true"></dt>
@@ -657,7 +657,7 @@
                 <dt data-include="terms/20/presentation.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/primary-education-level.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/process.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/programmatically-determined.html" data-include-replace="true"></dt>
@@ -667,7 +667,7 @@
                 <dt data-include="terms/20/programmatically-set.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/pure-decoration.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/real-time-event.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/21/region.html" data-include-replace="true"></dt>
@@ -693,11 +693,11 @@
                 <dt data-include="terms/20/sign-language.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/sign-language-interpretation.html" data-include-replace="true"></dt>
-            	
+
                 <dt data-include="terms/21/single-pointer.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/specific-sensory-experience.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/21/state.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/21/status-message.html" data-include-replace="true"></dt>
@@ -705,7 +705,7 @@
                 <dt data-include="terms/20/structure.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/21/style-property.html" data-include-replace="true"></dt>
-              
+
                 <dt data-include="terms/20/supplemental-content.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/synchronized-media.html" data-include-replace="true"></dt>
@@ -723,13 +723,13 @@
                 <dt data-include="terms/21/up-event.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/used-in-an-unusual-or-restricted-way.html" data-include-replace="true"></dt>
-                
+
                 <dt data-include="terms/20/user-agent.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/user-controllable.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/user-interface-component.html" data-include-replace="true"></dt>
-            	
+
             	<dt data-include="terms/21/user-inactivity.html" data-include-replace="true"></dt>
 
                 <dt data-include="terms/20/video.html" data-include-replace="true"></dt>
@@ -744,9 +744,9 @@
 
             </dl>
         </section>
-    	    	
+
       <div data-include="input-purposes.html" data-include-replace="true"></div>
-      
+
     	<section class="appendix" id="changelog">
     		<h2>Change Log</h2>
     		<p>This section shows substantive changes made in WCAG 2.2 since WCAG 2.1. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -93,13 +93,13 @@
 					<ul>
 						<li>2.4.11 <a href="#focus-appearance">Focus Appearance</a> (AA)</li>
 						<li>2.4.12 <a href="#focus-not-obscured-minimum">Focus Not Obscured</a> (AA)</li>
-						<li>2.4.13 <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a> (AAA)</li>
+						<li>2.4.13 <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a> (AAA)</li>	
+						<li>2.5.7 <a href="#dragging-movements">Dragging Movements</a> (AA)</li>
+						<li>2.5.8 <a href="#target-size-minimum">Target Size (Minimum)</a> (AA)</li>
 						<li>3.2.6 <a href="#consistent-help">Consistent Help</a> (A)</li>
 						<li>3.3.7 <a href="#accessible-authentication">Accessible Authentication</a> (AA)</li>
 						<li>3.3.8 <a href="#accessible-authentication-no-exception">Accessible Authentication (No Exception)</a> (AAA)</li>
 						<li>3.3.9 <a href="#redundant-entry">Redundant Entry</a> (A)</li>
-						<li>3.5.7 <a href="#dragging-movements">Dragging Movements</a> (AA)</li>
-						<li>3.5.8 <a href="#target-size-minimum">Target Size (Minimum)</a> (AA)</li>
 					</ul>
 					<p>The new success criteria may reference new terms that have also been added to the glossary and form part of the normative requirements of the success criteria.</p>
 					<p>In addition to the above new Success Criteria, <a href="#focus-visible">Focus Visible</a> has been promoted from Level AA to Level A.</p>


### PR DESCRIPTION
This change makes the list of success criteria look similar to the same list in WCAG 2.1. This is done to ensure that it’s easy to see what new SCs are there and what their level and SC number is.

- Fixes w3c/wcag#1807

Signed-off-by: Eric Eggert <mail@yatil.net>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yatil/wcag/pull/2667.html" title="Last updated on Sep 6, 2022, 7:17 PM UTC (de6a6a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/2667/17f8477...yatil:de6a6a3.html" title="Last updated on Sep 6, 2022, 7:17 PM UTC (de6a6a3)">Diff</a>