### PR TITLE
"Not modified by the author" does not exempt 2.4.7 Focus Visible

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -90,7 +90,7 @@
 
 				<h4 id="related-focus">Relationship with Focus Visible</h4>
 				
-				<p>In combination with <a href="https://www.w3.org/TR/WCAG21/#focus-visible">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
+				<p>Success Criterion <a href="https://www.w3.org/TR/WCAG21/#focus-visible">2.4.7 Focus Visible</a> says focus indicators can't be invisible, even system-default ones, but it does not say how much contrast they need. The Non-text Contrast criterion adds that focus indicators must have sufficient contrast, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
 
 				<p>Most focus indicators appear outside the component - in that case it needs to contrast with the background that the component is on. Other cases include focus indicators which are:</p>
 


### PR DESCRIPTION
Address this aspect of #1385:

> 1.4.11 has an exemption of contrast for unmodified user agent, but 2.4.7 has not.
> 
> While that (to my understanding) means that that there is no 1.4.11 3:1 contrast requirement, it seems still insufficient to have an invisible/imperceivable focus style even when relying on the UA style. So if the color of the focus outline of the UA is black it would not conform on a black background as it is not visible.