### PR TITLE
Change 'non-text graphics' to the normative SC term 'non-text content'

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -411,7 +411,7 @@
 
 			<section id="testing-principles">
 					<h3>Testing Principles</h3>
-					<p>A summary of the high-level process for finding and assessing non-text graphics on a web page:</p>
+					<p>A summary of the high-level process for finding and assessing non-text content on a web page:</p>
 					<ul>
 						<li>Identify each user-interface component (link, button, form control) on the page and:
 							<ul>


### PR DESCRIPTION
The "Testing Principles" section covers the two kinds of non-text content in scope for this SC: components and graphical objects. However, the introductory sentence said "non-text graphics" — this could be construed as limiting the scope of the testing just to the graphics (not the controls), and possibly further limiting it to just the "non-text" kind of graphics (if such things exist). So I changed "non-text graphics" to "non-text content" as in the normative SC.