### PR TITLE
Fix F108 title, tweak G219

### DIFF
--- a/techniques/failures/F108.html
+++ b/techniques/failures/F108.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-      <title>Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</title>
+      <title>Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</title>
 
       <link rel="stylesheet" type="text/css" href="../../css/editors.css"/>
 
@@ -9,7 +9,7 @@
 <body>
 
 
-    <h1>Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</h1>
+    <h1>Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</h1>
 
     <section id="meta">
         <h2>Metadata</h2>

--- a/techniques/failures/F108.html
+++ b/techniques/failures/F108.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-      <title>Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</title>
+      <title>Failure of Success Criterion 2.5.7 due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</title>
 
       <link rel="stylesheet" type="text/css" href="../../css/editors.css"/>
 

--- a/techniques/general/G219.html
+++ b/techniques/general/G219.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 	<head>
-		<title>Ensuring that a non-dragging-based single pointer alternative is available for dragging movements that operate on content</title>
+		<title>Ensuring that an alternative is available for dragging movements that operate on content</title>
 		<link rel="stylesheet" type="text/css" href="../../css/editors.css"/>
 	</head>
 	<body>

--- a/techniques/general/G219.html
+++ b/techniques/general/G219.html
@@ -5,7 +5,7 @@
 		<link rel="stylesheet" type="text/css" href="../../css/editors.css"/>
 	</head>
 	<body>
-    <h1>Ensuring that a non-dragging-based <a>single pointer</a> alternative is available for <a>dragging movement</a>s that operate on content</h1>
+    <h1>Ensuring that an alternative is available for <a>dragging movement</a>s that operate on content</h1>
 		<section id="meta">
 			<h2>Metadata</h2>
 			<p class="instructions">Provide information below to help editors associate the technique properly. Contents of the meta section are not output by the processor.</p>

--- a/techniques/general/G219.html
+++ b/techniques/general/G219.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 	<head>
-		<title>Ensuring that a single pointer alternative is available for dragging movements that operate on content</title>
+		<title>Ensuring that a non-dragging-based single pointer alternative is available for dragging movements that operate on content</title>
 		<link rel="stylesheet" type="text/css" href="../../css/editors.css"/>
 	</head>
 	<body>
-    <h1>Ensuring that a <a>single pointer</a> alternative is available for <a>dragging movement</a>s that operate on content</h1>
+    <h1>Ensuring that a non-dragging-based <a>single pointer</a> alternative is available for <a>dragging movement</a>s that operate on content</h1>
 		<section id="meta">
 			<h2>Metadata</h2>
 			<p class="instructions">Provide information below to help editors associate the technique properly. Contents of the meta section are not output by the processor.</p>
@@ -18,9 +18,9 @@
 		</section>
 		<section id="description">
 			<h2>Description</h2>
-			<p>The objective of this Technique is to ensure that people with motor impairments who cannot carry out <a>dragging movements</a> are presented with an alternative <a>single pointer</a> interaction.</p> 
+			<p>The objective of this Technique is to ensure that people with motor impairments who cannot carry out <a>dragging movements</a> are presented with an alternative <a>single pointer</a> interaction that does not involve dragging.</p> 
       <p>Some direct manipulation interfaces allow users to pick up targets and use dragging movements to move them to another position, for example, to change the position of an item in a priority list, or to move a task on a Kanban or planning board.</p>
-      <p>Such dragging movements are difficult or impossible to carry out for some users with motor disabilities. The alternative to dragging movements operates the underlying function by one or several <a>single pointer</a> activations. A single tap or click may reveal controls (arrows) to move a target in a stepwise fashion; open a drop-down menu where the drop position can be selected; or allow moving it to an ajacent postion by a swipe gesture.</p>
+      <p>Such dragging movements are difficult or impossible to carry out for some users with motor disabilities. The alternative to dragging movements operates the underlying function by one or several <a>single pointer</a> activations that don't require dragging. A single tap or click may reveal controls (arrows) to move a target in a stepwise fashion; open a drop-down menu where the drop position can be selected; or allow moving it to an ajacent postion by a swipe gesture.</p>
       
 
 		</section>
@@ -43,7 +43,7 @@
 				<p>For interface elements that support dragging:</p>
 				<ol>
 					<li>Check the interface for the presence of functions triggered by <a>dragging movement</a>s.</li>
-					<li>Check that there is a <a>single pointer</a> activation alternative to operate the same function</li>
+					<li>Check that there is a <a>single pointer</a> activation alternative that does not require dragging to operate the same function</li>
 				</ol>
 			</section>
 			<section class="test-results">

--- a/techniques/general/G219.html
+++ b/techniques/general/G219.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 	<head>
-		<title>Ensuring that an alternative is available for dragging movements that operate on content</title>
+		<title>Ensuring an alternative to dragging movements</title>
 		<link rel="stylesheet" type="text/css" href="../../css/editors.css"/>
 	</head>
 	<body>

--- a/understanding/22/dragging-movements.html
+++ b/understanding/22/dragging-movements.html
@@ -106,7 +106,7 @@
          
          <ol>
             <li>
-                <a href="../../techniques/general/G219" class="general">Ensuring that a non-dragging-based single pointer alternative is available for dragging movements that operate on content</a>
+                <a href="../../techniques/general/G219" class="general">Ensuring that an alternative is available for dragging movements that operate on content</a>
             </li>
          </ol>
          

--- a/understanding/22/dragging-movements.html
+++ b/understanding/22/dragging-movements.html
@@ -106,7 +106,7 @@
          
          <ol>
             <li>
-                <a href="../../techniques/general/G219" class="general">Ensuring that a single pointer operable alternative is available for dragging movements that operate on content</a>
+                <a href="../../techniques/general/G219" class="general">Ensuring that a non-dragging-based single pointer alternative is available for dragging movements that operate on content</a>
             </li>
          </ol>
          

--- a/understanding/22/dragging-movements.html
+++ b/understanding/22/dragging-movements.html
@@ -122,7 +122,7 @@
 
          <ul>
             <li>								         
-                <a href="../../techniques/failures/F108" class="failure">Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</a>						       
+                <a href="../../techniques/failures/F108" class="failure">Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method for the user to operate a function that does not require a dragging movement</a>						       
             </li>
          </ul>
       </section>


### PR DESCRIPTION
* for G219, the title and wording are incorrect. they seem to suggest that "dragging movements" are not "single pointer" gestures, which they are (if they only involve a single pointer). what counts is that the alternative must be *non-dragging-based* and single pointer. Closes #3128 
* for F108, the title is incomplete (from when the SC number, and final title of the SC, weren't finalised yet)