### PR TITLE
List SC 4.1.1 as obsolete

### DIFF
--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -1,8 +1,31 @@
 <section class="sc">
    
-   <h4>Parsing</h4>
+   <h4>Parsing (Obsolete)</h4>
 
-   
-   <p>This criterion has been removed.</p>
+   <p class="conformance-level">A</p>
+
+   <p>In content implemented using markup languages, elements have complete start and end
+      tags, elements are nested according to their specifications, elements do not contain
+      duplicate attributes, and any IDs are unique, except where the specifications allow
+      these features.
+   </p>
+
+   <div class="note">
+      <p>
+         Modern web technologies have standardized how user agents parse incorrect markup. 
+         Any invalid markup is therefore allowed under 4.1.1. Parsing for HTML 5 and CSS 3. 
+         When using such technologies this success criterion is always satisfied. 
+         This success criterion is therefore obsolete.
+      </p><p>
+         Issues such as incorrect states or names due to a duplicate ID, or missing roles 
+         due to nesting interactive elements are covered by different success criteria.
+      </p>
+   </div>
+
+   <p class="note">Start and end tags that are missing a critical character in their formation, such
+      as a closing angle bracket or a mismatched attribute value quotation mark are not
+      complete.
+   </p>
+
    
 </section>

--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -18,7 +18,7 @@
          This success criterion is therefore obsolete.
       </p><p>
          Issues such as incorrect states or names due to a duplicate ID, or missing roles 
-         due to nesting interactive elements are covered by different success criteria.
+         due to inappropriately nested elements are covered by different success criteria.
       </p>
    </div>
 

--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -13,7 +13,7 @@
    <div class="note">
       <p>
          Modern web technologies have standardized how user agents parse incorrect markup. 
-         Any invalid markup is therefore allowed under 4.1.1. Parsing for technologies such as
+         Any invalid markup is therefore allowed under 4.1.1 Parsing for technologies such as
          HTML 5 and CSS 3. This success criterion is always satisfied for these technologies. 
          This success criterion is therefore obsolete.
       </p><p>

--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -23,7 +23,7 @@
    </div>
 
    <p class="note">Start and end tags that are missing a critical character in their formation, such
-      as a closing angle bracket or a mismatched attribute value quotation mark are not
+      as a closing angle bracket or a mismatched attribute value quotation mark, are not
       complete.
    </p>
 

--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -13,8 +13,8 @@
    <div class="note">
       <p>
          Modern web technologies have standardized how user agents parse incorrect markup. 
-         Any invalid markup is therefore allowed under 4.1.1. Parsing for HTML 5 and CSS 3. 
-         When using such technologies this success criterion is always satisfied. 
+         Any invalid markup is therefore allowed under 4.1.1. Parsing for technologies such as
+         HTML 5 and CSS 3. This success criterion is always satisfied for these technologies. 
          This success criterion is therefore obsolete.
       </p><p>
          Issues such as incorrect states or names due to a duplicate ID, or missing roles 


### PR DESCRIPTION
See #2820. Instead of removing the SC, I think we should have marked it as obsolete, with a note explaining not to fail it for modern technologies. I think this causes far fewer down-stream problems. Even if we don't do an errata for WCAG 2.0 and 2.1 (which I think we should), this note makes it clear that 4.1.1 should not be failed there either.