### PR TITLE
Fix padding issue in nav bar

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -289,10 +289,6 @@ width: 2em;
 height: 2em;
 }
 
-.standalone-resource-pager {
-padding: .7em 0;
-}
-
 .standalone-resource-pager ul {
 display: block;
 }


### PR DESCRIPTION
There is some whitespace underneath the navigation that looks quite out of place:

<img width="796" alt="navigation with some whitespace at the bottom, indicated with dev tools, the nav is clearly larger than the space that is meant for it" src="https://user-images.githubusercontent.com/178782/216103713-cc2df6ee-a7fe-44e0-a161-b66feedefd2e.png">

This PR fixes it by removing that extra padding, so that the navigation is the same height as the items in it, this makes it looks more tidy, like this: 

<img width="830" alt="same as above but with extra space removed" src="https://user-images.githubusercontent.com/178782/216104049-fc2af9e6-8334-4b74-96a9-2bc6564e3bf1.png">
