### PR TITLE
Update ARIA5 technique

### DIFF
--- a/techniques/aria/ARIA5.html
+++ b/techniques/aria/ARIA5.html
@@ -2,70 +2,70 @@
       <p>Technologies that support <a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA)</a>. </p>
    </section><section id="description"><h2>Description</h2>
       <p>The objective of this technique is to use <a href="https://www.w3.org/TR/wai-aria/#states_and_properties">WAI-ARIA state and property attributes</a> to expose the state, properties and values of a user interface component so that they can be read and set by assistive technology, and so that assistive technology is notified of changes to these values. The WAI-ARIA specification provides a normative description of each attribute, and the role of the user interface elements that they support. When rich internet applications define new user interface widgets, exposing the state and property attributes enables users to understand the widget and how to interact with it.</p>
-   </section><section id="examples"><h2>Examples</h2>
+   </section>
+   <section id="examples">
+      <h2>Examples</h2>
       <section class="example">
          <h3>A toggle button</h3>
-         
             <p>A widget with role <code class="att">button</code> acts as a toggle button when it implements the attribute <code class="att">aria-pressed</code>. When <code class="att">aria-pressed</code> is true, the button is in a "pressed" state. When <code class="att">aria-pressed</code> is false, it is not pressed. If the attribute is not present, the button is a simple command button.</p>
-            <p>The following snippet from The Open Ajax Accessibility Examples, Example 38, shows WAI-ARIA mark-up for a toggle button that selects bold text:</p>
+            <p>The following snippet from the <a href="https://www.w3.org/WAI/ARIA/apg/example-index/button/button.html">ARIA Authoring Practices Guide (APG) examples for button</a> shows WAI-ARIA mark-up for a toggle button to mute/unmute audio:</p>
             <pre xml:space="preserve">
-  &lt;li id="bold1"  
-    class="toggleButton"
-    role="button"
-    tabindex="0"
-    aria-pressed="false"
-    aria-labelledby="bold_label"
-    aria-controls="text1"&gt;
-    &lt;img src="http://www.oaa-accessibility.org/media/examples/images/button-bold.png" alt="bold text" align="middle"&gt;
-&lt;/li&gt;
+&lt;a tabindex="0"
+   role="button"
+   id="toggle"
+   aria-pressed="false"&gt;
+  Mute
+  …
+&lt;/a&gt;
 </pre>
-            <p>The <code class="el">li</code> element has a role of "button" and an "aria-pressed" attribute. The following excerpt from the Javascript for this example updates the value of the "aria-pressed" attribute:</p>
+            <p>The <code class="el">a</code> element has a <code>role="button"</code> and an <code>aria-pressed</code> attribute. The following excerpt from the Javascript for this example updates the value of the <code>aria-pressed</code> attribute:</p>
             <pre xml:space="preserve">                   
-                             /**
-   * togglePressed() toggles the aria-pressed atribute between true or false
-   *
-   * @param ( id object) button to be operated on
-   *
-   * @return N/A
-   */
-  function togglePressed(id) {
-  
-    // reverse the aria-pressed state
-    if ($(id).attr('aria-pressed') == 'true') {
-      $(id).attr('aria-pressed', 'false');
-    }
-    else {
-      $(id).attr('aria-pressed', 'true');
-    }
-  }
-                            </pre>
-            <p>This button is available as part of the <a href="http://www.oaa-accessibility.org/examplep/toolbar1/">working example of Example 38 - Toolbar using inline images for visual state</a>, on the OpenAjax Alliance site.</p>
+/**
+ * Toggles the toggle button’s state between *pressed* and *not pressed*.
+ *
+ * @param {HTMLElement} button
+ */
+function toggleButtonState(button) {
+  var isAriaPressed = button.getAttribute('aria-pressed') === 'true';
+
+  button.setAttribute('aria-pressed', isAriaPressed ? 'false' : 'true');
+
+  …
+}
+</pre>
          
       </section>
       <section class="example">
          <h3>A slider</h3>
          
             <p>A widget with role <code class="att">slider</code> lets a user select a value from within a given range. The slider represents the current value and the range of possible values via the size of the slider and the position of the handle. These properties of the slider are represented by the attributes <code class="att">aria-valuemin</code>, <code class="att">aria-valuemax</code>, and <code class="att">aria-valuenow</code>.</p>
-            <p>The following snippet from The Open Ajax Accessibility Examples, Example 32, shows WAI-ARIA mark-up for a slider created in Javascript. Note that the javascript sets the attributes aria-valuemin, aria-valuemax, and aria-valuenow:</p>
-            <pre xml:space="preserve">   var handle = '&lt;img id="' + id + '" class="' + (this.vert == true ? 'v':'h') +'sliderHandle" ' +
-    'src="http://www.oaa-accessibility.org/media/examples/images/slider_' + (this.vert == true ? 'v':'h') + '.png" ' + 'role="slider" ' +
-    'aria-valuemin="' + this.min +
-    '" aria-valuemax="' + this.max +
-    '" aria-valuenow="' + (val == undefined ? this.min : val) +
-           '" aria-labelledby="' + label +
-           '" aria-controls="' + controls + '" tabindex="0"&gt;&lt;/img&gt;';</pre>
-            <p>The following excerpt from the Javascript for this example updates the value of the "aria-valuenow" attribute when the value of the slider handle is changed:</p>
-            <pre xml:space="preserve"> slider.prototype.positionHandle = function($handle, val) {
-    ...
-   // Set the aria-valuenow position of the handle
-  $handle.attr('aria-valuenow', val);
-   ...
-  }
+            <p>The following snippet from the <a href="https://www.w3.org/WAI/ARIA/apg/example-index/slider/slider-color-viewer.html">ARIA Authoring Practices Guide (APG) color viewer slider example</a> shows WAI-ARIA mark-up for one of the sliders:</p>
+            <pre xml:space="preserve">
+&lt;div id="id-red" class="color-slider-label"&gt;
+   Red
+&lt;/div&gt;
+&lt;div class="color-slider red"
+      role="slider"
+      tabindex="0"
+      aria-valuemin="0"
+      aria-valuenow="128"
+      aria-valuemax="255"
+      aria-labelledby="id-red"&gt;
+   …
+&lt;/div&gt;
 </pre>
-            <p>This slider is available as part of the <a href="http://oaa-accessibility.org/example/32/">working example of Example 32 - Slider</a>, on the OpenAjax Alliance site.</p>
-         
+            <p>The following excerpt from the Javascript for this example updates the value of the <code>aria-valuenow</code> attribute when the value of the slider handle is changed:</p>
+            <pre xml:space="preserve">
+moveSliderTo(slider, value) {
+  …
+  slider.sliderNode.setAttribute('aria-valuenow', value);
+  …
+}
+</pre>
+
       </section>
-   </section><section id="tests"><h2>Tests</h2>
+   </section>
+   <section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <p>
             <a href="https://www.w3.org/TR/wai-aria/#roles_categorization">The WAI-ARIA specification, Section 5.3, Categorization of Roles</a> defines the required and inherited states and properties for each role.</p>

--- a/wcag20/sources/techniques/aria/ARIA5.xml
+++ b/wcag20/sources/techniques/aria/ARIA5.xml
@@ -24,64 +24,60 @@
          <head>A toggle button</head>
          <description>
             <p>A widget with role <att>button</att> acts as a toggle button when it implements the attribute <att>aria-pressed</att>. When <att>aria-pressed</att> is true, the button is in a "pressed" state. When <att>aria-pressed</att> is false, it is not pressed. If the attribute is not present, the button is a simple command button.</p>
-            <p>The following snippet from The Open Ajax Accessibility Examples, Example 38, shows WAI-ARIA mark-up for a toggle button that selects bold text:</p>
+            <p>The following snippet from the <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/WAI/ARIA/apg/example-index/button/button.html">ARIA Authoring Practices Guide (APG) examples for button</loc> shows WAI-ARIA mark-up for a toggle button to mute/unmute audio:</p>
             <codeblock xml:space="preserve"><![CDATA[
-  <li id="bold1"  
-    class="toggleButton"
-    role="button"
-    tabindex="0"
-    aria-pressed="false"
-    aria-labelledby="bold_label"
-    aria-controls="text1">
-    <img src="http://www.oaa-accessibility.org/media/examples/images/button-bold.png" alt="bold text" align="middle">
-</li>
+<a tabindex="0"
+   role="button"
+   id="toggle"
+   aria-pressed="false">
+  Mute
+  …
+</a>
 ]]></codeblock>
-            <p>The <el>li</el> element has a role of "button" and an "aria-pressed" attribute. The following excerpt from the Javascript for this example updates the value of the "aria-pressed" attribute:</p>
+            <p>The <el>a</el> element has a <att>role="button"</att> and an <att>aria-pressed</att> attribute. The following excerpt from the Javascript for this example updates the value of the <att>aria-pressed</att> attribute:</p>
             <codeblock xml:space="preserve"><![CDATA[                   
-                             /**
-   * togglePressed() toggles the aria-pressed atribute between true or false
-   *
-   * @param ( id object) button to be operated on
-   *
-   * @return N/A
-   */
-  function togglePressed(id) {
-  
-    // reverse the aria-pressed state
-    if ($(id).attr('aria-pressed') == 'true') {
-      $(id).attr('aria-pressed', 'false');
-    }
-    else {
-      $(id).attr('aria-pressed', 'true');
-    }
-  }
-                            ]]></codeblock>
-            <p>This button is available as part of the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="http://www.oaa-accessibility.org/examplep/toolbar1/">working example of Example 38 - Toolbar using inline images for visual state</loc>, on the OpenAjax Alliance site.</p>
+/**
+ * Toggles the toggle button’s state between *pressed* and *not pressed*.
+ *
+ * @param {HTMLElement} button
+ */
+function toggleButtonState(button) {
+  var isAriaPressed = button.getAttribute('aria-pressed') === 'true';
+
+  button.setAttribute('aria-pressed', isAriaPressed ? 'false' : 'true');
+
+  …
+}
+]]></codeblock>
          </description>
       </eg-group>
       <eg-group>
          <head>A slider</head>
          <description>
             <p>A widget with role <att>slider</att> lets a user select a value from within a given range. The slider represents the current value and the range of possible values via the size of the slider and the position of the handle. These properties of the slider are represented by the attributes <att>aria-valuemin</att>, <att>aria-valuemax</att>, and <att>aria-valuenow</att>.</p>
-            <p>The following snippet from The Open Ajax Accessibility Examples, Example 32, shows WAI-ARIA mark-up for a slider created in Javascript. Note that the javascript sets the attributes aria-valuemin, aria-valuemax, and aria-valuenow:</p>
-            <codeblock xml:space="preserve"><![CDATA[   var handle = '<img id="' + id + '" class="' + (this.vert == true ? 'v':'h') +'sliderHandle" ' +
-    'src="http://www.oaa-accessibility.org/media/examples/images/slider_' + (this.vert == true ? 'v':'h') + '.png" ' + 'role="slider" ' +
-    'aria-valuemin="' + this.min +
-    '" aria-valuemax="' + this.max +
-    '" aria-valuenow="' + (val == undefined ? this.min : val) +
-           '" aria-labelledby="' + label +
-           '" aria-controls="' + controls + '" tabindex="0"></img>';]]></codeblock>
-            <p>The following excerpt from the Javascript for this example updates the value of the "aria-valuenow" attribute when the value of the slider handle is changed:</p>
-            <codeblock xml:space="preserve"><![CDATA[ slider.prototype.positionHandle = function($handle, val) {
-    ...
-   // Set the aria-valuenow position of the handle
-  $handle.attr('aria-valuenow', val);
-   ...
-  }
+            <p>The following snippet from the <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/WAI/ARIA/apg/example-index/slider/slider-color-viewer.html">ARIA Authoring Practices Guide (APG) color viewer slider example</loc> shows WAI-ARIA mark-up for one of the sliders:</p>
+            <codeblock xml:space="preserve"><![CDATA[
+<div id="id-red" class="color-slider-label">
+   Red
+</div>
+<div class="color-slider red"
+      role="slider"
+      tabindex="0"
+      aria-valuemin="0"
+      aria-valuenow="128"
+      aria-valuemax="255"
+      aria-labelledby="id-red">
+   …
+</div>
 ]]></codeblock>
-            <p>This slider is available as part of the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="http://oaa-accessibility.org/example/32/">working example of Example 32 - Slider</loc>, on the OpenAjax Alliance site.</p>
+            <p>The following excerpt from the Javascript for this example updates the value of the <att>>aria-valuenow</att> attribute when the value of the slider handle is changed:</p>
+            <codeblock xml:space="preserve"><![CDATA[
+moveSliderTo(slider, value) {
+  …
+  slider.sliderNode.setAttribute('aria-valuenow', value);
+  …
+}
+]]></codeblock>
          </description>
       </eg-group>
    </examples>


### PR DESCRIPTION
* remove the link and reference to the old oaa-accessibility.org Open Ajax Alliance site, which has since lapsed and been replaced with an online gambling site
* update the examples to use the new APG pattern examples

It doesn't look like there's any other references/links to oaa-accessibility.org throughout the site/examples.

Closes https://github.com/w3c/wcag/issues/2924