### PR TITLE
Addressing issue #2479

### DIFF
--- a/understanding/20/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/20/audio-description-or-media-alternative-prerecorded.html
@@ -39,12 +39,14 @@
          more complete representation of the synchronized media content than audio description
          alone.
       </p>
+      <p>
+        The language of the success criterion is an OR statement between the requirement for an <a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded.html">alternative for time-based media</a> OR an audio description. Therefore, if an audio description cannot be provided because there are insufficient spaces in the dialog to insert the Audio Description, then an alternative for time-based media would be required.</p>
       
       <p>If there is any interaction as part of the synchronized media presentation (e.g.,
          "press now to answer the question") then the alternative for time-based media would
          provide hyperlinks or whatever is needed to provide the same functionality.
       </p>
-      
+     
       <div class="note">
          
          <p>


### PR DESCRIPTION
Added language to clarify that The language of the success criterion is an OR statement between the requirement for an alternative for time-based media OR an audio description. Therefore, if an audio description cannot be provided because there are insufficient spaces in the dialog to insert the Audio Description, then an alternative for time-based media would be required.