### PR TITLE
Fixing broken link on 'cognitive function test' in F109

### DIFF
--- a/techniques/failures/F109.html
+++ b/techniques/failures/F109.html
@@ -23,7 +23,7 @@
 
     <p>Requiring users to authenticate by entering a password or code in a different format from which it was originally created is a failure to meet Success Criteria 3.3.8 and 3.3.9 (unless alternative authentication methods are available). The string to be entered could include a password, verification code, or any string of characters the user has to remember or record to authenticate.</p>
 
-    <p>If a user is required to enter individual characters across multiple fields in a way that prevents pasting the password in a single action, it prevents use of a password manager or pasting from local copy of the password. This means users cannot avoid transcription, resulting in a <a href="../../understanding/22/accessible-authentication.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the string, or just a subset.</p>
+    <p>If a user is required to enter individual characters across multiple fields in a way that prevents pasting the password in a single action, it prevents use of a password manager or pasting from local copy of the password. This means users cannot avoid transcription, resulting in a <a href="../../understanding/accessible-authentication-minimum.html#dfn-cognitive-function-test">cognitive function test</a>. This applies irrespective of whether users are required to enter all characters in the string, or just a subset.</p>
   
    </section>
 


### PR DESCRIPTION
The link on 'cognitive function test' in F109 is broken - repointing this.