### PR TITLE
Issue 3138 numbering

### DIFF
--- a/script/wcag.js
+++ b/script/wcag.js
@@ -83,10 +83,41 @@ function termTitles() {
 	});	
 }
 
+function numberNotes() {
+	var sectionsWithNotes = new Array();
+	document.querySelectorAll(".note").forEach(function(note) {
+		sectionsWithNotes.push(note.parentNode);
+	});
+	
+	sectionsWithNotes.forEach(function(sec) {
+		if (sec.processed) return;
+		var notes = sec.querySelectorAll('.note');
+		// no notes, shouldn't happen
+		if (notes.length == 0) return;
+		// one note, leave alone
+		if (notes.length == 1) return;
+		// more than one note, number them
+		if (notes.length > 1) {
+			var count = 1;
+			sec.querySelectorAll(".note").forEach(function(note) {
+				var span = note.querySelector(".note-title span");
+				span.textContent = "Note " + count;
+				count++;
+			});
+		}
+		sec.processed = true;
+	});
+}
+
+function renumberExamples() {
+	
+}
+
 // scripts after Respec has run
 function postRespec() {
 	addTextSemantics();
 	swapInDefinitions();
 	termTitles();
 	linkUnderstanding();
+	numberNotes();
 }

--- a/script/wcag.js
+++ b/script/wcag.js
@@ -86,11 +86,11 @@ function termTitles() {
 function numberNotes() {
 	var sectionsWithNotes = new Array();
 	document.querySelectorAll(".note").forEach(function(note) {
-		sectionsWithNotes.push(note.parentNode);
+		sectionsWithNotes.push(note.closest("section, dd"));
 	});
 	
 	sectionsWithNotes.forEach(function(sec) {
-		if (sec.processed) return;
+		if (sec.noteprocessed) return;
 		var notes = sec.querySelectorAll('.note');
 		// no notes, shouldn't happen
 		if (notes.length == 0) return;
@@ -105,12 +105,39 @@ function numberNotes() {
 				count++;
 			});
 		}
-		sec.processed = true;
+		sec.noteprocessed = true;
 	});
 }
 
 function renumberExamples() {
+	var sectionsWithExamples = new Array();
+	document.querySelectorAll(".example").forEach(function(example) {
+		var container = example.closest("dd");
+		if (container == null) container = example.closest("section");
+		sectionsWithExamples.push(container);
+	});
 	
+	sectionsWithExamples.forEach(function(sec) {
+		if (sec.exprocessed) return;
+		var examples = sec.querySelectorAll(".example");
+		// no examples, shouldn't happen
+		if (examples.length == 0) return;
+		// one example, remove the numbering
+		// more than one example, number them
+		else {
+			var count = 1;
+			var rmOrAdd = examples.length == 1 ? "rm" : "add";
+			sec.querySelectorAll(".example").forEach(function(example) {
+				var marker = example.querySelector(".marker");
+				if (rmOrAdd == "rm") marker.textContent = "Example";
+				else {
+					marker.textContent = "Example " + count;
+				}
+				count++;
+			});
+		}
+		sec.exprocessed = true;
+	});
 }
 
 // scripts after Respec has run
@@ -120,4 +147,5 @@ function postRespec() {
 	termTitles();
 	linkUnderstanding();
 	numberNotes();
+	renumberExamples();
 }

--- a/script/wcag.js
+++ b/script/wcag.js
@@ -83,10 +83,13 @@ function termTitles() {
 	});	
 }
 
+// number notes if there are multiple per section
 function numberNotes() {
 	var sectionsWithNotes = new Array();
 	document.querySelectorAll(".note").forEach(function(note) {
-		sectionsWithNotes.push(note.closest("section, dd"));
+		var container = note.closest("dd");
+		if (container == null) container = note.closest("section");
+		sectionsWithNotes.push(container);
 	});
 	
 	sectionsWithNotes.forEach(function(sec) {
@@ -109,11 +112,12 @@ function numberNotes() {
 	});
 }
 
+// change the numbering of examples to remove number from lone examples in a section, and restart numbering for multiple in each section
 function renumberExamples() {
 	var sectionsWithExamples = new Array();
 	document.querySelectorAll(".example").forEach(function(example) {
-		var container = example.closest("dd");
-		if (container == null) container = example.closest("section");
+		var container = example.closest("dd"); // use dd container if present
+		if (container == null) container = example.closest("section"); // otherwise section
 		sectionsWithExamples.push(container);
 	});
 	
@@ -130,9 +134,7 @@ function renumberExamples() {
 			sec.querySelectorAll(".example").forEach(function(example) {
 				var marker = example.querySelector(".marker");
 				if (rmOrAdd == "rm") marker.textContent = "Example";
-				else {
-					marker.textContent = "Example " + count;
-				}
+				else marker.textContent = "Example " + count;
 				count++;
 			});
 		}


### PR DESCRIPTION
fixes #3138 

Note this changes the text of note and example headings, but they continue to have respec-generated ids which won't "match up", assuming that's minor.