### PR TITLE
add mention of inline text links

### DIFF
--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -310,7 +310,7 @@
                     <figcaption> Passes: Although the CSS <code>border</code> on a multi-line link does not enclose the link, the minimum bounding box definition allows it to be assessed as if it was on a single line. As well, the indicator's area is invariably more than four times the shortest-side calculation .</figcaption>
                 </figure>
 
-<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is <em>likely</em> to meet the minimum size requirement if the text is more than 9 characters.</p>
+<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is <em>likely</em> to meet the minimum size requirement only if the text is more than 9 characters.</p>
 
 <p>For example, a 16px tall text link would need a width of four times the <strong>shortest</strong> side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. However, this is not a focus indicator that would <em>reliably</em> pass this criterion. It would be more visible to retain the browser's default indicator or use a complete perimeter indicator, either of which would pass. The lack of indicator for a link is also likely to fail <a href="use-of-color">1.4.1 Use of Color</a>.</p>
 

--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -311,7 +311,8 @@
                 </figure>
 
 <p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is <em>likely</em> to meet the minimum size requirement if the text is more than 9 characters.</p>
-<p>For example, a 16px tall text-link would need a width of four times the shorted side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. But this is <em>not</em> a focus indicator that <em>reliably</em> passes this criterion. It would be more visible to retain the browser's default indicator or to use a complete perimeter indicator, both of which would pass.</p>
+
+<p>For example, a 16px tall text link would need a width of four times the <strong>shortest</strong> side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. However, this is not a focus indicator that would <em>reliably</em> pass this criterion. It would be more visible to retain the browser's default indicator or use a complete perimeter indicator, either of which would pass. The lack of indicator for a link is also likely to fail <a href="use-of-color">1.4.1 Use of Color</a>.</p>
 
 
             </section>

--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -310,6 +310,9 @@
                     <figcaption> Passes: Although the CSS <code>border</code> on a multi-line link does not enclose the link, the minimum bounding box definition allows it to be assessed as if it was on a single line. As well, the indicator's area is invariably more than four times the shortest-side calculation .</figcaption>
                 </figure>
 
+<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is likely to meet the minimum size requirement if the text is more than 9 characters.</p>
+<p>For example, a 16px tall text-link would need a width of four times the shorted side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. This is not focus indicator that reliably passes this criterion, it would be more visible to retain the browser's default indicator or use a complete perimeter indicator, either of which would pass.</p>
+
 
             </section>
 
@@ -431,7 +434,6 @@
         <blockquote><p>The focus indicator and the indicator's background color are not modified by the author</p></blockquote>
         <p>If the focus indicator and the background behind the focus indicator are not modified by the author, the Success Criterion does not apply.</p>
         <p>The intent of this exception is to reduce burden on authors by allowing them to rely on the default indicators provided by user agents (browsers). If all user agents provided good focus indicators, author would be able to concentrate efforts on other accessibility considerations. Unfortunately, browser default focus indicators vary by component, browser, and across devices and operating systems, and the default focus indicators in some browsers can be difficult to see (such as a 1px dotted outline). For this reason, most authors override browser defaults in order to overcome these deficiencies and create a more uniform user experience, regardless of browser.</p>
-        <p>This exception includes the typical underline effect provided by most web browsing software for inline text links.</p>
         <p>Some browser makers are improving their default focus indicators to make them more visible. As more browsers adopt defaults that meet the primary bullets of this SC, authors will be able to achieve improved focus indicators without customization.</p>
 
         <h4>Modifying the focus indicator background</h4>

--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -431,6 +431,7 @@
         <blockquote><p>The focus indicator and the indicator's background color are not modified by the author</p></blockquote>
         <p>If the focus indicator and the background behind the focus indicator are not modified by the author, the Success Criterion does not apply.</p>
         <p>The intent of this exception is to reduce burden on authors by allowing them to rely on the default indicators provided by user agents (browsers). If all user agents provided good focus indicators, author would be able to concentrate efforts on other accessibility considerations. Unfortunately, browser default focus indicators vary by component, browser, and across devices and operating systems, and the default focus indicators in some browsers can be difficult to see (such as a 1px dotted outline). For this reason, most authors override browser defaults in order to overcome these deficiencies and create a more uniform user experience, regardless of browser.</p>
+        <p>This exception includes the typical underline effect provided by most web browsing software for inline text links.</p>
         <p>Some browser makers are improving their default focus indicators to make them more visible. As more browsers adopt defaults that meet the primary bullets of this SC, authors will be able to achieve improved focus indicators without customization.</p>
 
         <h4>Modifying the focus indicator background</h4>

--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -310,8 +310,8 @@
                     <figcaption> Passes: Although the CSS <code>border</code> on a multi-line link does not enclose the link, the minimum bounding box definition allows it to be assessed as if it was on a single line. As well, the indicator's area is invariably more than four times the shortest-side calculation .</figcaption>
                 </figure>
 
-<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is likely to meet the minimum size requirement if the text is more than 9 characters.</p>
-<p>For example, a 16px tall text-link would need a width of four times the shorted side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. This is not focus indicator that reliably passes this criterion, it would be more visible to retain the browser's default indicator or use a complete perimeter indicator, either of which would pass.</p>
+<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is <em>likely</em> to meet the minimum size requirement if the text is more than 9 characters.</p>
+<p>For example, a 16px tall text-link would need a width of four times the shorted side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. But this is <em>not</em> a focus indicator that <em>reliably</em> passes this criterion. It would be more visible to retain the browser's default indicator or to use a complete perimeter indicator, both of which would pass.</p>
 
 
             </section>

--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -310,7 +310,7 @@
                     <figcaption> Passes: Although the CSS <code>border</code> on a multi-line link does not enclose the link, the minimum bounding box definition allows it to be assessed as if it was on a single line. As well, the indicator's area is invariably more than four times the shortest-side calculation .</figcaption>
                 </figure>
 
-<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is <em>likely</em> to meet the minimum size requirement only if the text is more than 9 characters.</p>
+<p>If authors rely on the text-decoration property of links as a focus indicator (i.e. no text underline by default, then showing a 1px underline when focused), that is likely to meet the minimum size requirement only if the text is more than 9 characters. If the number of characters in the links vary, it is likely some links will fail.</p>
 
 <p>For example, a 16px tall text link would need a width of four times the <strong>shortest</strong> side (4 * 16 = 64px). With default browser styles, a 10 character word (e.g. "accessible") is usually over 70px wide, and would therefore pass. However, this is not a focus indicator that would <em>reliably</em> pass this criterion. It would be more visible to retain the browser's default indicator or use a complete perimeter indicator, either of which would pass. The lack of indicator for a link is also likely to fail <a href="use-of-color">1.4.1 Use of Color</a>.</p>
 


### PR DESCRIPTION
Updates Understanding for 2.4.11 Focus Appearance to mention that default inline text link underlines meets the exception:
> The focus indicator is determined by the user agent and cannot be adjusted by the author

Closes #2679