### PR TITLE
Adding privacy / security section

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -531,6 +531,25 @@
                 <p>A "statement of partial conformance due to language" may be made when the page does not conform, but would conform if <a>accessibility support</a> existed for (all of) the language(s) used on the page. The form of that statement would be, "This page does not conform, but would conform to WCAG 2.2 at level X if accessibility support existed for the following language(s):"</p>
             </section>
 
+            <section id="privacy-security-summary">
+                <h2>Privacy Considerations</h2>
+                <p>Success Criteria within this specification that have normative text or notes which relate to privacy are:</p>
+                <ul>
+                    <li><a href="#timeouts">2.2.6 Timeouts (AAA)</a></li>
+                </ul>
+
+            </section>
+
+            <section>
+                <h2>Security Considerations</h2>
+                <p>Success Criteria within this specification that have normative text or notes which relate to security are:</p>
+                <ul>
+                    <li><a href="#concurrent-input-mechanisms">2.5.6 Concurrent Input Mechanisms (AAA)</a></li>
+                    <li><a href="#error-suggestion">3.3.3 Error Suggestion (AA)</a></li>
+                    <li><a href="#redundant-entry">3.3.7 Redundant Entry (A)</a></li>
+                </ul>
+            </section>
+
         </section>
         <section id="glossary">
             <h1>Glossary</h1>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -533,7 +533,8 @@
 
             <section id="privacy-security-summary">
                 <h2>Privacy Considerations</h2>
-                <p>Success Criteria within this specification that have normative text or notes which relate to privacy are:</p>
+                <p>This section is informative.</p>
+                <p>Success Criteria within this specification that relate to privacy are:</p>
                 <ul>
                     <li><a href="#timeouts">2.2.6 Timeouts (AAA)</a></li>
                 </ul>
@@ -542,7 +543,8 @@
 
             <section>
                 <h2>Security Considerations</h2>
-                <p>Success Criteria within this specification that have normative text or notes which relate to security are:</p>
+                <p>This section is informative.</p>
+                <p>Success Criteria within this specification that relate to security are:</p>
                 <ul>
                     <li><a href="#concurrent-input-mechanisms">2.5.6 Concurrent Input Mechanisms (AAA)</a></li>
                     <li><a href="#error-suggestion">3.3.3 Error Suggestion (AA)</a></li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -533,22 +533,31 @@
 
             <section id="privacy-security-summary">
                 <h2>Privacy Considerations</h2>
-                <p>This section is informative.</p>
-                <p>Success Criteria within this specification that relate to privacy are:</p>
+                <p>This section is non-normative.</p>
+                <p>Success Criteria within this specification that may relate to privacy are:</p>
                 <ul>
                     <li><a href="#timeouts">2.2.6 Timeouts (AAA)</a></li>
+                    <li><a href="#redundant-entry">3.3.7 Redundant Entry (A)</a></li>
                 </ul>
 
             </section>
 
             <section>
                 <h2>Security Considerations</h2>
-                <p>This section is informative.</p>
-                <p>Success Criteria within this specification that relate to security are:</p>
+                <p>This section is non-normative.</p>
+                <p>Success Criteria within this specification that may relate to security are:</p>
                 <ul>
+                    <li><a href="#non-text-content">1.1.1 Non-text Content (A)</a></li>
+                    <li><a href="#identify-input-purpose">1.3.5 Identify Input Purpose (AA)</a></li>
+                    <li><a href="#low-or-no-background-audio">1.4.7 Low or No Background Audio (AAA)</a></li>
+                    <li><a href="#timing-adjustable">2.2.1 Timing Adjustable (A)</a></li>
+                    <li><a href="#re-authenticating">2.2.5 Re-authenticating (AAA)</a></li>
+                    <li><a href="#timeouts">2.2.6 Timeouts (AAA)</a></li>
                     <li><a href="#concurrent-input-mechanisms">2.5.6 Concurrent Input Mechanisms (AAA)</a></li>
                     <li><a href="#error-suggestion">3.3.3 Error Suggestion (AA)</a></li>
                     <li><a href="#redundant-entry">3.3.7 Redundant Entry (A)</a></li>
+                    <li><a href="#accessible-authentication-minimum">3.3.8 Accessible Authentication (Minimum) (AA)</a></li>
+                    <li><a href="#accessible-authentication-enhanced">3.3.9 Accessible Authentication (Enhanced) (AAA)</a></li>                    
                 </ul>
             </section>
 

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -531,7 +531,7 @@
                 <p>A "statement of partial conformance due to language" may be made when the page does not conform, but would conform if <a>accessibility support</a> existed for (all of) the language(s) used on the page. The form of that statement would be, "This page does not conform, but would conform to WCAG 2.2 at level X if accessibility support existed for the following language(s):"</p>
             </section>
 
-            <section id="privacy-security-summary">
+            <section class="informative" id="privacy-summary">
                 <h2>Privacy Considerations</h2>
                 <p>This section is non-normative.</p>
                 <p>Success Criteria within this specification that may relate to privacy are:</p>
@@ -542,7 +542,7 @@
 
             </section>
 
-            <section>
+            <section class="informative" id="security-summary">
                 <h2>Security Considerations</h2>
                 <p>This section is non-normative.</p>
                 <p>Success Criteria within this specification that may relate to security are:</p>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -533,7 +533,6 @@
 
             <section class="informative" id="privacy-summary">
                 <h2>Privacy Considerations</h2>
-                <p>This section is non-normative.</p>
                 <p>Success Criteria within this specification that may relate to privacy are:</p>
                 <ul>
                     <li><a href="#timeouts">2.2.6 Timeouts (AAA)</a></li>
@@ -544,7 +543,6 @@
 
             <section class="informative" id="security-summary">
                 <h2>Security Considerations</h2>
-                <p>This section is non-normative.</p>
                 <p>Success Criteria within this specification that may relate to security are:</p>
                 <ul>
                     <li><a href="#non-text-content">1.1.1 Non-text Content (A)</a></li>


### PR DESCRIPTION
This change added two sections after Conformance, on Privacy and Security.

Each section is marked as non-normative, and simply lists SCs which may have security/privacy implications.

Closes #3135

NB: The links in the preview don't work, but will do when published.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3215.html" title="Last updated on Sep 26, 2023, 10:43 AM UTC (14b76e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3215/6a2adfd...14b76e9.html" title="Last updated on Sep 26, 2023, 10:43 AM UTC (14b76e9)">Diff</a>