### PR TITLE
Converting XML to HTML

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -103,7 +103,7 @@
 		<mkdir dir="output/guidelines/${guidelines.version}"/>
 		<copy file="css/base.css" todir="output/guidelines/${guidelines.version}"/>
 		<copy file="guidelines/guidelines.css" todir="output/guidelines/${guidelines.version}"/>
-		<copy file="guidelines/relative-luminance.xml" todir="output/guidelines/${guidelines.version}"/>
+		<copy file="guidelines/relative-luminance.html" todir="output/guidelines/${guidelines.version}"/>
 		<exec executable="curl">
 			<arg value="&quot;https://labs.w3.org/spec-generator/?type=respec&amp;url=https://raw.githack.com/w3c/wcag/master/guidelines/index.html&quot;"/>
 			<arg value="-o"/>
@@ -251,7 +251,7 @@
 		<copy file="css/base.css" todir="output/understanding/"/>
 		<copy file="understanding/understanding.css" todir="output/understanding/"/>
 		<copy file="css/slicenav.css" todir="output/understanding/"/>
-		<copy file="guidelines/relative-luminance.xml" todir="output/understanding/"/>
+		<copy file="guidelines/relative-luminance.html" todir="output/understanding/"/>
 		<copy todir="output/understanding/img/" flatten="true">
 			<fileset dir="understanding">
 				<patternset includes="*/img/*"/>

--- a/wcag20/sources/wcag2-src.REC.xml
+++ b/wcag20/sources/wcag2-src.REC.xml
@@ -1931,7 +1931,7 @@ and operating content do not rely solely on sensory characteristics of component
               
               <!--BBC: Remember to update the MathML version should this be revised -->
               <p>
-                A <loc href="relative-luminance.xml">MathML version of the relative luminance definition</loc> is available. 
+                A <loc href="relative-luminance.html">MathML version of the relative luminance definition</loc> is available. 
                   
                 
               </p>

--- a/wcag20/sources/wcag2-src.xml
+++ b/wcag20/sources/wcag2-src.xml
@@ -1932,7 +1932,7 @@ and operating content do not rely solely on sensory characteristics of component
               
               <!--BBC: Remember to update the MathML version should this be revised -->
               <p>
-                A <loc href="relative-luminance.xml">MathML version of the relative luminance definition</loc> is available. 
+                A <loc href="relative-luminance.html">MathML version of the relative luminance definition</loc> is available. 
                   
                 
               </p>


### PR DESCRIPTION
This is blocking the build: Updating file references to the relative luminance file. Hopefully straightforward and correct.

I left one reference in WCAG2ICT for http://www.w3.org/WAI/GL/WCAG20/relative-luminance.xml, assuming that's still correct for it's time.