### PR TITLE
Removed key beneficiaries line from 2.2 In briefs

### DIFF
--- a/understanding/22/accessible-authentication-enhanced.html
+++ b/understanding/22/accessible-authentication-enhanced.html
@@ -50,7 +50,6 @@
         <dl>
             <dt>Objective</dt><dd>Make logins possible with less mental effort</dd>
             <dt>Author task</dt><dd>Don’t make people recognize objects or user-supplied information in order to login</dd>
-            <dt>Key beneficiaries</dt><dd>Users with some cognitive disabilities</dd>
         </dl>
 
     </section>

--- a/understanding/22/accessible-authentication-minimum.html
+++ b/understanding/22/accessible-authentication-minimum.html
@@ -61,7 +61,6 @@
         <dl>
             <dt>Objective</dt><dd>Make logins possible with less mental effort</dd>
             <dt>Author task</dt><dd>Don’t make people memorize or transcribe something in order to log in</dd>
-            <dt>Key beneficiaries</dt><dd>Users with some cognitive disabilities</dd>
         </dl>
 
     </section>

--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -46,7 +46,6 @@
       <dl>
           <dt>Objective</dt><dd>Consistently locate user help</dd>
           <dt>Author task</dt><dd>If you provide a help mechanism, provide it in a consistent location</dd>
-          <dt>Key beneficiaries</dt><dd>Users with some cognitive disabilities</dd>
       </dl>
 
   </section>

--- a/understanding/22/dragging-movements.html
+++ b/understanding/22/dragging-movements.html
@@ -29,7 +29,6 @@
       <dl>
          <dt>Objective</dt><dd>Don’t rely on dragging for user actions</dd>
          <dt>Author task</dt><dd>Provide a simple pointer alternative to any action that involves dragging</dd>
-         <dt>Key beneficiaries</dt><dd>Users with some physical disabilities</dd>
       </dl>
 
   </section>

--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -56,7 +56,6 @@
         <dl>
             <dt>Objective</dt><dd>Make it easier to spot the keyboard focus</dd>
             <dt>Author task</dt><dd>Use a focus indicator of sufficient size and contrast</dd>
-            <dt>Key beneficiaries</dt><dd>Sighted users reliant on keyboard interaction</dd>
         </dl>
 
     </section>

--- a/understanding/22/focus-not-obscured-enhanced.html
+++ b/understanding/22/focus-not-obscured-enhanced.html
@@ -18,6 +18,16 @@
   </blockquote>
   <p class="note">If the interface is configurable so that the user can reposition content such as toolbars and non-modal dialogs, then only the initial positions of user-movable content are considered for testing and conformance of this Success Criterion.</p>
 </section>
+
+<section id="brief">
+  <h2>In brief</h2>
+  <dl>
+      <dt>Objective</dt><dd>Do not cover any part of the item with focus</dd>
+      <dt>Author task</dt><dd>Ensure no content obstructs the item receiving keyboard focus</dd>
+  </dl>  
+
+ </section>
+
 <section id="intent">
   <h2>Intent of Focus Not Obscured (Enhanced)</h2>
   <p>The intent of this Success Criterion is to ensure that the item receiving keyboard focus is always visible in the user's viewport. For sighted people who rely on a keyboard (or on a device that operates through the keyboard interface, such as a switch or voice input), knowing the current point of focus is critical. The component with focus signals the interaction point on the page. Where users cannot see the item with focus, they may not know how to proceed, or may even think the system has become unresponsive.</p>

--- a/understanding/22/focus-not-obscured-minimum.html
+++ b/understanding/22/focus-not-obscured-minimum.html
@@ -29,7 +29,6 @@
       <dl>
          <dt>Objective</dt><dd>Keep the focused item visible</dd>
          <dt>Author task</dt><dd>Ensure the item receiving keyboard focus is at least partially visible in the viewport</dd>
-         <dt>Key beneficiaries</dt><dd>Some users with cognitive disabilities and sighted users reliant on keyboard interaction</dd>
       </dl>
 
   </section>

--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -40,7 +40,6 @@
       <dl>
           <dt>Objective</dt><dd>Make controls easier to activate</dd>
           <dt>Author task</dt><dd>Ensure targets meet a minimum size or have sufficient spacing around them</dd>
-          <dt>Key beneficiaries</dt><dd>Users with some physical disabilities</dd>
       </dl>
     </section>
     


### PR DESCRIPTION
As per AGWG decision Jun 13, removing Key beneficiaries information, to be added in more detail by EOWG in Benefits section.

Note that Focus Not Obscured Enhanced has lost its In Brief section, which should have been added in https://github.com/w3c/wcag/pull/2905, so I re-added it (minus the Key beneficiaries).

 I suspect this file may be related to why the 2.2 'In brief section was not merged to the published version