### PR TITLE
update WCAG2ICT Work statement & overview

### DIFF
--- a/task-forces/wcag2ict/Overview.php
+++ b/task-forces/wcag2ict/Overview.php
@@ -26,10 +26,10 @@
 	</section>
 	<section id="communication">
 		<h2>Meetings and Communication</h2>
-		<p>The WCAG2ICT TF conducts its work using a variety of synchronous and asynchronous tools. Once the TF is re-established, its work will be done via teleconference, email and GitHub issues.</p>
+		<p>The WCAG2ICT TF conducts its work using a variety of synchronous and asynchronous tools. Work is being done via teleconference, email and GitHub issues.</p>
 		<ul>
 			<li><a href="#email">Email lists</a>;</li>
-			<li><a href="https://github.com/w3c/wcag2ict/">wcag2ict GitHub repository</a> and <a href="https://w3c.github.io/wcag2ict/">GitHub draft documents</a>;</li>
+			<li><a href="https://github.com/w3c/wcag2ict/">wcag2ict GitHub repository</a> and <a href="https://w3c.github.io/wcag2ict/">GitHub draft document</a>;</li>
 			<li>IRC options</li>
 			<ul>
 				<li>IRC discussion on the <li><a href="http://irc.w3.org/?channels=#wcag2ict">#wcag2ict</a> IRC channel, used largely for minute-taking;</li>
@@ -43,7 +43,7 @@
 		
 		<section id="teleconferences">
 			<h3>Teleconferences</h3>
-			<p>A teleconference schedule will be created when the WCAG2ICT Task Force is officially re-established.</p>
+			<p>Weekly teleconferences are being held on Thursdays at 10:00 AM Eastern (Boston time).</p>
 			<ul>
 				<?php
 					include "../../../../2017/01/telecon-info/filtered-telecon-list.phi";
@@ -63,7 +63,7 @@
 	
 	<section id="work">
 		<h2>Current Work</h2>
-		<p><a href="https://w3c.github.io/wcag2ict/">Editors' draft of Guidance on Applying WCAG 2.x to Non-Web Information and Communications Technologies (WCAG2ICT)</a></p>
+		<p><a href="https://w3c.github.io/wcag2ict/">Editors' draft of Guidance on Applying WCAG 2.2 to Non-Web Information and Communications Technologies (WCAG2ICT)</a></p>
 	</section>
 	
 	<section id="publications">
@@ -84,15 +84,15 @@
 		<section id="facilitator">
 			<h3>Facilitator and Contacts</h3>
 			<ul>
-				<li><strong>Facilitators:</strong> Mary Jo Mueller (IBM) and TBD</li>
-				<li><strong>Technical Staff Contact:</strong> <a href="https://www.w3.org/People/Brewer/">Judy Brewer</a></li>
-				<li><strong>Administrative Staff Contact:</strong> <a href="http://www.w3.org/People/cooper/">Michael Cooper</a></li>
+				<li><strong>Facilitator:</strong> Mary Jo Mueller (IBM)</li>
+				<li><strong>Technical Staff Contact:</strong> <a href="http://www.w3.org/People/cooper/">Michael Cooper</a></li>
+				<li><strong>Administrative Staff Contact:</strong> <a href="http://www.w3.org/People/#dmontalvo"></a></li>
 			</ul>
-			<p>Contact the task force leadership and working group chairs by email to <a href="mailto:group-ag-chairs@w3.org">group-ag-chairs@w3.org</a></p>
+			<p>Contact the task force leadership and working group chairs via email at <a href="mailto:group-ag-chairs@w3.org">group-ag-chairs@w3.org</a></p>
 		</section>
 		<section id="work-statement">
 			<h3>Work Statement</h3>
-			<p>The <a href="work-statement">Draft WCAG2ICT Task Force Work Statement</a> defines the initial objective, scope, approach, and participation of the Task Force. The draft work statement is subject to the review and approval of the Accessibility Guidelines WG.</p>
+			<p>The <a href="work-statement">WCAG2ICT Task Force Work Statement</a> defines the objectives, scope, approach, and participation of the Task Force. The work statement has been approved by the Accessibility Guidelines WG.</p>
 		</section>
 	</section>
 	

--- a/task-forces/wcag2ict/work-statement.php
+++ b/task-forces/wcag2ict/work-statement.php
@@ -2,15 +2,15 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" dir="ltr">
 	<head>
 		<?php include "../../_head.phi"; ?>
-		<title>DRAFT Accessibility Guidelines WCAG2ICT Task Force Work Statement</title>
+		<title>Accessibility Guidelines WCAG2ICT Task Force Work Statement</title>
 	</head>
 	<body>
 		<?php include "../../_header.phi"; ?>
-		<h1>DRAFT WCAG2ICT Task Force Work Statement</h1>
+		<h1>WCAG2ICT Task Force Work Statement</h1>
 		<p>The WCAG2ICT Task Force is a task force of the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group (AG WG)</a>. It assists this Working Group with the work identified below.</p>
 		<section id="status">
 			<h2>Status</h2>
-			<p>This work statement was <a href="https://lists.w3.org/Archives/Public/w3c-wai-gl/2022AprJun/0280.html">accepted by the AG WG on 22 June 2022</a>. The task force is active.</p>
+			<p>This work statement was <a href="https://lists.w3.org/Archives/Public/w3c-wai-gl/2022AprJun/0280.html">approved by the AG WG on 26 October 2022</a>. The task force is active.</p>
 			<p>NOTE: This work is mentioned in the <a href="https://www.w3.org/2019/12/ag-charter#ig-other-deliverables">Other Deliverables section of the current AG WG Charter.</a>  The continuation of the work is also included in the proposed AG WG Charter.</p>
 		</section>
 		<section id="objective">
@@ -130,16 +130,20 @@
 			<h2>Facilitation</h2>
 			<p>Staff contacts from the Accessibility Guidelines Working Group oversee attention to W3C Process with respect to the chartered requirements of the Working Group. The facilitators set agenda, lead meetings, determine consensus, and are the primary liaison to the Working Group.</p>
 			<ul>
-				<li><strong>Facilitators:</strong>
-					<a href="mailto:maryjom@us.ibm.com">Mary Jo Mueller</a> and TBD</li>
+				<li><strong>Facilitator:</strong>
+					<a href="mailto:maryjom@us.ibm.com">Mary Jo Mueller</a></li>
 				<li><strong>Technical Staff Contact:</strong>
-					<a href="https://www.w3.org/People/Brewer/">Judy Brewer</a></li>
-				<li><strong>Administrative Staff Contact:</strong>
 					<a href="http://www.w3.org/People/cooper/">Michael Cooper</a></li>
+				<li><strong>Administrative Staff Contact:</strong>
+					<a href="http://www.w3.org/People#dmontalvo">Daniel Montalvo</a></li>
 					<li><strong>Liaison to AG WG:</strong> one of the AG WG co-chairs</li>
-				<li><strong>Editorial Team:</strong> TBD</li>
+				<li><strong>Editorial Team:</strong></li>
+				<ul>
+					<li>Mary Jo Mueller</li>
+					<li>Phil Day</li>
+					<li>Chris Loiselle</li>
+				</ul>
 			</ul>
-			<p class="ednote">The TBD's above will be updated in the work statement once these positions are filled.</p>
 		</section>
 		<section id="patentpolicy">
 			<h2>Patent Policy</h2>


### PR DESCRIPTION
- Remove "Draft" from both pages.
- Updated W3C administrative staff to be Michael & Technical staff to be Daniel on both pages
- Removed TBD from facilitators, as there's one facilitator for the foreseeable future
- Overview Page: TF is now active, so updated when we are meeting, added document editors, and removed editor's note about TBD's.