### PR TITLE
Parsing update for WCAG 2.1 understanding

### DIFF
--- a/understanding/20/parsing.html
+++ b/understanding/20/parsing.html
@@ -12,10 +12,8 @@
    <section id="intent">
       <h2>Intent of Parsing</h2>
       
-      <div class="wcag22">
-         <p>This criterion has been removed from WCAG 2.2.</p>
-
-         <p>The intent of this Success Criterion was to ensure that user-agents, including assistive technologies, can accurately interpret and parse content. Since WCAG 2.0 was published, the specifications (such as HTML) and browsers have improved their handling of parsing errors. It is also the case that assistive technology used to do their own parsing of markup, but now rely on the browser. For that reason this success criterion has been removed. Many issues that would have failed this criterion will fail <a href="info-and-relationships">Info and Relationships</a> or <a href="name-role-value">Name, Role, Value</a>. Other issues are excepted by the "except where the specification allow these features" part of the criterion.</p>
+      <div class="wcag21">
+         <p>This criterion has been removed from WCAG 2.2. In WCAG 2.1 and 2.0 this Success Criterion should be considered as always satisfied for any content using HTML or XML.</p>
 
          <p>The following content is left for historical purposes to show the original intent.</p>  
             


### PR DESCRIPTION
Adjusts the understanding document on the basis that #3152 is merged. 

I had thought to include more of the note from 3152, but in the understanding document that note will be included with the normative text, so it will be right above the intent section.