### PR TITLE
Rounding update

### DIFF
--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -69,7 +69,8 @@
          </p>
          <p>The 7:1 and 4.5:1 contrast ratios referenced in this Success Criterion are intended to be
             treated as threshold values. When comparing the computed contrast ratio to the Success Criterion
-            ratio, the computed values should not be rounded (e.g. 4.499:1 would not meet the 4.5:1 threshold).</p>
+            ratio, the computed value must be rounded to a precision of at least one decimal place, i.e. 7.0:1.
+            (For example, 4.45:1 would round up to the 4.5:1 threshold, but 4.44:1 would not).</p>
          
       </div>
       

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -63,8 +63,8 @@
          </p>
          <p>The 3:1 and 4.5:1 contrast ratios referenced in this Success Criterion are intended to be
             treated as threshold values. When comparing the computed contrast ratio to the Success Criterion
-            ratio, the computed values should not be rounded (e.g. 4.499:1 would not meet the 4.5:1 threshold).</p>
-         
+            ratio, the computed value must be rounded to a precision of at least one decimal place, i.e. 3.0:1.
+            (For example, 4.45:1 would round up to the 4.5:1 threshold, but 4.44:1 would not).</p>
       </div>
       
       <p>The previously-mentioned contrast requirements for text also apply to images of text

--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -16,7 +16,7 @@
 			<p>Low contrast controls are more difficult to perceive, and may be completely missed by people with a visual impairment. Similarly, if a graphic is needed to understand the content or functionality of the webpage then it should be perceivable by people with low vision or other impairments without the need for contrast-enhancing assistive technology.</p>
 
 			<div class="note">
-				<p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed values should not be rounded (e.g. 2.999:1 would not meet the 3:1 threshold).</p>
+				<p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed value must be rounded to a precision of at least one decimal place, i.e. 3.0:1. (For example, 2.95:1 would round up to the 3.0:1 threshold, but 2.94:1 would not).</p>
 			</div>
 
 			<section id="user-interface-components">


### PR DESCRIPTION
This clarifies the rounding note in the contrast SCs, essentially modifying PR #2254 as:

> _....the computed value must be rounded to a precision of at least one decimal place, i.e. 3.0:1. (For example, 4.45:1 would round up to the 4.5:1 threshold, but 4.44:1 would not)._

This pull request was suggested in issue #2251 

This is functionally equivalent to the meaning of these SCs per 2.0, and for 2.1 prior to PR #2254.

RATIONALE: When specifying if something should or should not be rounded, it is incomplete to say "don't round". What is needed is the specific desired precision to be rounded to.

In the present case, rounding to one decimal point is the difference of no more than one 8bit code value, as shown in the below example. This means that rounding to a higher precision brings no functional benefit. 


<img width="685" alt="4 5 vs 4 45 examples shown, there is no visible difference as changing a single code value in this use case is below the threshold of human perception" src="https://user-images.githubusercontent.com/42009457/195182858-bcad3060-4aab-480f-bc52-0325bd931a65.png">


This potentially closes issue #2251 


Thank you for reading.

Andy

