### PR TITLE
1.4.1 Use of Color Understanding doc: add note concerning same color case

### DIFF
--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-   <meta charset="UTF-8"></meta>
+   <meta charset="UTF-8" />
    <title>Understanding Use of Color</title>
-   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link>
+   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove" />
 </head>
 <body>
    <h1>Understanding Use of Color</h1>
@@ -63,6 +63,16 @@
 
       </div>
 
+     <div class="note">
+       
+       <p>This criterion is not applicable when assessing adjacent content that is rendered as the same color. For instance,
+         a hyperlink which has been styled to appear no different than the static text surrounding it. As there would be no color 
+         differentiation between the actionable hyperlink text and the static text adjacent to it, this would be a poor experience 
+         for all sighted users, but not a failure of this Success Criterion.
+       </p>
+       
+     </div>
+
       <div class="note">
 
          <p>This criterion does not directly address the needs of users with assistive technologies.
@@ -83,24 +93,24 @@
       </div>
 
       <div class="note">
-
-         <p>Most user agents provide users with a color-only cue that a link has been previously activated by them ("visited"). However, several technical constraints result in authors having very limited control over these color-only indications of visited links.  The technical constraints are as follows:
-            <ol>
-               <li> 
-                  User agents constrain the exposure of a link's visited state due to <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector">privacy concerns</a>. Author queries to user agents will indicate all links have not been visited.
-               </li>
-               <li>
-                  Any available information on the visited state of a link would be inaccurate since it is both user and browser-dependent. Even if an author could accurately get information on previously activated links by a certain user, the author would be constrained to the current browser's preserved history, and would be unable to determine if the user had visited the page using a different browser (or if the history was not preserved, either from cache clearing or use of private sessions).
-               </li>
-               <li>
-                  Authors can <em>only</em> use color to modify the <code>:visited</code> CSS pseudoclass style. The technology constrains any non-color styling. Due to palette limitations, an author cannot use color alone to achieve 3:1 contrast between link and non-link text as well as between visited and unvisited links while also achieving 4.5:1 contrast for all link and non-link text.
-               </li>
-               <li>
-                  Authors also cannot set the visited state of links. The anchor element does not include a "visited" attribute; therefore the author has no ability to alter the state through an attribute setting. As such, authors cannot achieve <a href="info-and-relationships">1.3.1 Info and Relationships</a> or
-                  <a href="name-role-value">4.1.2 Name, Role, Value</a> in regard to visited links.
-               </li>            
-            </ol>
-         </p>
+        
+        <p>Most user agents provide users with a color-only cue that a link has been previously activated by them ("visited"). However, several technical constraints result in authors having very limited control over these color-only indications of visited links.  The technical constraints are as follows</p>
+        
+        <ol>
+           <li> 
+              User agents constrain the exposure of a link's visited state due to <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector">privacy concerns</a>. Author queries to user agents will indicate all links have not been visited.
+           </li>
+           <li>
+              Any available information on the visited state of a link would be inaccurate since it is both user and browser-dependent. Even if an author could accurately get information on previously activated links by a certain user, the author would be constrained to the current browser's preserved history, and would be unable to determine if the user had visited the page using a different browser (or if the history was not preserved, either from cache clearing or use of private sessions).
+           </li>
+           <li>
+              Authors can <em>only</em> use color to modify the <code>:visited</code> CSS pseudoclass style. The technology constrains any non-color styling. Due to palette limitations, an author cannot use color alone to achieve 3:1 contrast between link and non-link text as well as between visited and unvisited links while also achieving 4.5:1 contrast for all link and non-link text.
+           </li>
+           <li>
+              Authors also cannot set the visited state of links. The anchor element does not include a "visited" attribute; therefore the author has no ability to alter the state through an attribute setting. As such, authors cannot achieve <a href="info-and-relationships">1.3.1 Info and Relationships</a> or
+              <a href="name-role-value">4.1.2 Name, Role, Value</a> in regard to visited links.
+           </li>            
+        </ol>         
 
          <p>For these reasons, setting or conveying a link's visited status is not an author responsibility. Where color alone distinguishes between visited and unvisited links, it does not result in a failure of this Success Criterion, even where the contrast between the two link colors is below 3:1. Note that authors must continue to ensure that all text links meet contrast minimums against the page background (SC 1.4.3).</p>
       </div>


### PR DESCRIPTION
closes #1467

Per the feedback in the thread, the use case of a hyperlink being styled to look no different than adjacent static text would not be a failure of 1.4.1 since there is no difference in color to compare against.  

This PR adds a note to call that out.

Additionally this PR makes some corrections to the source code.  Namely:
- removes the `</meta>` and `</link>` in the header - these are self-closing tags so these shouldn't be there.
- fixes an instance where a list was nested in a `p` element, which is invalid and was causing the HTML parser to kick it out/created an empty paragraph after the list.