### PR TITLE
Changes/corrections to 1.4.3 and 1.4.6 understanding

### DIFF
--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -8,10 +8,8 @@
 <body>
    <h1>Understanding Contrast (Enhanced)</h1>
    
-   
    <section id="intent">
       <h2>Intent of Contrast (Enhanced)</h2>
-      
       
       <p>The intent of this Success Criterion is to provide enough contrast between text and
          its background so that it can be read by people with moderately low vision (who do
@@ -27,7 +25,6 @@
          words are used to create a background and the words could be rearranged or substituted
          without changing meaning, then it would be decorative and would not need to meet this
          criterion. 
-         
       </p>
       
       <p>Text that is larger and has wider character strokes is easier to read at lower contrast.
@@ -37,53 +34,52 @@
          enough to require a lower contrast ratio. (See The American Printing House for the
          Blind Guidelines for Large Printing and The Library of Congress Guidelines for Large
          Print under 
-         <a href="#visual-audio-contrast7-resources-head">Resources</a>). "18 point" and "bold" can both have different meanings in different fonts but,
-         except for very thin or unusual fonts, they should be sufficient. Since there are
-         so many different fonts, the general measures are used and a note regarding fancy
-         or thin fonts is included.
+         <a href="#resources">Resources</a>). "18 point" and "bold" can both have different meanings in
+         different fonts but, except for very thin or unusual fonts, they should be sufficient. Since there
+         are so many different fonts, the general measures are used and a note regarding thin or unusual
+         fonts is included if the definition for <a>large-scale</a> text.
       </p>
       
       <div class="note">
-         
-         <p>The point size should be obtained from the user agent, or calculated based on font
-            metrics as the user agent does when evaluating this success criterion. Point sizes
-            are based on the CSS pt size as defined in 
-            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
-            and 18pt are equivalent to approximately 18.5px and 24px.
+         <p>When evaluating this Success Criterion, the font size in points should be obtained
+            from the user agent or calculated on font metrics in the way that user agents do.
+            Point sizes are based on the CSS <code>pt</code> size as defined in 
+            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between
+            sizes in points and CSS pixels is <code>1pt = 1.333px</code>, therefore <code>14pt</code>
+            and <code>18pt</code> are equivalent to approximately <code>18.5px</code> and <code>24px</code>.
          </p>
-         
-         <p>When fonts have anti-aliasing applied to make them look smoother, they can lose darkness
-            or lightness.  Thus, the actual contrast can be reduced. Thicker stem widths will
-            reduce this effect (thin fonts could have the full stem lightened rather than just
-            the ends). Using larger fonts and testing for legibility in user agents with font
-            smoothing turned on is recommended.
-            
-         </p>
-         
          <p>Because different image editing applications default to different pixel densities
-            (ex. 72 PPI or 96 PPI), specifying point sizes for fonts from within an image editing
-            application can be unreliable when it comes to presenting text at a specific size.
+            (e.g. <code>72ppi</code> or <code>96ppi</code>), specifying point sizes for fonts from within an
+            image editing application can be unreliable when it comes to presenting text at a specific size.
             When creating images of large-scale text, authors should ensure that the text in the
             resulting image is roughly equivalent to 1.2 and 1.5 em or to 120% or 150% of the
-            default size for body text as rendered by the browser.
+            default size for body text. For example, for a <code>72ppi</code> image, an author would need
+            to use approximately 19pt and 24pt font sizes in order to successfully present images
+            of large-scale text to a user. 
          </p>
          <p>The 7:1 and 4.5:1 contrast ratios referenced in this Success Criterion are intended to be
             treated as threshold values. When comparing the computed contrast ratio to the Success Criterion
             ratio, the computed values should not be rounded (e.g. 4.499:1 would not meet the 4.5:1 threshold).</p>
-         
+      </div>
+
+      <div class="note">
+         <p>Due to anti-aliasing, particularly thin or unusual fonts may be rendered by user agents with a much fainter
+            color than the actual text color defined in the underlying CSS. This can lead to situations where text has
+            a contrast ratio that nominally passes the Success Criterion, but has a much lower contrast in practice.
+            For these cases, we recommend as a best practice that authors choose a font with stronger/thicker lines,
+            or aim for a text color that exceeds the baseline requirements of this Success Criterion.
+         </p>
       </div>
       
-      <p>The previously-mentioned contrast requirements for text also apply to
-         images of text (text that has been rendered into pixels and then stored in an image
-         format) as stated in Success Criterion 1.4.5
-         
-         
+      <p>The contrast requirements for text also apply to images of text
+         (text that has been rendered into pixels and then stored in an image format) - see
+         <a href="images-of-text">Success Criterion 1.4.5: Images of Text</a>.
       </p>
       
       <p>This requirement applies to situations in which images of text were intended to be
          understood as text. Incidental text, such as in photographs that happen to include
          a street sign, are not included. Nor is text that for some reason is designed to be
-         invisible to all users. Stylized text, such as in corporate logos, should be treated
+         invisible to all viewers. Stylized text, such as in corporate logos, should be treated
          in terms of its function on the page, which may or may not warrant including the content
          in the text alternative. Corporate visual guidelines beyond logo and logotype are
          not included in the exception.
@@ -96,14 +92,31 @@
          in order to get a particular look. 
       </p>
       
-      <p>Although this Success Criterion only applies to text, similar issues occur for content presented in charts, graphs, diagrams, and other non-text-based information which is covered by 
-         <a href="../21/non-text-contrast.html">Success Criterion 1.4.11 Non-Text Contrast</a>.         
+      <div class="note">
+         
+         <p>Images of text do not scale as well as text because they tend to pixelate. It is also
+            harder to change foreground and background contrast and color combinations for images
+            of text, which is necessary for some users. Therefore, we suggest using text wherever
+            possible, and when not, consider supplying an image of higher resolution.
+            
+         </p>
+         
+      </div>
+      
+      <p>The minimum contrast Success Criterion (1.4.3) applies to text in the page, including
+         placeholder text and text that is shown when a pointer is hovering over an object
+         or when an object has keyboard focus. If any of these are used in a page, the text
+         needs to provide sufficient contrast.
+      </p>
+      
+      <p>Although this Success Criterion only applies to text, similar issues occur for content presented
+         in charts, graphs, diagrams, and other non-text-based information which is covered by
+         <a href="non-text-contrast">Success Criterion 1.4.11 Non-Text Contrast</a>.         
       </p>
       
       <section>
          
          <h3>Rationale for the Ratios Chosen</h3>
-         
          
          <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] for standard text and vision. The 4.5:1 ratio is used in Success Criterion 1.4.3
             to account for the loss in contrast that results from moderately low visual acuity,
@@ -136,11 +149,22 @@
             [[ARDITI]].
          </p>
          
+         <div class="note">
+            
+            <p>Some people with cognitive disabilities require color combinations or hues that have
+               low contrast, and therefore we allow and encourage authors to provide mechanisms to
+               adjust the foreground and background colors of the content. Some of the combinations
+               that could be chosen may have contrast levels that will be lower than those found
+               in the Success Criteria. This is not a violation of this Success Criterion provided
+               there is a mechanism that will return to the default values set out here.
+            </p>          
+            
+         </div>
+         
          <p>The contrast ratio of 4.5:1 was chosen for level AA because it compensated for the
             loss in contrast sensitivity usually experienced by users with vision loss equivalent
             to approximately 20/40 vision. (20/40 calculates to approximately 4.5:1.) 20/40 is
             commonly reported as typical visual acuity of elders at roughly age 80. [[GITTINGS-FOZARD]] 
-            
          </p>
          
          <p>The contrast ratio of 7:1 was chosen for level AAA because it compensated for the
@@ -154,9 +178,8 @@
          </p>
          
          <div class="note">
-            
-            <p>Calculations in [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] are for body text. A relaxed contrast ratio is provided for text that is much larger.</p>
-            
+            <p>Calculations in [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] are for body text. A relaxed contrast
+               ratio is provided for text that is much larger.</p>
          </div>
          
       </section>
@@ -167,10 +190,10 @@
          
          <p>Conversion from nonlinear to linear RGB values is based on IEC/4WD 61966-2-1 [[IEC-4WD]].</p>
          
-         <p>The formula (L1/L2) for contrast is based on [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] standards.</p>
+         <p>The formula (<code>L1/L2</code>) for contrast is based on [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] standards.</p>
          
          <p>The ANSI/HFS 100-1988 standard calls for the contribution from ambient light to be
-            included in the calculation of L1 and L2. The .05 value used is based on Typical Viewing
+            included in the calculation of L1 and L2. The <code>.05</code> value used is based on Typical Viewing
             Flare from [[IEC-4WD]].
          </p>
          
@@ -181,18 +204,14 @@
          </p>
          
          <div class="note">
-            
             <p>
-               	Refer to 
-               <a href="#visual-audio-contrast7-resources-head">related resources</a> for a list of tools that utilize the contrast ratio to analyze the contrast of Web
-               content. 
-               
+               Refer to 
+               <a href="#resources">related resources</a> for a list of tools that utilize the contrast ratio
+               to analyze the contrast of Web content.
             </p>
-            
             <p>See also 
                <a href="focus-visible">2.4.7: Focus Visible</a> for techniques for indicating keyboard focus.
             </p>
-            
          </div>
          
       </section>
@@ -230,57 +249,39 @@
       <ul>
          
          <li>
-            								       
             <a href="https://www.tpgi.com/color-contrast-checker/">Colour Contrast Analyser application</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://juicystudio.com/services/luminositycontrastratio.php">Luminosity Colour Contrast Ratio Analyser</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://snook.ca/technical/colour_contrast/colour.html">Colour Contrast Check</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://www.msfw.com/Services/ContrastRatioCalculator">Contrast Ratio Calculator</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://color.adobe.com/create/color-contrast-analyzer">Adobe Color - Color Contrast Analyzer Tool</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://www.w3.org/Graphics/atypical-color-response">Atypical colour response</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="http://www.colorsontheweb.com/colorcontrast.asp">Colors On the Web Color Contrast Analyzer</a>
-            							     
          </li>
          
          <li>
-            
             <a href="https://www.iansyst.co.uk/fonts/">Reading with Dyslexia - Fonts that can help alleviate visual stress.</a>
-            
          </li>
          
          <li>
-            
             <a href="https://blog.dyslexia.com/good-fonts-for-dyslexia-an-experimental-study/">Good Fonts for Dyslexia - An Experimental Study</a>
-            
          </li>
          
       </ul>
@@ -302,27 +303,21 @@
             <ol>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G17" class="general">Ensuring that  contrast of at least 10:1 exists between text and background behind
                      the text
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G148" class="general">Not specifying background color, not specifying text color, and not using technology
                      features that change those defaults
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G174" class="general">Providing a control with a sufficient contrast ratio that allows users to switch to
                      a presentation that uses sufficient contrast
                   </a>
-                  									         
                </li>
                
             </ol>
@@ -336,27 +331,21 @@
             <ol>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G18" class="general">Ensuring that a contrast ratio of at least 4.5:1 exists between text and background
                      behind the text
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G148" class="general">Not specifying background color, not specifying text color, and not using technology
                      features that change those defaults
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G174" class="general">Providing a control with a sufficient contrast ratio that allows users to switch to
                      a presentation that uses sufficient contrast
                   </a>
-                  									         
                </li>
                
             </ol>
@@ -372,9 +361,7 @@
          <ul>
             
             <li>
-               									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G156" class="general">G156</a>
-               								       
             </li>
             
          </ul>
@@ -388,19 +375,15 @@
          <ul>
             
             <li>
-               									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F24" class="failure">Failure of Success Criterion 1.4.3 due to specifying foreground colors without specifying
                   background colors or vice versa
                </a>
-               								       
             </li>
             
             <li>
-               									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F83" class="failure">Failure of 1.4.3 and 1.4.6 due to using background images that do not provide sufficient
                   contrast with foreground text (or images of text)
                </a>
-               								       
             </li>
             
          </ul>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -45,7 +45,7 @@
       
       <div class="note">
          
-         <p>When evaluating this success criterion, the font size in points should be obtained
+         <p>When evaluating this Success Criterion, the font size in points should be obtained
             from the user agent or calculated on font metrics in the way that user agents do.
             Point sizes are based on the CSS <code>pt</code> size as defined in 
             <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is <code>1pt = 1.333px</code>, therefore 14pt
@@ -100,7 +100,7 @@
          
       </div>
       
-      <p>The minimum contrast success criterion (1.4.3) applies to text in the page, including
+      <p>The minimum contrast Success Criterion (1.4.3) applies to text in the page, including
          placeholder text and text that is shown when a pointer is hovering over an object
          or when an object has keyboard focus. If any of these are used in a page, the text
          needs to provide sufficient contrast.

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -47,9 +47,9 @@
          
          <p>When evaluating this success criterion, the font size in points should be obtained
             from the user agent or calculated on font metrics in the way that user agents do.
-            Point sizes are based on the CSS pt size as defined in 
-            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
-            and 18pt are equivalent to approximately 18.5px and 24px.
+            Point sizes are based on the CSS <code>pt</code> size as defined in 
+            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is <code>1pt = 1.333px</code>, therefore 14pt
+            and <code>18pt</code> are equivalent to approximately <code>18.5px</code> and <code>24px</code>.
          </p>
          
          <p>Because different image editing applications default to different pixel densities
@@ -58,7 +58,7 @@
             When creating images of large-scale text, authors should ensure that the text in the
             resulting image is roughly equivalent to 1.2 and 1.5 em or to 120% or 150% of the
             default size for body text. For example, for a 72 PPI image, an author would need
-            to use approximately 19 pt and 24 pt font sizes in order to successfully present images
+            to use approximately 19pt and 24pt font sizes in order to successfully present images
             of large-scale text to a user. 
          </p>
          <p>The 3:1 and 4.5:1 contrast ratios referenced in this Success Criterion are intended to be
@@ -158,7 +158,7 @@
          <p>The rationale is based on a) adoption of the 3:1 contrast ratio for minimum acceptable
             contrast for normal observers, in the ANSI standard, and b) the empirical finding
             that in the population, visual acuity of 20/40 is associated with a contrast sensitivity
-            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of 3 * 1.5 = 4.5 to 1.  Following
+            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of <code>3 * 1.5 = 4.5 to 1</code>.  Following
             analogous empirical findings and the same logic, the user with 20/80 visual acuity
             would require contrast of about 7:1.
          </p>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -156,9 +156,7 @@
                adjust the foreground and background colors of the content. Some of the combinations
                that could be chosen may have contrast levels that will be lower than those found
                in the Success Criteria. This is not a violation of this Success Criterion provided
-               there is a mechanism that will return to the default values set out in the Success
-               Criteria.
-               
+               there is a mechanism that will return to the default values set out here.
             </p>          
             
          </div>
@@ -167,7 +165,6 @@
             loss in contrast sensitivity usually experienced by users with vision loss equivalent
             to approximately 20/40 vision. (20/40 calculates to approximately 4.5:1.) 20/40 is
             commonly reported as typical visual acuity of elders at roughly age 80. [[GITTINGS-FOZARD]] 
-            
          </p>
          
          <p>The contrast ratio of 7:1 was chosen for level AAA because it compensated for the

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -62,6 +62,15 @@
             ratio, the computed values should not be rounded (e.g. 4.499:1 would not meet the 4.5:1 threshold).</p>
       </div>
       
+      <div class="note">
+         <p>Due to anti-aliasing, particularly thin or unusual fonts may be rendered by user agents with a much fainter
+            color than the actual text color defined in the underlying CSS. This can lead to situations where text has
+            a contrast ratio that nominally passes the Success Criterion, but has a much lower contrast in practice.
+            For these cases, we recommend as a best practice that authors choose a font with stronger/thicker lines,
+            or aim for a text color that exceeds the baseline requirements of this Success Criterion.
+         </p>
+      </div>
+
       <p>The contrast requirements for text also apply to images of text
          (text that has been rendered into pixels and then stored in an image format) - see
          <a href="images-of-text">Success Criterion 1.4.5: Images of Text</a>.

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -118,6 +118,20 @@
          
          <h3>Rationale for the Ratios Chosen</h3>
          
+         <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] for standard text and vision. The 4.5:1 ratio is used in this provision to account
+            for the loss in contrast that results from moderately low visual acuity, congenital
+            or acquired color deficiencies, or the loss of contrast sensitivity that typically
+            accompanies aging.
+         </p>
+         
+         <p>The rationale is based on a) adoption of the 3:1 contrast ratio for minimum acceptable
+            contrast for normal observers, in the ANSI standard, and b) the empirical finding
+            that in the population, visual acuity of 20/40 is associated with a contrast sensitivity
+            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of <code>3 * 1.5 = 4.5 to 1</code>.  Following
+            analogous empirical findings and the same logic, the user with 20/80 visual acuity
+            would require contrast of about 7:1.
+         </p>
+
          <p>Hues are perceived differently by users with color vision deficiencies (both congenital
             and acquired) resulting in different colors and relative luminance contrasts than
             for normally sighted users. Because of this, effective contrast and readability are
@@ -148,20 +162,6 @@
             </p>          
             
          </div>
-         
-         <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] for standard text and vision. The 4.5:1 ratio is used in this provision to account
-            for the loss in contrast that results from moderately low visual acuity, congenital
-            or acquired color deficiencies, or the loss of contrast sensitivity that typically
-            accompanies aging.
-         </p>
-         
-         <p>The rationale is based on a) adoption of the 3:1 contrast ratio for minimum acceptable
-            contrast for normal observers, in the ANSI standard, and b) the empirical finding
-            that in the population, visual acuity of 20/40 is associated with a contrast sensitivity
-            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of <code>3 * 1.5 = 4.5 to 1</code>.  Following
-            analogous empirical findings and the same logic, the user with 20/80 visual acuity
-            would require contrast of about 7:1.
-         </p>
          
          <p>The contrast ratio of 4.5:1 was chosen for level AA because it compensated for the
             loss in contrast sensitivity usually experienced by users with vision loss equivalent

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -67,10 +67,9 @@
          
       </div>
       
-      <p>The previously-mentioned contrast requirements for text also apply to images of text
-         (text that has been rendered into pixels and then stored in an image format) as stated
-         in Success Criterion 1.4.3.
-         
+      <p>The contrast requirements for text also apply to images of text
+         (text that has been rendered into pixels and then stored in an image format) - see
+         <a href="images-of-text">Success Criterion 1.4.5: Images of Text</a>.
       </p>
       
       <p>This requirement applies to situations in which images of text were intended to be

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -53,11 +53,11 @@
          </p>
          
          <p>Because different image editing applications default to different pixel densities
-            (e.g. 72 PPI or 96 PPI), specifying point sizes for fonts from within an image editing
+            (e.g. <code>72ppi</code> or <code>96ppi</code>), specifying point sizes for fonts from within an image editing
             application can be unreliable when it comes to presenting text at a specific size.
             When creating images of large-scale text, authors should ensure that the text in the
             resulting image is roughly equivalent to 1.2 and 1.5 em or to 120% or 150% of the
-            default size for body text. For example, for a 72 PPI image, an author would need
+            default size for body text. For example, for a <code>72ppi</code> image, an author would need
             to use approximately 19pt and 24pt font sizes in order to successfully present images
             of large-scale text to a user. 
          </p>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -8,10 +8,8 @@
 <body>
    <h1>Understanding Contrast (Minimum)</h1>
    
-   
    <section id="intent">
       <h2>Intent of Contrast (Minimum)</h2>
-      
       
       <p>The intent of this Success Criterion is to provide enough contrast between text and
          its background so that it can be read by people with moderately low vision (who do
@@ -27,7 +25,6 @@
          words are used to create a background and the words could be rearranged or substituted
          without changing meaning, then it would be decorative and would not need to meet this
          criterion. 
-         
       </p>
       
       <p>Text that is larger and has wider character strokes is easier to read at lower contrast.
@@ -37,24 +34,23 @@
          enough to require a lower contrast ratio. (See The American Printing House for the
          Blind Guidelines for Large Printing and The Library of Congress Guidelines for Large
          Print under 
-         <a href="#resources">Resources</a>). "18 point" and "bold" can both have different meanings in different fonts but,
-         except for very thin or unusual fonts, they should be sufficient. Since there are
-         so many different fonts, the general measures are used and a note regarding thin or unusual fonts
-         is included if the definition for <a>large-scale</a> text.
+         <a href="#resources">Resources</a>). "18 point" and "bold" can both have different meanings in
+         different fonts but, except for very thin or unusual fonts, they should be sufficient. Since there
+         are so many different fonts, the general measures are used and a note regarding thin or unusual
+         fonts is included if the definition for <a>large-scale</a> text.
       </p>
       
       <div class="note">
-         
          <p>When evaluating this Success Criterion, the font size in points should be obtained
             from the user agent or calculated on font metrics in the way that user agents do.
             Point sizes are based on the CSS <code>pt</code> size as defined in 
-            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is <code>1pt = 1.333px</code>, therefore 14pt
+            <a href="https://www.w3.org/TR/css-values-3/#reference-pixel">CSS3 Values</a>. The ratio between
+            sizes in points and CSS pixels is <code>1pt = 1.333px</code>, therefore <code>14pt</code>
             and <code>18pt</code> are equivalent to approximately <code>18.5px</code> and <code>24px</code>.
          </p>
-         
          <p>Because different image editing applications default to different pixel densities
-            (e.g. <code>72ppi</code> or <code>96ppi</code>), specifying point sizes for fonts from within an image editing
-            application can be unreliable when it comes to presenting text at a specific size.
+            (e.g. <code>72ppi</code> or <code>96ppi</code>), specifying point sizes for fonts from within an
+            image editing application can be unreliable when it comes to presenting text at a specific size.
             When creating images of large-scale text, authors should ensure that the text in the
             resulting image is roughly equivalent to 1.2 and 1.5 em or to 120% or 150% of the
             default size for body text. For example, for a <code>72ppi</code> image, an author would need
@@ -64,7 +60,6 @@
          <p>The 3:1 and 4.5:1 contrast ratios referenced in this Success Criterion are intended to be
             treated as threshold values. When comparing the computed contrast ratio to the Success Criterion
             ratio, the computed values should not be rounded (e.g. 4.499:1 would not meet the 4.5:1 threshold).</p>
-         
       </div>
       
       <p>The contrast requirements for text also apply to images of text
@@ -105,7 +100,8 @@
          needs to provide sufficient contrast.
       </p>
       
-      <p>Although this Success Criterion only applies to text, similar issues occur for content presented in charts, graphs, diagrams, and other non-text-based information which is covered by 
+      <p>Although this Success Criterion only applies to text, similar issues occur for content presented
+         in charts, graphs, diagrams, and other non-text-based information which is covered by
          <a href="non-text-contrast">Success Criterion 1.4.11 Non-Text Contrast</a>.         
       </p>
       
@@ -117,7 +113,8 @@
          
          <h3>Rationale for the Ratios Chosen</h3>
          
-         <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] for standard text and vision. The 4.5:1 ratio is used in this provision to account
+         <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]]
+            for standard text and vision. The 4.5:1 ratio is used in this provision to account
             for the loss in contrast that results from moderately low visual acuity, congenital
             or acquired color deficiencies, or the loss of contrast sensitivity that typically
             accompanies aging.
@@ -126,9 +123,9 @@
          <p>The rationale is based on a) adoption of the 3:1 contrast ratio for minimum acceptable
             contrast for normal observers, in the ANSI standard, and b) the empirical finding
             that in the population, visual acuity of 20/40 is associated with a contrast sensitivity
-            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of <code>3 * 1.5 = 4.5 to 1</code>.  Following
-            analogous empirical findings and the same logic, the user with 20/80 visual acuity
-            would require contrast of about 7:1.
+            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of
+            <code>3 * 1.5 = 4.5 to 1</code>.  Following analogous empirical findings and the same logic,
+            the user with 20/80 visual acuity would require contrast of about 7:1.
          </p>
 
          <p>Hues are perceived differently by users with color vision deficiencies (both congenital
@@ -177,9 +174,8 @@
          </p>
          
          <div class="note">
-            
-            <p>Calculations in [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] are for body text. A relaxed contrast ratio is provided for text that is much larger.</p>
-            
+            <p>Calculations in [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] are for body text. A relaxed contrast
+               ratio is provided for text that is much larger.</p>
          </div>
          
       </section>
@@ -207,9 +203,8 @@
             
             <p>
                Refer to 
-               <a href="#resources">related resources</a> for a list of tools that utilize the contrast ratio to analyze the contrast of Web
-               content. 
-               
+               <a href="#resources">related resources</a> for a list of tools that utilize the contrast ratio
+               to analyze the contrast of Web content.
             </p>
             
             <p>See also 
@@ -230,7 +225,6 @@
    </section>
    <section id="benefits">
       <h2>Benefits of Contrast (Minimum)</h2>
-      
       
       <ul>
          
@@ -259,67 +253,47 @@
       <ul>
          
          <li>
-            								       
             <a href="https://www.tpgi.com/color-contrast-checker/">Colour Contrast Analyser application</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://juicystudio.com/services/luminositycontrastratio.php">Luminosity Colour Contrast Ratio Analyser</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://snook.ca/technical/colour_contrast/colour.html">Colour Contrast Check</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://www.msfw.com/Services/ContrastRatioCalculator">Contrast Ratio Calculator</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://color.adobe.com/create/color-contrast-analyzer">Adobe Color - Color Contrast Analyzer Tool</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://www.w3.org/Graphics/atypical-color-response">Atypical colour response</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="http://www.colorsontheweb.com/colorcontrast.asp">Colors On the Web Color Contrast Analyzer</a>
-            							     
          </li>
          
          <li>
-            								       
             <a href="https://www.vischeck.com/daltonize/runDaltonize.php">Tool to convert images based on color loss</a> so that contrast is restored as luminance contrast when there was only color contrast (that was lost due to color deficiency)
-         							     
          </li>
          
          <li>
-            								       
             <a href="https://www.456bereastreet.com/archive/200709/10_colour_contrast_checking_tools_to_improve_the_accessibility_of_your_design/">List of color contrast tools</a>
-            							     
          </li>
 
          <li>
-         	
-         	<a href="https://www.aph.org/resources/large-print-guidelines/">The American Printing House for the Blind Guidelines for Large Printing</a>
+            <a href="https://www.aph.org/resources/large-print-guidelines/">The American Printing House for the Blind Guidelines for Large Printing</a>
          </li>
 
          <li>
-         	
-         	<a href="https://www.loc.gov/nls/resources/general-resources-on-disabilities/large-print-materials/">National Library Service for the Blind and Physically Handicapped (NLS), The Library of Congress reference guide on large print materials</a>
+            <a href="https://www.loc.gov/nls/resources/general-resources-on-disabilities/large-print-materials/">National Library Service for the Blind and Physically Handicapped (NLS), The Library of Congress reference guide on large print materials</a>
          </li>
          
       </ul>
@@ -341,27 +315,21 @@
             <ol>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G18" class="general">Ensuring that  contrast of at least 4.5:1 exists between text (and images of text)
                      and background behind the text
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G148" class="general">Not specifying background color, not specifying text color, and not using technology
                      features that change those defaults
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G174" class="general">Providing a control with a sufficient contrast ratio that allows users to switch to
                      a presentation that uses sufficient contrast
                   </a>
-                  									         
                </li>
                
             </ol>
@@ -375,27 +343,21 @@
             <ol>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G145" class="general">Ensuring that a contrast ratio of at least 3:1 exists between text (and images of
                      text) and background behind the text
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G148" class="general">Not specifying background color, not specifying text color, and not using technology
                      features that change those defaults
                   </a>
-                  									         
                </li>
                
                <li>
-                  										           
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G174" class="general">Providing a control with a sufficient contrast ratio that allows users to switch to
                      a presentation that uses sufficient contrast
                   </a>
-                  									         
                </li>
                
             </ol>
@@ -411,9 +373,7 @@
          <ul>
             
             <li>
-               									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G156" class="general">G156</a>
-               								       
             </li>
             
          </ul>
@@ -427,19 +387,15 @@
          <ul>
             
             <li>
-               									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F24" class="failure">Failure due to specifying foreground colors without specifying background colors or
                   vice versa
                </a>
-               								       
             </li>
             
             <li>
-               									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F83" class="failure">Failure of 1.4.3 and 1.4.6 due to using background images that do not provide sufficient
                   contrast with foreground text (or images of text)
                </a>
-               								       
             </li>
             
          </ul>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -195,10 +195,10 @@
          
          <p>Conversion from nonlinear to linear RGB values is based on IEC/4WD 61966-2-1 [[IEC-4WD]].</p>
          
-         <p>The formula (L1/L2) for contrast is based on [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] standards.</p>
+         <p>The formula (<code>L1/L2</code>) for contrast is based on [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] standards.</p>
          
          <p>The ANSI/HFS 100-1988 standard calls for the contribution from ambient light to be
-            included in the calculation of L1 and L2. The .05 value used is based on Typical Viewing
+            included in the calculation of L1 and L2. The <code>.05</code> value used is based on Typical Viewing
             Flare from [[IEC-4WD]].
          </p>
          

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -209,23 +209,14 @@
          </p>
          
          <div class="note">
-            
             <p>
                Refer to 
                <a href="#resources">related resources</a> for a list of tools that utilize the contrast ratio
                to analyze the contrast of Web content.
             </p>
-            
             <p>See also 
                <a href="focus-visible">2.4.7: Focus Visible</a> for techniques for indicating keyboard focus.
             </p>
-            
-            <p>It is sometimes helpful for authors to not specify colors for certain sections of
-               a page in order to help users who need to view content with specific color combinations
-               to view the content in their preferred color scheme. Refer to 
-               <a href="images-of-text">1.4.5: Images of Text</a> for more information.
-            </p>
-            
          </div>
          
       </section>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -106,7 +106,7 @@
       </p>
       
       <p>Although this Success Criterion only applies to text, similar issues occur for content presented in charts, graphs, diagrams, and other non-text-based information which is covered by 
-         <a href="../21/non-text-contrast.html">Success Criterion 1.4.11 Non-Text Contrast</a>.         
+         <a href="non-text-contrast">Success Criterion 1.4.11 Non-Text Contrast</a>.         
       </p>
       
       <p>See also 

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -39,8 +39,8 @@
          Print under 
          <a href="#resources">Resources</a>). "18 point" and "bold" can both have different meanings in different fonts but,
          except for very thin or unusual fonts, they should be sufficient. Since there are
-         so many different fonts, the general measures are used and a note regarding fancy
-         or thin fonts is included.
+         so many different fonts, the general measures are used and a note regarding thin or unusual fonts
+         is included if the definition for <a>large-scale</a> text.
       </p>
       
       <div class="note">

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -118,38 +118,6 @@
          
          <h3>Rationale for the Ratios Chosen</h3>
          
-         <p>Text that is larger and has wider character strokes is easier to read at lower contrast.
-            The contrast requirement for larger text is therefore lower. This allows authors to
-            use a wider range of color choices for large text, which is helpful for design of
-            pages, particularly titles. 18 point text or 14 point bold text is judged to be large
-            enough to require a lower contrast ratio. (See The American Printing House for the
-            Blind Guidelines for Large Printing and The Library of Congress Guidelines for Large
-            Print under 
-            <a href="#resources">Resources</a>). "18 point" and "bold" can both have different meanings in different fonts but,
-            except for very thin or unusual fonts, they should be sufficient. Since there are
-            so many different fonts, the general measures are used and a note regarding fancy
-            or thin fonts is included.
-         </p>
-         
-         <div class="note">
-            
-            <p>When evaluating this success criterion, the font size in points should be obtained
-               from the user agent or calculated on font metrics in the way that user agents do.
-               Point sizes are based on the CSS pt size as defined in 
-               <a href="">CSS3 Values</a>. The ratio between sizes in points and CSS pixels is 1pt = 1.333px, therefore 14pt
-               and 18pt are equivalent to approximately 18.5px and 24px.
-            </p>
-            
-            <p>Because different image editing applications default to different pixel densities
-               (e.g. 72 PPI or 96 PPI), specifying point sizes for fonts from within an image editing
-               application can be unreliable when it comes to presenting text at a specific size.
-               When creating images of large-scale text, authors should ensure that the text in the
-               resulting image is roughly equivalent to 1.2 and 1.5 em or to 120% or 150% of the
-               default size for body text as rendered by the browser.
-            </p>
-            
-         </div>
-         
          <p>Hues are perceived differently by users with color vision deficiencies (both congenital
             and acquired) resulting in different colors and relative luminance contrasts than
             for normally sighted users. Because of this, effective contrast and readability are


### PR DESCRIPTION
The understanding documents for 1.4.3 Contrast (Minimum) and 1.4.6 Contrast (Enhanced) currently contain various small errors, incorrect links/references, a few throwaway non-sequiturs, some unnecessarily duplicated content, and are not harmonised. Key changes include:

* add a new note (inspired by the note that was in 1.4.6) about thin/unusual fonts and antialiasing and what to actually *do* as an author
* remove the weird inconsistency of talking about "thin or unusual", and in the next part of the sentence "fancy or thin" (also... "fancy"? really?)
* harmonise capitalisation of "Success Criterion"
* in 1.4.3, removes the whole start of the "Rationale" section which is an exact copy of the end of the "Intent" section? reorders that section to be more logical
* some code cleanup (removing excessive line breaks, sorting out some excessively long single lines
* use of `ppi` (as a unit of measure) lowercase and without preceding space
* use of `<code>` for code-y things (measurements, formulae)
* harmonise 1.4.3 and 1.4.6 understanding

in the process, this also removes some broken and incorrect links in 1.4.6 understanding (e.g. link to "resources" that was borked)