### PR TITLE
Update date used at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WCAG (Web Content Accessibility Guidelines) - Branch for production of August 2016 review versions
 ===
 
-Please use this branch as the target for pull requests until July 10, 2016.
+Please use this branch as the target for pull requests until July 10, 2023.
 
 This repository is used to develop content for WCAG 2, as well as associated understanding documents and techniques.
 


### PR DESCRIPTION
Correct date prominently shown at the top of the README.md doc, when opening repo at root.

I am not sure what the best date referenced should be, but mention of 2016 is distracting.