### PR TITLE
C27 corrections

### DIFF
--- a/techniques/css/C27.html
+++ b/techniques/css/C27.html
@@ -31,8 +31,7 @@
       
          <ul>
          <li><a href="https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/">How users change colours on websites (gov.uk)</a></li>
-           <li>Most browsers offer developer tools to inspect the source code. These tools can usually  be called up by pressing F12 or via the browser settings.</li>
-           <li>
+           <li>Most browsers offer developer tools to inspect the source code. These tools can usually  be called up by pressing F12 or via the browser settings.      
             <ul>
             <li>
                   <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Web Developer Toolbar (Chrome)</a>. Allows examination of the source code with CSS turned off in Chrome. This can be helpful in determining whether reading order and source code order match.</li>

--- a/techniques/css/C27.html
+++ b/techniques/css/C27.html
@@ -30,11 +30,11 @@
    </ul></section><section id="resources"><h2>Resources</h2>
       
          <ul>
-           <li>Most browsers offer developer tools to inspect source code. This can often be called up by pressing F12 or displayed via the browser settings.</li>
+           <li>Most browsers offer developer tools to inspect the source code. These tools can usually  be called up by pressing F12 or via the browser settings.</li>
            <li>
-                  <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Web Developer Toolbar (Chrome)</a>. Allows examination of sourche code with CSS turned off in Chrome. This can be helpful in determining whether reading order and source code order match.</li>
+                  <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Web Developer Toolbar (Chrome)</a>. Allows examination of the source code with CSS turned off in Chrome. This can be helpful in determining whether reading order and source code order match.</li>
             <li>
-                  <a href="https://addons.mozilla.org/de/firefox/addon/web-developer/">The Web Developer Toolbar (Firefox)</a>. Allows examination of sourche code with CSS turned off in Firefox. This can be helpful in determining whether reading order and source code order match.</li>
+                  <a href="https://addons.mozilla.org/de/firefox/addon/web-developer/">The Web Developer Toolbar (Firefox)</a>. Allows examination of the source code with CSS turned off in Firefox. This can be helpful in determining whether reading order and source code order match.</li>
          </ul>
       
    </section></body></html>

--- a/techniques/css/C27.html
+++ b/techniques/css/C27.html
@@ -30,10 +30,11 @@
    </ul></section><section id="resources"><h2>Resources</h2>
       
          <ul>
+           <li>Most browsers offer developer tools to inspect source code. This can often be called up by pressing F12 or displayed via the browser settings.</li>
+           <li>
+                  <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Web Developer Toolbar (Chrome)</a>. Allows examination of sourche code with CSS turned off in Chrome. This can be helpful in determining whether reading order and source code order match.</li>
             <li>
-                  <a href="http://www.microsoft.com/en-us/download/details.aspx?id=18359">Microsoft Internet Explorer Developer Toolbar</a>. Allows examination of script-generated DOM in Microsoft Internet Explorer.</li>
-            <li>
-                  <a href="http://getfirebug.com/">Firebug</a>. Allows examination of script-generated DOM in Firefox.</li>
+                  <a href="https://addons.mozilla.org/de/firefox/addon/web-developer/">The Web Developer Toolbar (Firefox)</a>. Allows examination of sourche code with CSS turned off in Firefox. This can be helpful in determining whether reading order and source code order match.</li>
          </ul>
       
    </section></body></html>

--- a/techniques/css/C27.html
+++ b/techniques/css/C27.html
@@ -30,11 +30,17 @@
    </ul></section><section id="resources"><h2>Resources</h2>
       
          <ul>
+         <li><a href="https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/">How users change colours on websites (gov.uk)</a></li>
            <li>Most browsers offer developer tools to inspect the source code. These tools can usually  be called up by pressing F12 or via the browser settings.</li>
            <li>
+            <ul>
+            <li>
                   <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Web Developer Toolbar (Chrome)</a>. Allows examination of the source code with CSS turned off in Chrome. This can be helpful in determining whether reading order and source code order match.</li>
             <li>
                   <a href="https://addons.mozilla.org/de/firefox/addon/web-developer/">The Web Developer Toolbar (Firefox)</a>. Allows examination of the source code with CSS turned off in Firefox. This can be helpful in determining whether reading order and source code order match.</li>
-         </ul>
+                  </ul>
+                  </li>
+        
+        </ul>
       
    </section></body></html>


### PR DESCRIPTION
* Removed references to Internet explorer tool bar and Firebug
* Added a generic advice to use Browser developer tools
* Added links to Web Developer Toolbar (Chrome and Firefox)

[Making the DOM order match the visual order](https://raw.githack.com/w3c/wcag/cb9e966f5a674835cef95155813dea4de7b0132f/techniques/css/C27.html) (GitHack rendering)

Closes #2937 