### PR TITLE
Update normative text

### DIFF
--- a/guidelines/sc/22/focus-not-obscured-enhanced.html
+++ b/guidelines/sc/22/focus-not-obscured-enhanced.html
@@ -5,7 +5,7 @@
     <p class="conformance-level">AAA</p>
 	<p class="change">New</p>
     
-    <p>When a <a>user interface component</a> receives keyboard focus, no part of the <a>focus indicator</a> is hidden by author-created content.</p>
+    <p>When a <a>user interface component</a> receives keyboard focus, no part of the component is hidden by author-created content.</p>
 
     
  </section>

--- a/understanding/22/focus-not-obscured-enhanced.html
+++ b/understanding/22/focus-not-obscured-enhanced.html
@@ -18,7 +18,7 @@
    
         <h2>Focus Not Obscured Success Criterion text</h2>
         <blockquote>
-         <p>When a <a>user interface component</a> receives keyboard focus, no part of the <a>focus indicator</a> is hidden by author-created content.</p>
+         <p>When a <a>user interface component</a> receives keyboard focus, no part of the component is hidden by author-created content.</p>
         </blockquote>
      </section>
    


### PR DESCRIPTION
Addresses #2736 with the preferred approach from Tuesday's AGWG meeting.
The requirement is reworded to focus on the obscuring of the component, not its focus indicator