### PR TITLE
Editorial: Match terms spelling and add links

### DIFF
--- a/guidelines/terms/22/dragging-movement.html
+++ b/guidelines/terms/22/dragging-movement.html
@@ -2,7 +2,7 @@
 <dd class="new">
 	<p class="change">New</p>
    					
-   <p>an operation where the pointer engages with an element on the down event and the element (or a representation of its position) follows the pointer until an up event</p>
+  <p>an operation where the pointer engages with an element on the <a>down-event</a> and the element (or a representation of its position) follows the pointer until an <a>up-event</a></p>
    
    <p class="note">Examples of draggable elements include list items, text elements, and images.</p>
 </dd>


### PR DESCRIPTION
This definition uses other defined terms "down-event" and "up-event" introduced in WCAG 2.1. This edit adds in the hyphen in the spelling. It also adds links to the definitions of those terms.