### PR TITLE
Editorial fixes to term "assistive technology"

### DIFF
--- a/guidelines/terms/20/assistive-technology.html
+++ b/guidelines/terms/20/assistive-technology.html
@@ -6,7 +6,7 @@
       of users with disabilities that go beyond those offered by mainstream user agents
    </p>
    
-   <p class="note">functionality provided by assistive technology includes alternative presentations
+   <p class="note">Functionality provided by assistive technology includes alternative presentations
       (e.g., as synthesized speech or magnified content), alternative input methods (e.g.,
       voice), additional navigation or orientation mechanisms, and content transformations
       (e.g., to make tables more accessible).
@@ -29,7 +29,7 @@
    
    <aside class="example"><p>Assistive technologies that are important in the context of this document include
       the following:
-   </p></aside>
+   </p>
    
    <ul>
       
@@ -59,5 +59,5 @@
       </li>
       
    </ul>
-   
+   </aside>
 </dd>

--- a/guidelines/terms/20/idiom.html
+++ b/guidelines/terms/20/idiom.html
@@ -5,7 +5,7 @@
       the specific words cannot be changed without losing the meaning
    </p>
    
-   <p class="note">idioms cannot be translated directly, word for word, without losing their (cultural
+   <p class="note">Idioms cannot be translated directly, word for word, without losing their (cultural
       or language-dependent) meaning.
    </p>
    


### PR DESCRIPTION
Capitalize first word of sentence, and have the example formatting include the list of examples so it shows in the block. This latter error was introduced in WCAG 2.1 when new document formatting was added but the bulleted list that comes after the sentence ending in ":" should be included inside the boundaries of the markdown for the example 
`<div  class="example"> All of the content including the bullets </div>` 