### PR TITLE
New Failure Technique F109 for Issue #1918 Accessible Authentication needs better techniques

### DIFF
--- a/techniques/failures/F109.HTML
+++ b/techniques/failures/F109.HTML
@@ -1,0 +1,80 @@
+<!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+ 
+ <head><title>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</title>
+   
+ <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
+      <p>All technologies.</p>
+   </section><section id="description"><h2>Description</h2>
+      <p>The objective of this technique is to describe how requiring users to enter a subset of characters in a password is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). 
+				
+				using white space
+                        characters, such as space, tab, line break, or carriage return, to format tables in text
+                        content is a failure to use structure properly. When tables are created in
+                        this manner there is no way to indicate that a cell is intended to be a
+                        header cell, no way to associate the table header cells with the table data
+                        cells, or to navigate directly to a particular cell in a table.</p>
+      <p>In addition, assistive technologies will interpret content in the reading
+                        order of the current language. Using white space to organize data in a
+                        visual table does not provide the information in a natural reading order in
+                        the source of the document. Thus, the assistive technology user will not be
+                        presented with the information in a logical reading order.</p>
+      <p>Plain text is not suitable for displaying complex information like tables
+                        because the structure of the table cannot be perceived. Rather than using
+                        visual formatting to represent tabular relations, 
+            tabular information would need to be presented using a different technology or presented linearly. (See Presenting tabular information in plain text)</p>
+      
+   </section><section id="examples"><h2>Examples</h2>
+      <section class="example">
+         
+            <p>The following example incorrectly uses white space to format a Menu
+                                as a visual table.</p>
+         
+         <pre xml:space="preserve">
+Menu
+         Breakfast        Lunch           Dinner
+
+Monday   2 fried eggs    tomato soup     garden salad
+         bacon           hamburger       Fried Chicken
+         toast           onion rings     green beans
+                         Oatmeal cookie  mashed potatoes
+
+Tuesday   Pancakes       vegetable soup  Caesar salad
+          sausage        hot dogs        Spaghetti with meatballs
+          orange juice   potato salad    Italian bread
+                         brownie         ice cream
+</pre>
+         
+            <p>If this table was to be interpreted and spoken by a screen reader it
+                                would speak the following lines:</p>
+            <ul>
+               <li>Menu</li>
+               <li>Breakfast Lunch Dinner</li>
+               <li>Monday 2 fried eggs tomato soup garden salad</li>
+               <li>bacon hamburger Fried Chicken</li>
+               <li>toast onion rings green beans</li>
+               <li>Oatmeal cookie mashed potatoes</li>
+            </ul>
+            <p>This reading order does not make sense since there is no structure in
+                                the table for the assistive technology to identify it as a table. If
+                                the text were reflowed, or changed from a fixed to a variable font,
+                                or increased in size until lines no longer fit on the page, similar
+                                issues would arise in the visual presentation.</p>
+         
+      </section>
+   </section><section id="tests"><h2>Tests</h2>
+      <section class="procedure"><h3>Procedure</h3>
+         <ol>
+            <li>Examine the document for visually formatted tables.</li>
+            <li>Check whether the tables are created using white space characters
+                                    to layout the tabular data.</li>
+         </ol>
+      </section>
+      <section class="results"><h3>Expected Results</h3>
+         <ul>
+            <li>If step #2 is true, then this failure condition applies and the
+                                    content fails these Success Criteria.</li>
+         </ul>
+      </section>
+   </section><section id="related"><h2>Related Techniques</h2><ul>
+      <li><a href="../html/H51">H51</a></li>
+   </ul></section><section id="resources"><h2>Resources</h2></section></body></html>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -5,7 +5,7 @@
  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="/understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
+      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="/wcag/understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
 				
       
    </section><section id="examples"><h2>Examples</h2>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -5,15 +5,15 @@
  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
+      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="/understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
 				
       
    </section><section id="examples"><h2>Examples</h2>
-   The following examples prevent a user from auto-filling a password using a password manager, or copying the password into a field.
+   These  examples would prevent a user from auto-filling a password using a password manager, or copying the password into a field:
      <ul>
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
 				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
-        <li>A password input fieldset composed of <code class="el">&lt;select&gt;</code> elements that requires a user to select each character of a fixed-length password from downdown fields.</li>
+        <li>A password input fieldset composed of <code class="el">&lt;select&gt;</code> elements that requires a user to select each character of a fixed-length password from individual dropdown fields.</li>
 			</ul>
    </section>
    
@@ -21,7 +21,7 @@
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check whether the password input format prevents the user from pasting or auto-filling their entire password in one action.</li>
-            <li>Confirm that no other acceptable authentication methods exist that satisfy Success Criteria 3.3.8 or 3.39 (such as an authentication method that does not rely on a cognitive function test).</li>
+            <li>Confirm that no other acceptable authentication methods are present that satisfy Success Criteria 3.3.8 or 3.39 (such as an authentication method that does not rely on a cognitive function test).</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -2,10 +2,10 @@
  
  <head><title>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</title>
    
- <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
+ <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual passphrase characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies that require authentication.</p>
    </section><section id="description"><h2>Description</h2>
-  <p>Requiring users to authenticate by entering a password in a different format from which it was originally created is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). If a user is required to enter individual password characters across multiple fields, in a way that prevents pasting the password in a single action, it prevents use of a password manager or pasting from local copy of the password. This means users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the password, or just a subset.</p>
+  <p>Requiring users to authenticate by entering a password or passcode in a different format from which it was originally created is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). If a user is required to enter individual password characters across multiple fields, in a way that prevents pasting the password in a single action, it prevents use of a password manager or pasting from local copy of the password or passcode. This means users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the string, or just a subset.</p>
   
   
    </section><section id="examples"><h2>Examples</h2>
@@ -20,7 +20,7 @@
    <section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
-            <li>Check if the structure of the password input field(s) prevents the user from pasting or auto-filling their entire password in the format in which it was originally created.</li>
+            <li>Check if the structure of the input field(s) prevents the user from pasting or auto-filling the entire password or passcode in the format in which it was originally created.</li>
             <li>Confirm that no other acceptable authentication methods are present that satisfy Success Criteria 3.3.8 or 3.3.9 (such as an authentication method that does not rely on a cognitive function test).</li>
          </ol>
       </section>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -5,23 +5,8 @@
  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>The objective of this technique is to describe how requiring users to enter a subset of characters in a password is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). 
+      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
 				
-				using white space
-                        characters, such as space, tab, line break, or carriage return, to format tables in text
-                        content is a failure to use structure properly. When tables are created in
-                        this manner there is no way to indicate that a cell is intended to be a
-                        header cell, no way to associate the table header cells with the table data
-                        cells, or to navigate directly to a particular cell in a table.</p>
-      <p>In addition, assistive technologies will interpret content in the reading
-                        order of the current language. Using white space to organize data in a
-                        visual table does not provide the information in a natural reading order in
-                        the source of the document. Thus, the assistive technology user will not be
-                        presented with the information in a logical reading order.</p>
-      <p>Plain text is not suitable for displaying complex information like tables
-                        because the structure of the table cannot be perceived. Rather than using
-                        visual formatting to represent tabular relations, 
-            tabular information would need to be presented using a different technology or presented linearly. (See Presenting tabular information in plain text)</p>
       
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -21,7 +21,7 @@
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check whether the structure of the password input field(s) prevent the user from pasting or auto-filling their entire password in the format in which it was originally created.</li>
-            <li>Confirm that no other acceptable authentication methods are present that satisfy Success Criteria 3.3.8 or 3.39 (such as an authentication method that does not rely on a cognitive function test).</li>
+            <li>Confirm that no other acceptable authentication methods are present that satisfy Success Criteria 3.3.8 or 3.3.9 (such as an authentication method that does not rely on a cognitive function test).</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -13,9 +13,7 @@
      <ul>
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
 				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
-        <li>A password input fieldset composed of <pre xml:space="preserve">
-        &lt;p&gt;select&lt;p&gt;
-        </pre> elements that requires a user to select each character of a fixed-length password from downdown fields.<li>
+        <li>A password input fieldset composed of <pre xml:space="preserve">&lt;select&gt;</pre> elements that requires a user to select each character of a fixed-length password from downdown fields.<li>
 			</ul>
    </section>
    

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -12,7 +12,7 @@
   <p>These examples would prevent a user from entering a password in the same format in which the password was originally created:</p>
      <ul>
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character.</li>
-				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields (unless the user can paste the entire 6-digit passcode into one field, and the remaining fields are populated automatically).</li>
+				<li>A fieldset that prompts a user to enter each digit of a passcode in a separate input (unless the user can paste the entire passcode in the first input, and the remaining inputs are populated automatically).</li>
         <li>A password input fieldset composed of <code class="el">&lt;select&gt;</code> elements that requires a user to select each character of a fixed-length password from individual dropdown fields.</li>
 			</ul>
    </section>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -2,7 +2,7 @@
  
  <head><title>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</title>
    
- <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
+ <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies.</p>
    </section><section id="description"><h2>Description</h2>
       <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -5,14 +5,14 @@
  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies that require authentication.</p>
    </section><section id="description"><h2>Description</h2>
-  <p>Requiring users to authenticate by entering a password in a different format from which it was originally created is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Requiring users to enter individual characters of a single password across multiple fields prevents users pasting credentials from a password manager or local copy of the password. This means users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the password, or a subset thereof.</p>
+  <p>Requiring users to authenticate by entering a password in a different format from which it was originally created is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). If a user is required to enter individual password characters across multiple fields, in a way that prevents pasting the password in a single action, it prevents use of a password manager or pasting from local copy of the password. This means users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the password, or just a subset.</p>
   
   
    </section><section id="examples"><h2>Examples</h2>
-  <p>These examples would prevent a user from filling a password in the same format in which the password was origianlly created:</p>
+  <p>These examples would prevent a user from entering a password in the same format in which the password was originally created:</p>
      <ul>
-				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
-				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
+				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character.</li>
+				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields (unless the user can paste the entire 6-digit passcode into one field, and the remaining fields are populated automatically).</li>
         <li>A password input fieldset composed of <code class="el">&lt;select&gt;</code> elements that requires a user to select each character of a fixed-length password from individual dropdown fields.</li>
 			</ul>
    </section>
@@ -20,14 +20,13 @@
    <section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
-            <li>Check whether the structure of the password input field(s) prevent the user from pasting or auto-filling their entire password in the format in which it was originally created.</li>
+            <li>Check if the structure of the password input field(s) prevents the user from pasting or auto-filling their entire password in the format in which it was originally created.</li>
             <li>Confirm that no other acceptable authentication methods are present that satisfy Success Criteria 3.3.8 or 3.3.9 (such as an authentication method that does not rely on a cognitive function test).</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>
          <ul>
-            <li>If steps #1 and #2 are true, then this failure condition applies and content
-                            fails the Success Criterion.</li>
+            <li>If steps #1 and #2 are true, then this failure condition applies and content fails the Success Criterion.</li>
          </ul>
       </section>
    </section><section id="related"><h2>Related Techniques</h2></section>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -5,7 +5,7 @@
  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>All technologies.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="/wcag/understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
+      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
 				
       
    </section><section id="examples"><h2>Examples</h2>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -9,57 +9,28 @@
 				
       
    </section><section id="examples"><h2>Examples</h2>
-      <section class="example">
-         
-            <p>The following example incorrectly uses white space to format a Menu
-                                as a visual table.</p>
-         
-         <pre xml:space="preserve">
-Menu
-         Breakfast        Lunch           Dinner
-
-Monday   2 fried eggs    tomato soup     garden salad
-         bacon           hamburger       Fried Chicken
-         toast           onion rings     green beans
-                         Oatmeal cookie  mashed potatoes
-
-Tuesday   Pancakes       vegetable soup  Caesar salad
-          sausage        hot dogs        Spaghetti with meatballs
-          orange juice   potato salad    Italian bread
-                         brownie         ice cream
-</pre>
-         
-            <p>If this table was to be interpreted and spoken by a screen reader it
-                                would speak the following lines:</p>
-            <ul>
-               <li>Menu</li>
-               <li>Breakfast Lunch Dinner</li>
-               <li>Monday 2 fried eggs tomato soup garden salad</li>
-               <li>bacon hamburger Fried Chicken</li>
-               <li>toast onion rings green beans</li>
-               <li>Oatmeal cookie mashed potatoes</li>
-            </ul>
-            <p>This reading order does not make sense since there is no structure in
-                                the table for the assistive technology to identify it as a table. If
-                                the text were reflowed, or changed from a fixed to a variable font,
-                                or increased in size until lines no longer fit on the page, similar
-                                issues would arise in the visual presentation.</p>
-         
-      </section>
-   </section><section id="tests"><h2>Tests</h2>
+   The following examples prevent a user from auto-filling a password using a password manager, or copying the password into a field.
+     <ul>
+				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
+				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
+        <li>A password input fieldset composed of <pre xml:space="preserve">
+        <select>
+        </pre> elements that requires a user to select each character of a fixed-length password from downdown fields.<li>
+			</ul>
+   </section>
+   
+   <section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
-            <li>Examine the document for visually formatted tables.</li>
-            <li>Check whether the tables are created using white space characters
-                                    to layout the tabular data.</li>
+            <li>Check whether the password input format prevents the user from pasting or auto-filling their entire password in one action.</li>
+            <li>Confirm that no other acceptable authentication methods exist that satisfy Success Criteria 3.3.8 or 3.39 (such as an authentication method that does not rely on a cognitive function test).</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>
          <ul>
-            <li>If step #2 is true, then this failure condition applies and the
-                                    content fails these Success Criteria.</li>
+            <li>If steps #1 and #2 are true, then this failure condition applies and content
+                            fails the Success Criterion.</li>
          </ul>
       </section>
-   </section><section id="related"><h2>Related Techniques</h2><ul>
-      <li><a href="../html/H51">H51</a></li>
-   </ul></section><section id="resources"><h2>Resources</h2></section></body></html>
+   </section><section id="related"><h2>Related Techniques</h2></section>
+   <section id="resources"><h2>Resources</h2></section></body></html>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -9,7 +9,7 @@
 				
       
    </section><section id="examples"><h2>Examples</h2>
-   These  examples would prevent a user from auto-filling a password using a password manager, or copying the password into a field:
+  <p>These  examples would prevent a user from auto-filling a password using a password manager, or copying the password into a field:</p>
      <ul>
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
 				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -3,13 +3,13 @@
  <head><title>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</title>
    
  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></head><body><h1>Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</h1><section class="meta"><p class="id">ID: F109</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
-      <p>All technologies.</p>
+      <p>All technologies that require authentication.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>Requiring users to transcribe a password by modifying the password input format is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Using an input format that differs from the format in which the password is stored in a password manager or local copy of the password means that users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>.</p>
-				
-      
+  <p>Requiring users to authenticate by entering a password in a different format from which it was originally created is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authenticaton methods are available). Requiring users to enter individual characters of a single password across multiple fields prevents users pasting credentials from a password manager or local copy of the password. This means users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the password, or a subset thereof.</p>
+  
+  
    </section><section id="examples"><h2>Examples</h2>
-  <p>These  examples would prevent a user from auto-filling a password using a password manager, or copying the password into a field:</p>
+  <p>These examples would prevent a user from filling a password in the same format in which the password was origianlly created:</p>
      <ul>
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
 				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
@@ -20,7 +20,7 @@
    <section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
-            <li>Check whether the password input format prevents the user from pasting or auto-filling their entire password in one action.</li>
+            <li>Check whether the structure of the password input field(s) prevent the user from pasting or auto-filling their entire password in the format in which it was originally created.</li>
             <li>Confirm that no other acceptable authentication methods are present that satisfy Success Criteria 3.3.8 or 3.39 (such as an authentication method that does not rely on a cognitive function test).</li>
          </ol>
       </section>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -14,7 +14,7 @@
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
 				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
         <li>A password input fieldset composed of <pre xml:space="preserve">
-        <select>
+        &lt;p&gt;select&lt;p&gt;
         </pre> elements that requires a user to select each character of a fixed-length password from downdown fields.<li>
 			</ul>
    </section>

--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -13,7 +13,7 @@
      <ul>
 				<li>A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character</li>
 				<li>A fieldset that prompts a user to enter all digits of a 6-digit passcode, across 6 individual fields.</li>
-        <li>A password input fieldset composed of <pre xml:space="preserve">&lt;select&gt;</pre> elements that requires a user to select each character of a fixed-length password from downdown fields.<li>
+        <li>A password input fieldset composed of <code class="el">&lt;select&gt;</code> elements that requires a user to select each character of a fixed-length password from downdown fields.</li>
 			</ul>
    </section>
    

--- a/understanding/22/accessible-authentication-enhanced.html
+++ b/understanding/22/accessible-authentication-enhanced.html
@@ -119,7 +119,11 @@
       
       <section id="failure">
          <h3>Failures for Accessible Authentication (Enhanced)</h3>
-
+         <ol>
+            <li>
+               <a href="../../techniques/failures/F109.html">Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</a>
+            </li>
+         </ol>
       </section>
       
    </section>

--- a/understanding/22/accessible-authentication.html
+++ b/understanding/22/accessible-authentication.html
@@ -148,6 +148,13 @@
       
       <section id="failure">
          <h3>Failures for Accessible Authentication</h3>
+         <ol>
+            <li>
+               <a href="../../techniques/failures/F109.html">Failure of Success Criterion 3.3.8 and 3.3.9 due to forcing transcription of individual password characters</a>
+            </li>
+         </ol>
+      </section>
+
 
       </section>
       


### PR DESCRIPTION
- Created new failure technique F109 for forcing transcription of individual password characters, including some examples of failures I've seen in the wild
- Linked out to this new failure technique from the Understanding pages for SC3.3.8 and 3.3.9

#1916 