### PR TITLE
Follow-up changes to 1.4.3 and 1.4.6 understanding documents

### DIFF
--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -106,7 +106,7 @@
          
       </div>
       
-      <p>The minimum contrast Success Criterion (1.4.3) applies to text in the page, including
+      <p>This Success Criterion applies to text in the page, including
          placeholder text and text that is shown when a pointer is hovering over an object
          or when an object has keyboard focus. If any of these are used in a page, the text
          needs to provide sufficient contrast.
@@ -121,18 +121,20 @@
          
          <h3>Rationale for the Ratios Chosen</h3>
          
-         <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]] for standard text and vision. The 4.5:1 ratio is used in Success Criterion 1.4.3
-            to account for the loss in contrast that results from moderately low visual acuity,
-            congenital or acquired color deficiencies, or the loss of contrast sensitivity that
-            typically accompanies aging.
+         <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]]
+            for standard text and vision. The 4.5:1 ratio is used in Success Criterion 1.4.3 to account
+            for the loss in contrast that results from moderately low visual acuity, congenital
+            or acquired color deficiencies, or the loss of contrast sensitivity that typically
+            accompanies aging.
          </p>
          
          <p>The rationale is based on a) adoption of the 3:1 contrast ratio for minimum acceptable
             contrast for normal observers, in the ANSI standard, and b) the empirical finding
             that in the population, visual acuity of 20/40 is associated with a contrast sensitivity
-            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of 3 * 1.5 = 4.5 to 1.  Following
-            analogous empirical findings and the same logic, the user with 20/80 visual acuity
-            would require contrast of about 7:1.
+            loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of
+            <code>3 * 1.5 = 4.5 to 1</code>. Following analogous empirical findings and the same logic,
+            the user with 20/80 visual acuity would require contrast of about 7:1. This ratio is used in
+            this Success Criterion.
          </p>
          
          <p>Hues are perceived differently by users with color vision deficiencies (both congenital

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -107,7 +107,7 @@
          
       </div>
       
-      <p>The minimum contrast Success Criterion (1.4.3) applies to text in the page, including
+      <p>This Success Criterion applies to text in the page, including
          placeholder text and text that is shown when a pointer is hovering over an object
          or when an object has keyboard focus. If any of these are used in a page, the text
          needs to provide sufficient contrast.
@@ -127,7 +127,7 @@
          <h3>Rationale for the Ratios Chosen</h3>
          
          <p>A contrast ratio of 3:1 is the minimum level recommended by [[ISO-9241-3]] and [[ANSI-HFES-100-1988]]
-            for standard text and vision. The 4.5:1 ratio is used in this provision to account
+            for standard text and vision. The 4.5:1 ratio is used in this Success Criterion to account
             for the loss in contrast that results from moderately low visual acuity, congenital
             or acquired color deficiencies, or the loss of contrast sensitivity that typically
             accompanies aging.
@@ -137,8 +137,9 @@
             contrast for normal observers, in the ANSI standard, and b) the empirical finding
             that in the population, visual acuity of 20/40 is associated with a contrast sensitivity
             loss of roughly 1.5 [[ARDITI-FAYE]]. A user with 20/40 would thus require a contrast ratio of
-            <code>3 * 1.5 = 4.5 to 1</code>.  Following analogous empirical findings and the same logic,
-            the user with 20/80 visual acuity would require contrast of about 7:1.
+            <code>3 * 1.5 = 4.5 to 1</code>. Following analogous empirical findings and the same logic,
+            the user with 20/80 visual acuity would require contrast of about 7:1. This ratio is used in
+            Success Criterion 1.4.6.
          </p>
 
          <p>Hues are perceived differently by users with color vision deficiencies (both congenital


### PR DESCRIPTION
* corrects a mistake where the text about focus/hover in 1.4.6 understanding talks about 1.4.3 applying also to focus/hover, when it actually means to say that THIS SC applies here as well. this PR now generalises that text to just say "This Success Criterion"
* adds a `<code>` block that was missed out for the contrast formula
* reformats the contrast formula rationale part for enhanced contrast, to bring it in line with the same text in the minimum contrast understanding
* tweaks the rationale to mention 1.4.6 in relation to 7:1 ratio