### PR TITLE
Fix reflow issue in 1.4.10 Reflow Understanding

### DIFF
--- a/understanding/21/reflow.html
+++ b/understanding/21/reflow.html
@@ -72,7 +72,7 @@
           <h2>Examples</h2>
           <section class="example">
             <h3>Example 1: Responsive Design</h3>
-            <p><video controls="controls"><source src="https://alastairc.uk/w3c/reflow-example-1-BBC.mp4" type="video/mp4" /><source src="https://alastairc.uk/w3c/reflow-example-1-BBC.ogv" type="video/ogg" />Animation of zooming in on a responsive site. The content reflows to fit the screen.</video></p>
+            <p><video style="max-width: 100%;" controls="controls"><source src="https://alastairc.uk/w3c/reflow-example-1-BBC.mp4" type="video/mp4" /><source src="https://alastairc.uk/w3c/reflow-example-1-BBC.ogv" type="video/ogg" />Animation of zooming in on a responsive site. The content reflows to fit the screen.</video></p>
             <p>Note that as the zoom percentage increases, the navigation changes first to hide options behind a &quot;More&quot; dropdown menu. As zooming continues, most navigation options are eventually behind a &quot;hamburger&quot; menu button. All the information and functionality is still available from this web page. There is no horizontal scrolling.</p>
         </section>
 </section>


### PR DESCRIPTION
@alastc please merge.

The video breaks out of the grid and creates horizontal scrolling. It’s bad. Added a max-width: 100% style to fix it.

(Contributing this change was only possible due to [my supporters](https://steadyhq.com/en/yatil/about).)