### PR TITLE
special case parsing name

### DIFF
--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section class="sc" id="parsing">
    
    <h4>Parsing (Obsolete and removed)</h4>
 

--- a/xslt/base.xslt
+++ b/xslt/base.xslt
@@ -36,7 +36,12 @@
 	
 	<xsl:function name="wcag:generate-id">
 		<xsl:param name="title"/>
-		<xsl:value-of select="lower-case(replace(replace($title, '\s+', '-'), '[\s,\():]+', ''))"/>
+		<xsl:choose>
+			<xsl:when test="$title = 'Parsing (Obsolete and removed)'">parsing</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="lower-case(replace(replace($title, '\s+', '-'), '[\s,\():]+', ''))"/>
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:function>
 	
 	<xsl:function name="wcag:find-heading">


### PR DESCRIPTION
The name change of "Parsing" to "Parsing (Obsolete and removed)" caused the filename generation algorithm to break. This is a patch to special-case the parsing situation.