### PR TITLE
use aside for examples

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -431,7 +431,7 @@
             	<section id="cc3">
                     <h3>Complete processes</h3>
                     <p>When a <a>Web page</a> is one of a series of Web pages presenting a <a>process</a> (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all Web pages in the process conform at the specified level or better. (Conformance is not possible at a particular level if any page in the process does not conform at that level or better.)</p>
-                    <p class="example">An online store has a series of pages that are used to select and purchase products. All pages in the series from start to finish (checkout) conform in order for any page that is part of the process to conform.</p>
+                    <aside class="example"><p>An online store has a series of pages that are used to select and purchase products. All pages in the series from start to finish (checkout) conform in order for any page that is part of the process to conform.</p></aside>
                 </section>
 
             	<!-- This section is quoted in Understanding Conformance. If updated, the update needs to be copied there. -->

--- a/guidelines/terms/20/abbreviation.html
+++ b/guidelines/terms/20/abbreviation.html
@@ -17,10 +17,10 @@
          
          <p class="note">Not defined in all languages.</p>
          
-         <p class="example">SNCF is a French initialism that contains the initial letters of the <span lang="fr">Société Nationale des Chemins de Fer</span>, the French national railroad.
-         </p>
+         <aside class="example"><p>SNCF is a French initialism that contains the initial letters of the <span lang="fr">Société Nationale des Chemins de Fer</span>, the French national railroad.
+         </p></aside>
          
-         <p class="example">ESP is an initialism for extrasensory perception.</p>
+         <aside class="example"><p>ESP is an initialism for extrasensory perception.</p></aside>
          
       </li>
       
@@ -30,9 +30,9 @@
             name or phrase) which may be pronounced as a word
          </p>
          
-         <p class="example">NOAA is an acronym made from the initial letters of the National Oceanic and Atmospheric
+         <aside class="example"><p>NOAA is an acronym made from the initial letters of the National Oceanic and Atmospheric
             Administration in the United States.
-         </p>
+         </p></aside>
          
       </li>
       

--- a/guidelines/terms/20/ambiguous-to-users-in-general.html
+++ b/guidelines/terms/20/ambiguous-to-users-in-general.html
@@ -6,10 +6,10 @@
       would not know what a link would do until they activated it)
    </p>
    
-   <p class="example">The word guava in the following sentence "One of the notable exports is guava" is
+   <aside class="example"><p>The word guava in the following sentence "One of the notable exports is guava" is
       a link. The link could lead to a definition of guava, a chart listing the quantity
       of guava exported or a photograph of people harvesting guava. Until the link is activated,
       all readers are unsure and the person with a disability is not at any disadvantage.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/assistive-technology.html
+++ b/guidelines/terms/20/assistive-technology.html
@@ -27,9 +27,9 @@
       markup into identifiable bundles.
    </p>
    
-   <p class="example">Assistive technologies that are important in the context of this document include
+   <aside class="example"><p>Assistive technologies that are important in the context of this document include
       the following:
-   </p>
+   </p></aside>
    
    <ul>
       

--- a/guidelines/terms/20/changes-of-context.html
+++ b/guidelines/terms/20/changes-of-context.html
@@ -27,9 +27,9 @@
       context, unless they also change one of the above (e.g., focus).
    </p>
    
-   <p class="example">Opening a new window, moving focus to a different component, going to a new page (including
+   <aside class="example"><p>Opening a new window, moving focus to a different component, going to a new page (including
       anything that would look to a user as if they had moved to a new page) or significantly
       re-arranging the content of a page are examples of changes of context.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/idiom.html
+++ b/guidelines/terms/20/idiom.html
@@ -9,16 +9,16 @@
       or language-dependent) meaning.
    </p>
    
-   <p class="example">In English, "spilling the beans" means "revealing a secret." However, "knocking over
+   <aside class="example"><p>In English, "spilling the beans" means "revealing a secret." However, "knocking over
       the beans" or "spilling the vegetables" does not mean the same thing.
-   </p>
+   </p></aside>
    
-   <p class="example">In Japanese, the phrase "<span lang="ja">さじを投げる</span>" literally translates into "he throws a spoon," but it means that there is nothing
+   <aside class="example"><p>In Japanese, the phrase "<span lang="ja">さじを投げる</span>" literally translates into "he throws a spoon," but it means that there is nothing
       he can do and finally he gives up.
-   </p>
+   </p></aside>
    
-   <p class="example">In Dutch, "<span lang="nl">Hij ging met de kippen op stok</span>" literally translates into "He went to roost with the chickens," but it means that
+   <aside class="example"><p>In Dutch, "<span lang="nl">Hij ging met de kippen op stok</span>" literally translates into "He went to roost with the chickens," but it means that
       he went to bed early.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/image-of-text.html
+++ b/guidelines/terms/20/image-of-text.html
@@ -8,6 +8,6 @@
    <p class="note">This does not include <a>text</a> that is part of a picture that contains significant other visual content.
    </p>
    
-   <p class="example">A person's name on a nametag in a photograph.</p>
+   <aside class="example"><p>A person's name on a nametag in a photograph.</p></aside>
    
 </dd>

--- a/guidelines/terms/20/jargon.html
+++ b/guidelines/terms/20/jargon.html
@@ -3,6 +3,6 @@
    
    <p>words used in a particular way by people in a particular field</p>
    
-   <p class="example">The word StickyKeys is jargon from the field of assistive technology/accessibility.</p>
+   <aside class="example"><p>The word StickyKeys is jargon from the field of assistive technology/accessibility.</p></aside>
    
 </dd>

--- a/guidelines/terms/20/keyboard-interface.html
+++ b/guidelines/terms/20/keyboard-interface.html
@@ -7,11 +7,11 @@
         <p>A keyboard interface allows users to provide keystroke input to programs even if the
         native technology does not contain a keyboard.</p>
 
-        <p class="example">A touchscreen PDA has a keyboard interface built into its operating system as well
+       <aside class="example"><p>A touchscreen PDA has a keyboard interface built into its operating system as well
         as a connector for external keyboards. Applications on the PDA can use the interface
         to obtain keyboard input either from an external keyboard or from other applications
         that provide simulated keyboard output, such as handwriting interpreters or speech-to-text
-        applications with "keyboard emulation" functionality.</p>
+        applications with "keyboard emulation" functionality.</p></aside>
     </div>
    
    <p class="note">Operation of the application (or parts of the application) through a keyboard-operated

--- a/guidelines/terms/20/legal-commitments.html
+++ b/guidelines/terms/20/legal-commitments.html
@@ -3,8 +3,8 @@
    
    <p>transactions where the person incurs a legally binding obligation or benefit</p>
    
-   <p class="example">A marriage license, a stock trade (financial and legal), a will, a loan, adoption,
+   <aside class="example"><p>A marriage license, a stock trade (financial and legal), a will, a loan, adoption,
       signing up for the army, a contract of any type, etc.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/process.html
+++ b/guidelines/terms/20/process.html
@@ -3,13 +3,13 @@
    
    <p>series of user actions where each action is required in order to complete an activity</p>
    
-   <p class="example">Successful use of a series of Web pages on a shopping site requires users to view
+   <aside class="example"><p>Successful use of a series of Web pages on a shopping site requires users to view
       alternative products, prices and offers, select products, submit an order, provide
       shipping information and provide payment information.
-   </p>
+   </p></aside>
    
-   <p class="example">An account registration page requires successful completion of a <a href="https://www.w3.org/TR/turingtest/">Turing test</a> before
+   <aside class="example"><p>An account registration page requires successful completion of a <a href="https://www.w3.org/TR/turingtest/">Turing test</a> before
       the registration form can be accessed.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/programmatically-determined-link-context.html
+++ b/guidelines/terms/20/programmatically-determined-link-context.html
@@ -4,10 +4,10 @@
    <p>additional information that can be <a>programmatically determined</a> from <a>relationships</a> with a link, combined with the link text, and presented to users in different modalities
    </p>
    
-   <p class="example">In HTML, information that is programmatically determinable from a link in English
+   <aside class="example"><p>In HTML, information that is programmatically determinable from a link in English
       includes text that is in the same paragraph, list, or table cell as the link or in
       a table header cell that is associated with the table cell that contains the link.
-   </p>
+   </p></aside>
    
    <p class="note">Since screen readers interpret punctuation, they can also provide the context from
       the current sentence, when the focus is on a link in that sentence.

--- a/guidelines/terms/20/programmatically-determined.html
+++ b/guidelines/terms/20/programmatically-determined.html
@@ -6,13 +6,13 @@
       <a>user agents</a>, including <a>assistive technologies</a>, can extract and present this information to users in different modalities
    </p>
    
-   <p class="example">Determined in a markup language from elements and attributes that are accessed directly
+   <aside class="example"><p>Determined in a markup language from elements and attributes that are accessed directly
       by commonly available assistive technology.
-   </p>
+   </p></aside>
    
-   <p class="example">Determined from technology-specific data structures in a non-markup language and exposed
+      <aside class="example"><p>Determined from technology-specific data structures in a non-markup language and exposed
       to assistive technology via an accessibility API that is supported by commonly available
       assistive technology.
-   </p>
+      </p></aside>
    
 </dd>

--- a/guidelines/terms/20/pure-decoration.html
+++ b/guidelines/terms/20/pure-decoration.html
@@ -7,6 +7,6 @@
       changing their purpose.
    </p>
    
-   <p class="example">The cover page of a dictionary has random words in very light text in the background.</p>
+   <aside class="example"><p>The cover page of a dictionary has random words in very light text in the background.</p></aside>
    
 </dd>

--- a/guidelines/terms/20/real-time-event.html
+++ b/guidelines/terms/20/real-time-event.html
@@ -5,14 +5,14 @@
       by the content
    </p>
    
-   <p class="example">A Webcast of a live performance (occurs at the same time as the viewing and is not
+   <aside class="example"><p>A Webcast of a live performance (occurs at the same time as the viewing and is not
       prerecorded).
-   </p>
+   </p></aside>
    
-   <p class="example">An on-line auction with people bidding (occurs at the same time as the viewing).</p>
+   <aside class="example"><p>An on-line auction with people bidding (occurs at the same time as the viewing).</p></aside>
    
-   <p class="example">Live humans interacting in a virtual world using avatars (is not completely generated
+   <aside class="example"><p>Live humans interacting in a virtual world using avatars (is not completely generated
       by the content and occurs at the same time as the viewing).
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/role.html
+++ b/guidelines/terms/20/role.html
@@ -5,8 +5,8 @@
       content
    </p>
    
-   <p class="example">A number that indicates whether an image functions as a hyperlink, command button,
+   <aside class="example"><p>A number that indicates whether an image functions as a hyperlink, command button,
       or check box.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/same-functionality.html
+++ b/guidelines/terms/20/same-functionality.html
@@ -3,10 +3,10 @@
    
    <p>same result when used</p>
    
-   <p class="example">A submit "search" button on one Web page and a "find" button on another Web page may
+   <aside class="example"><p>A submit "search" button on one Web page and a "find" button on another Web page may
       both have a field to enter a term and list topics in the Web site related to the term
       submitted. In this case, they would have the same functionality but would not be labeled
       consistently.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/specific-sensory-experience.html
+++ b/guidelines/terms/20/specific-sensory-experience.html
@@ -5,6 +5,6 @@
       information or perform a function
    </p>
    
-   <p class="example">Examples include a performance of a flute solo, works of visual art etc.</p>
+   <aside class="example"><p>Examples include a performance of a flute solo, works of visual art etc.</p></aside>
    
 </dd>

--- a/guidelines/terms/20/supplemental-content.html
+++ b/guidelines/terms/20/supplemental-content.html
@@ -4,14 +4,14 @@
    <p>additional <a>content</a> that illustrates or clarifies the primary content
    </p>
    
-   <p class="example">An audio version of a <a>Web page</a>.
-   </p>
+   <aside class="example"><p>An audio version of a <a>Web page</a>.
+   </p></aside>
    
-   <p class="example">An illustration of a complex <a>process</a>.
-   </p>
+   <aside class="example"><p>An illustration of a complex <a>process</a>.
+   </p></aside>
    
-   <p class="example">A paragraph summarizing the major outcomes and recommendations made in a research
+   <aside class="example"><p>A paragraph summarizing the major outcomes and recommendations made in a research
       study.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/technology.html
+++ b/guidelines/terms/20/technology.html
@@ -14,8 +14,8 @@
       applications.
    </p>
    
-   <p class="example">Some common examples of Web content technologies include HTML, CSS, SVG, PNG, PDF,
+   <aside class="example"><p>Some common examples of Web content technologies include HTML, CSS, SVG, PNG, PDF,
       Flash, and JavaScript.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/text-alternative.html
+++ b/guidelines/terms/20/text-alternative.html
@@ -6,9 +6,9 @@
       from the non-text content.
    </p>
    
-   <p class="example">An image of a chart is described in text in the paragraph after the chart. The short
+   <aside class="example"><p>An image of a chart is described in text in the paragraph after the chart. The short
       text alternative for the chart indicates that a description follows.
-   </p>
+   </p></aside>
    
    <p class="note">Refer to <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#text-alternatives">Understanding Text Alternatives</a> for more information.
    </p>

--- a/guidelines/terms/20/used-in-an-unusual-or-restricted-way.html
+++ b/guidelines/terms/20/used-in-an-unusual-or-restricted-way.html
@@ -5,10 +5,10 @@
       in order to understand the content correctly
    </p>
    
-   <p class="example">The term "gig" means something different if it occurs in a discussion of music concerts
+   <aside class="example"><p>The term "gig" means something different if it occurs in a discussion of music concerts
       than it does in article about computer hard drive space, but the appropriate definition
       can be determined from context. By contrast, the word "text" is used in a very specific
       way in WCAG 2.1, so a definition is supplied in the glossary.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/user-agent.html
+++ b/guidelines/terms/20/user-agent.html
@@ -3,7 +3,7 @@
    
    <p>any software that retrieves and presents Web content for users</p>
    
-   <p class="example">Web browsers, media players, plug-ins, and other programs — including <a>assistive technologies</a> — that help in retrieving, rendering, and interacting with Web content.
-   </p>
+   <aside class="example"><p>Web browsers, media players, plug-ins, and other programs — including <a>assistive technologies</a> — that help in retrieving, rendering, and interacting with Web content.
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/user-controllable.html
+++ b/guidelines/terms/20/user-controllable.html
@@ -5,6 +5,6 @@
    
    <p class="note">This does not refer to such things as Internet logs and search engine monitoring data.</p>
    
-   <p class="example">Name and address fields for a user's account.</p>
+   <aside class="example"><p>Name and address fields for a user's account.</p></aside>
    
 </dd>

--- a/guidelines/terms/20/user-interface-component.html
+++ b/guidelines/terms/20/user-interface-component.html
@@ -18,9 +18,9 @@
       called "user interface element".
    </p>
    
-   <p class="example">An applet has a "control" that can be used to move through content by line or page
+   <aside class="example"><p>An applet has a "control" that can be used to move through content by line or page
       or random access. Since each of these would need to have a name and be settable independently,
       they would each be a "user interface component."
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/20/web-page.html
+++ b/guidelines/terms/20/web-page.html
@@ -12,24 +12,24 @@
       within the scope of conformance to be considered a Web page.
    </p>
    
-   <p class="example">A Web resource including all embedded images and media.</p>
+   <aside class="example"><p>A Web resource including all embedded images and media.</p></aside>
    
-   <p class="example">A Web mail program built using Asynchronous JavaScript and XML (AJAX). The program
+   <aside class="example"><p>A Web mail program built using Asynchronous JavaScript and XML (AJAX). The program
       lives entirely at http://example.com/mail, but includes an inbox, a contacts area
       and a calendar. Links or buttons are provided that cause the inbox, contacts, or calendar
       to display, but do not change the URI of the page as a whole.
-   </p>
+   </p></aside>
    
-   <p class="example">A customizable portal site, where users can choose content to display from a set of
+   <aside class="example"><p>A customizable portal site, where users can choose content to display from a set of
       different content modules.
-   </p>
+   </p></aside>
    
-   <p class="example">When you enter "http://shopping.example.com/" in your browser, you enter a movie-like
+   <aside class="example"><p>When you enter "http://shopping.example.com/" in your browser, you enter a movie-like
       interactive shopping environment where you visually move around in a store dragging
       products off of the shelves around you and into a visual shopping cart in front of
       you. Clicking on a product causes it to be demonstrated with a specification sheet
       floating alongside. This might be a single-page Web site or just one page within a
       Web site.
-   </p>
+   </p></aside>
    
 </dd>

--- a/guidelines/terms/21/motion-animation.html
+++ b/guidelines/terms/21/motion-animation.html
@@ -2,6 +2,6 @@
 <dd>
    					
    <p>addition of steps between conditions to create the illusion of movement or to give a sense of a smooth transition</p>
-	<p class="example">For example, an element which moves into place or changes size while appearing is considered to be animated. An element which appears instantly without transitioning is not using animation. Motion animation does not include changes of color, blurring, or opacity which do not change the perceived size, shape, or position of the element.</p>
+	<aside class="example"><p>For example, an element which moves into place or changes size while appearing is considered to be animated. An element which appears instantly without transitioning is not using animation. Motion animation does not include changes of color, blurring, or opacity which do not change the perceived size, shape, or position of the element.</p></aside>
    				
 </dd>

--- a/guidelines/terms/21/set-of-web-pages.html
+++ b/guidelines/terms/21/set-of-web-pages.html
@@ -4,11 +4,11 @@
    <p>collection of <a>web pages</a> that share a common purpose and that are created by the same author, group or organization
    </p>
    
-   <p class="example">Examples include a publication which is split across multiple Web pages, where each page contains
+   <aside class="example"><p>Examples include a publication which is split across multiple Web pages, where each page contains
       one chapter or other significant section of the work. The publication is logically
       a single contiguous unit, and contains navigation features that enable access to the
       full set of pages.
-   </p>
+   </p></aside>
 
   <p class="note">Different language versions would be considered different sets of Web pages.</p>
    

--- a/guidelines/terms/22/perimeter.html
+++ b/guidelines/terms/22/perimeter.html
@@ -2,6 +2,6 @@
 <dd class="new">
 	<p class="change">New</p>	
    <p>continuous line forming the boundary of a shape not including shared pixels, or the <a>minimum bounding box</a>, whichever is shortest.</p>
-  <p class="example">The perimeter calculation for a rectangle is 2<em>h</em>+2<em>w</em> -4, where <em>h</em> is the height and <em>w</em> is the width and the corners are not counted twice. The perimeter of a circle is 2𝜋<em>r</em>.</p>
+  <aside class="example"><p>The perimeter calculation for a rectangle is 2<em>h</em>+2<em>w</em> -4, where <em>h</em> is the height and <em>w</em> is the width and the corners are not counted twice. The perimeter of a circle is 2𝜋<em>r</em>.</p></aside>
 </dd>
 


### PR DESCRIPTION
Respec only formats examples on aside and pre, so it was ignoring the p.

Fixes #2597


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/2719.html" title="Last updated on Oct 10, 2022, 11:42 AM UTC (1a13cdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/2719/969ed41...1a13cdd.html" title="Last updated on Oct 10, 2022, 11:42 AM UTC (1a13cdd)">Diff</a>