### PR TITLE
Reformat definition lists, ordered lists, fix Reading Level understanding

### DIFF
--- a/understanding/20/abbreviations.html
+++ b/understanding/20/abbreviations.html
@@ -82,50 +82,17 @@
    <section id="examples">
       <h2>Examples of Abbreviations</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An abbreviation whose expansion is provided the first time the abbreviation appears
-                  in the content.
-               </strong>
-               							     
-            </p>
-            
-            <p>The name, "World Wide Web Consortium," appears as the first heading on the organization's
-               home page. The abbreviation, "W3C," is enclosed in parentheses in the same heading.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A dictionary search form.</strong>
-               							     
-            </p>
-            
-            <p>A Web site includes a search form provided by an on-line acronym service. Users enter
+      <dl>
+         <dt>An abbreviation whose expansion is provided the first time the abbreviation appears
+            in the content</dt>
+         <dd>The name, "World Wide Web Consortium," appears as the first heading on the organization's
+               home page. The abbreviation, "W3C," is enclosed in parentheses in the same heading.</dd>
+         <dt>A dictionary search form</dt>
+         <dd>A Web site includes a search form provided by an on-line acronym service. Users enter
                an acronym and the form returns a list of possible expansions from the sources that
-               it searched. 
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A medical Web site.</strong>
-               							     
-            </p>
-            
-            <p>A medical Web site provides information for both doctors and patients. The site includes
+               it searched.</dd>
+         <dt>A medical Web site</dt>
+         <dd>A medical Web site provides information for both doctors and patients. The site includes
                a set of cascading dictionaries;  a very specialized medical dictionary is first,
                followed by a second medical dictionary for the general public. The cascade also includes
                a list of acronyms and abbreviations that are unique to the site, and finally there
@@ -133,34 +100,13 @@
                definitions for most words in the text. The specialized medical dictionary yields
                definitions of unusual medical terms. Definitions for words that appear in more than
                one dictionary are listed in the order of the cascade. The meaning of acronyms and
-               abbreviations is provided by the list of acronyms and abbreviations. 
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  Expanded forms of Abbreviations.
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>
-               The expanded form of each abbreviation is available in a programmatically determinable
+               abbreviations is provided by the list of acronyms and abbreviations.</dd>
+         <dt>Expanded forms of Abbreviations</dt>
+         <dd>The expanded form of each abbreviation is available in a programmatically determinable
                manner. User agents that speak the text can use the expanded form to announce the
                abbreviation. Other user agents might make the expanded form available as a tooltip
-               or as contextual help for the abbreviation. 
-               
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               or as contextual help for the abbreviation.</dd>
+      </dl>
       
    </section>
    
@@ -200,7 +146,7 @@
                
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -214,15 +160,11 @@
                   <ul>
                      
                      <li>
-                        												               
                         <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G97" class="general">Providing the abbreviation immediately following the expanded form</a>
-                        											             
                      </li>
                      
                      <li>
-                        												               
                         <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G55" class="general">Linking to definitions</a>
-                        											             
                      </li>
                      
                      <li>
@@ -291,7 +233,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -301,7 +243,7 @@
                
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -336,7 +278,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/audio-control.html
+++ b/understanding/20/audio-control.html
@@ -66,13 +66,10 @@
    <section id="examples">
       <h2>Examples of Audio Control</h2>
       
-      
       <ul>
-         
          <li>An audio file begins playing automatically when a page is opened. However, the audio
             can be stopped by the user by selecting a "silent" link at the top of the page.
          </li>
-         
       </ul>
       
    </section>
@@ -91,7 +88,7 @@
          <h3>Sufficient Techniques for Audio Control</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -111,7 +108,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/20/audio-description-or-media-alternative-prerecorded.html
@@ -95,69 +95,41 @@
    
    <section id="examples">
       <h2>Examples of Audio Description or Media Alternative (Prerecorded)</h2>
-      
-      
-      <ul>
-         
-         <li>
-            
+
+      <dl>
+         <dt>A movie with audio description</dt>
+         <dd>
             <p>
-               								       
-               <strong>A movie with audio description.</strong>
-               							     
-            </p>
-            
-            <p> 
-               
                <strong>Describer: </strong>A title, "Teaching Evolution Case Studies. Bonnie Chen." A teacher shows photographs
                of birds with long, thin beaks.
             </p>
             
             <p> 
-               
                <strong>Bonnie Chen: </strong>"These photos were all taken at the Everglades."
             </p>
             
             <p> 
-               
                <strong>Describer: </strong>The teacher hands each student two flat, thin wooden sticks.
             </p>
             
             <p> 
-               
                <strong>Bonnie Chen: </strong>"Today you will pretend to be a species of wading bird that has a beak like this."
             </p>
             
             <p> 
-               
                <strong>Describer: </strong>The teacher holds two of the sticks to her mouth making the shape of a beak.
             </p>
             
-            <p>Transcript of audio based on the first few minutes of "
-               <a href="http://www.pbs.org/wgbh/evolution/educators/teachstuds/tvideos.html">Teaching Evolution Case Studies, Bonnie Chen</a>" (copyright WGBH and Clear Blue Sky Productions, Inc.)
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An alternative for time-based media for a training video</strong>
-               							     
-            </p>
-            
-            <p>A company purchases a Training video for use by its employees and puts it on the companies
+            <p>Transcript of audio based on the first few minutes of "<a href="http://www.pbs.org/wgbh/evolution/educators/teachstuds/tvideos.html">Teaching Evolution Case Studies, Bonnie Chen</a>" (copyright WGBH and Clear Blue Sky Productions, Inc.)</p>
+            </dd>
+         <dt>An alternative for time-based media for a training video</dt>
+         <dd>A company purchases a Training video for use by its employees and puts it on the companies
                intranet. The video involves explaining use of a new technology and has a person talking
                and showing things at the same time. Since there is no place to insert audio description
                of the visual demonstrations during gaps in dialogue, the company provides an alternative
                for time-based media that all employees, including those who cannot see the demonstrations,
-               can use to better understand what is being presented. 
-            </p>
-            
-         </li>
-         
-      </ul>
+               can use to better understand what is being presented.</dd>
+</dl>
       
    </section>
    
@@ -209,7 +181,7 @@
          <h3>Sufficient Techniques for Audio Description or Media Alternative (Prerecorded)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -314,7 +286,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/audio-description-prerecorded.html
+++ b/understanding/20/audio-description-prerecorded.html
@@ -67,19 +67,10 @@
    <section id="examples">
       <h2>Examples of Audio Description (Prerecorded)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
+      <dl>
+         <dt>A movie with audio description</dt>
+         <dd> 
             <p>
-               								       
-               <strong>A movie with audio description.</strong>
-               							     
-            </p>
-            
-            <p> 
-               
                <strong>Describer: </strong>A title, "Teaching Evolution Case Studies. Bonnie Chen." A teacher shows photographs
                of birds with long, thin beaks.
             </p>
@@ -104,13 +95,9 @@
                <strong>Describer: </strong>The teacher holds two of the sticks to her mouth making the shape of a beak.
             </p>
             
-            <p>Transcript of audio based on the first few minutes of "
-               <a href="http://www.pbs.org/wgbh/evolution/educators/teachstuds/tvideos.html">Teaching Evolution Case Studies, Bonnie Chen</a>" (copyright WGBH and Clear Blue Sky Productions, Inc.)
-            </p>
-            
-         </li>
-         
-      </ul>
+            <p>Transcript of audio based on the first few minutes of "<a href="http://www.pbs.org/wgbh/evolution/educators/teachstuds/tvideos.html">Teaching Evolution Case Studies, Bonnie Chen</a>" (copyright WGBH and Clear Blue Sky Productions, Inc.)</p>
+         </dd>
+      </dl>
       
    </section>
    
@@ -162,7 +149,7 @@
          <h3>Sufficient Techniques for Audio Description (Prerecorded)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -230,7 +217,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/audio-only-and-video-only-prerecorded.html
+++ b/understanding/20/audio-only-and-video-only-prerecorded.html
@@ -80,72 +80,25 @@
    <section id="examples">
       <h2>Examples of Audio-only and Video-only (Prerecorded)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An audio recording of a speech</strong>
-               							     
-            </p>
-            
-            <p>The link to an audio clip says, "Chairman's speech to the assembly." A link to a text
-               transcript is provided immediately after the link to the audio clip.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An audio recording of a press conference</strong>
-               							     
-            </p>
-            
-            <p>A Web page includes a link to an audio recording of a press conference that identifies
+      <dl>
+         <dt>An audio recording of a speech</dt>
+         <dd>The link to an audio clip says, "Chairman's speech to the assembly." A link to a text
+               transcript is provided immediately after the link to the audio clip.</dd>
+         <dt>An audio recording of a press conference</dt>
+         <dd>A Web page includes a link to an audio recording of a press conference that identifies
                the audio recording. The page also links to a text transcript of the press conference.
                The transcript includes a verbatim record of everything the speakers say. It identifies
                who is speaking as well as noting other significant sounds that are part of the recording,
-               such as applause, laughter, questions from the audience, and so on.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An animation that illustrates how a car engine works</strong>
-               							     
-            </p>
-            
-            <p>An animation shows how a car engine works. There is no audio and the animation is
+               such as applause, laughter, questions from the audience, and so on.</dd>
+         <dt>An animation that illustrates how a car engine works</dt>
+         <dd>An animation shows how a car engine works. There is no audio and the animation is
                part of a tutorial that describes how an engine works. Since the text of the tutorial
                already provides a full explanation, the media is an alternative for text and the
                text alternative includes only a brief description of the animation and refers to
-               the tutorial text for more information.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A video-only file with an audio track</strong>
-               							     
-            </p>
-            
-            <p>A silent movie includes an audio track which includes a description of the action
-               in the video.
-            </p>
-            
-         </li>
-         
-      </ul>
+               the tutorial text for more information.</dd>
+         <dt>A video-only file with an audio track</dt>
+         <dd>A silent movie includes an audio track which includes a description of the action in the video.</dd>
+      </dl>
       
    </section>
    
@@ -189,7 +142,7 @@
             
             <h4>Situation A: If the content is prerecorded audio-only:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -197,7 +150,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -205,7 +158,7 @@
             
             <h4>Situation B: If the content is prerecorded video-only:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -219,7 +172,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/audio-only-live.html
+++ b/understanding/20/audio-only-live.html
@@ -42,7 +42,6 @@
    <section id="examples">
       <h2>Examples of Audio-only (Live)</h2>
       
-      
       <ul>
          
          <li>A public relations firm uses Web based caption services to cover live events; the
@@ -108,7 +107,7 @@
          <h3>Sufficient Techniques for Audio-only (Live)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -130,7 +129,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/bypass-blocks.html
+++ b/understanding/20/bypass-blocks.html
@@ -101,7 +101,6 @@
    <section id="examples">
       <h2>Examples of Bypass Blocks</h2>
       
-      
       <ul>
          
          <li>A news organization's home page contains a main story in the middle of the page, surrounded
@@ -148,7 +147,7 @@
          <h3>Sufficient Techniques for Bypass Blocks</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -226,7 +225,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/captions-live.html
+++ b/understanding/20/captions-live.html
@@ -46,38 +46,15 @@
    <section id="examples">
       <h2>Examples of Captions (Live)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A Web cast</strong>
-               							     
-            </p>
-            
-            <p>A news organization provides a live, captioned Web cast. </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A music Web cast</strong>
-               							     
-            </p>
-            
-            <p>An orchestra provides Communication Access Realtime Translation (CART) captioning
+      <dl>
+         <dt>A Web cast</dt>
+         <dd>A news organization provides a live, captioned Web cast. </dd>
+         <dt>A music Web cast</dt>
+         <dd>An orchestra provides Communication Access Realtime Translation (CART) captioning
                of each real-time Web performance. The CART service captures lyrics and dialog as
                well as identifies non-vocal music by title, movement, composer, and any information
-               that will help the user comprehend the nature of the audio.
-            </p>
-            
-         </li>
-         
-      </ul>
+               that will help the user comprehend the nature of the audio.</dd>
+      </dl>
       
    </section>
    
@@ -103,7 +80,7 @@
          <h3>Sufficient Techniques for Captions (Live)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -155,7 +132,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/captions-prerecorded.html
+++ b/understanding/20/captions-prerecorded.html
@@ -62,7 +62,6 @@
    <section id="examples">
       <h2>Examples of Captions (Prerecorded)</h2>
       
-      
       <ul>
          
          <li>
@@ -79,9 +78,7 @@
             
             <p>for the likes of sailors, soldiers and woodsmen.." </p>
             
-            <p>From Sample Transcript Formatting by Whit Anderson.</p>
-            
-         </li>
+            <p>From Sample Transcript Formatting by Whit Anderson.</dd>
          
          <li>A complex legal document contains synchronized media clips for different paragraphs
             that show a person speaking the contents of the paragraph. Each clip is associated
@@ -191,8 +188,7 @@
       <section id="sufficient">
          <h3>Sufficient Techniques for Captions (Prerecorded)</h3>
          
-         
-         <ol>
+         <ul>
             
             <li>
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G93" class="general">Providing open (always visible) captions</a>
@@ -231,7 +227,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/captions-prerecorded.html
+++ b/understanding/20/captions-prerecorded.html
@@ -63,56 +63,32 @@
       <h2>Examples of Captions (Prerecorded)</h2>
       
       <ul>
-         
          <li>
-            
-            <p>
-               <strong>A captioned tutorial</strong>
-            </p>
-            
-            <p> A video clip shows how to tie a knot. The captions read, </p>
-            
+            <p><strong>A captioned tutorial</strong></p>
+            <p>A video clip shows how to tie a knot. The captions read, </p>
             <p>"(music) </p>
-            
             <p>Using rope to tie knots was an important skill</p>
-            
             <p>for the likes of sailors, soldiers and woodsmen.." </p>
-            
-            <p>From Sample Transcript Formatting by Whit Anderson.</dd>
-         
+            <p>From Sample Transcript Formatting by Whit Anderson.</p>
+         </li>
          <li>A complex legal document contains synchronized media clips for different paragraphs
             that show a person speaking the contents of the paragraph. Each clip is associated
-            with its corresponding paragraph. No captions are provided for the synchronized media.
-            
-            
-         </li>
-         
+            with its corresponding paragraph. No captions are provided for the synchronized media.</li>
          <li>An instruction manual containing a description of a part and its necessary orientation
             is accompanied by a synchronized media clip showing the part in its correct orientation.
-            No captions are provided for the synchronized media clip.  
-            
-         </li>
-         
+            No captions are provided for the synchronized media clip.</li>
          <li>
-            
             <p>An orchestra provides captions for videos of performances. In addition to capturing
                dialog and lyrics verbatim, captions identify non-vocal music by title, movement,
                composer, and any information that will help the user comprehend the nature of the
-               audio. For instance captions read,
-            </p>
-            
+               audio. For instance captions read,</p>
             <p>"[Orchestral Suite No. 3.2 in D major, BWV 1068, Air]</p>
-            
             <p>[Johann Sebastian Bach, Composer] </p>
-            
             <p>♪ Calm melody with a slow tempo ♪"</p>
-            
             <div class="note">
                <p>Style guides for captions may differ among different languages.</p>
             </div>
-            
          </li>
-         
       </ul>
       
    </section>

--- a/understanding/20/change-on-request.html
+++ b/understanding/20/change-on-request.html
@@ -91,40 +91,14 @@
    <section id="examples">
       <h2>Examples of Change on Request</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>an "update now" button</strong>
-               							     
-            </p>
-            
-            <p> Instead of automatically updating the content, the author provides an "Update now"
-               button that requests a refresh of the content.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An automatic redirection</strong>
-               							     
-            </p>
-            
-            <p>A user is automatically redirected from an old page to a new page in such a way that
-               he or she never realizes the redirect has occurred.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+      <dl>
+         <dt>an "update now" button</dt>
+         <dd> Instead of automatically updating the content, the author provides an "Update now"
+               button that requests a refresh of the content.</dd>
+         <dt>An automatic redirection</dt>
+         <dd>A user is automatically redirected from an old page to a new page in such a way that
+               he or she never realizes the redirect has occurred.</dd>
+      </dl>
       
    </section>
    
@@ -163,7 +137,7 @@
             
             <h4>Situation A: If the Web page allows automatic updates:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -171,7 +145,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -179,7 +153,7 @@
             
             <h4>Situation B: If automatic redirects are possible:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -206,7 +180,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -214,7 +188,7 @@
             
             <h4>Situation C: If the Web page uses pop-up windows:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -238,7 +212,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -246,7 +220,7 @@
             
             <h4>Situation D: If using an onchange event on a select element:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -254,7 +228,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/consistent-identification.html
+++ b/understanding/20/consistent-identification.html
@@ -66,143 +66,49 @@
    <section id="examples">
       <h2>Examples of Consistent Identification</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 1: Document Icon</strong>
-               							     
-            </p>
-            
-            <p>A document icon is used to indicate document download throughout a site. The text
+      <dl>
+         <dt>Example 1: Document Icon</dt>
+         <dd>A document icon is used to indicate document download throughout a site. The text
                alternative for the icon always begins with the word “Download," followed by a shortened
                form of the document title. Using different text alternatives to identify document
-               names for different documents is a consistent use of text alternatives.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 2: Check Mark</strong>
-               							     
-            </p>
-            
-            <p>A check mark icon functions as "approved", on one page but as "included" on another.
-               Since they serve different functions, they have different text alternatives.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 3: Consistent references to other pages</strong>
-               							     
-            </p>
-            
-            <p> A Web site publishes articles on-line. Each article spans multiple Web pages and
+               names for different documents is a consistent use of text alternatives.</dd>
+         <dt>Example 2: Check Mark</dt>
+         <dd>A check mark icon functions as "approved", on one page but as "included" on another.
+               Since they serve different functions, they have different text alternatives.</dd>
+         <dt>Example 3: Consistent references to other pages</dt>
+         <dd> A Web site publishes articles on-line. Each article spans multiple Web pages and
                each page contains a link to the first page, the next page and the previous page of
                the article. If the references to the next page read "page 2", "page 3", "page 4"
                etcetera, the labels are not the same but they are consistent. Therefore, these references
-               are not failures of this Success Criterion. 
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 4: Icons with similar functions</strong>
-               							     
-            </p>
-            
-            <p>An e-commerce application uses a printer icon that allows the user to print receipts
+               are not failures of this Success Criterion.</dd>
+         <dt>Example 4: Icons with similar functions</dt>
+         <dd>An e-commerce application uses a printer icon that allows the user to print receipts
                and invoices. In one part of the application, the printer icon is labeled "Print receipt"
                and is used to print receipts, while in another part it is labeled "Print invoice"
                and is used to print invoices. The labeling is consistent ("Print x"), but the labels
                are different to reflect the different functions of the icons. Therefore, this example
-               does not fail the Success Criterion.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 5: Save icon</strong>
-               							     
-            </p>
-            
-            <p>A common "save" icon is used through out the site where page save function is provided
-               on multiple Web pages.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 6: Icon and adjacent link to same destination</strong>
-               							     
-            </p>
-            
-            <p>An icon with alt text and a link are next to each other and go to the same location.
+               does not fail the Success Criterion.</dd>
+         <dt>Example 5: Save icon</dt>
+         <dd>A common "save" icon is used through out the site where page save function is provided
+               on multiple Web pages.</dd>
+         <dt>Example 6: Icon and adjacent link to same destination</dt>
+         <dd>An icon with alt text and a link are next to each other and go to the same location.
                The best practice would be to group them into one link as per 
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H2" class="html"></a>. However if they are visually positioned one above the other but separated in the
                source, this may not be possible. To meet the Success Criterion, the link text for
                these two links need only be consistent, not identical. But best practice is to have
                identical text so that when users encounter the second one, it is clear that it goes
-               to the same place as the first.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 7: Example of a Failure</strong>
-               							     
-            </p>
-            
-            <p>A submit "search" button on one Web page and a "find" button on another Web page both
+               to the same place as the first.</dd>
+         <dt>Example 7: Example of a Failure</dt>
+         <dd>A submit "search" button on one Web page and a "find" button on another Web page both
                have a field to enter a term and list topics in the Web site related to the term submitted.
-               In this case, the buttons have the same functionality but are not labeled consistently.
-               
-               
-            </p>
-            
-         </li>
+               In this case, the buttons have the same functionality but are not labeled consistently.</dd>
 
-         <li>
-            
-               <p>
-                                                 
-                  <strong>Example 8: Failure primarily impacting assistive technology users</strong>
-                                            
-               </p>
-               
-               <p>Two buttons with the same functionality visually have the same text, but have been given
+         <dt>Example 8: Failure primarily impacting assistive technology users</dt>
+         <dd>Two buttons with the same functionality visually have the same text, but have been given
                   different <code>aria-label="..."</code> accessible names. For users of assistive technologies,
-                  these two buttons will be announced differently and inconsistently.
-                  
-               </p>
-               
-            </li>
-         
-      </ul>
+                  these two buttons will be announced differently and inconsistently.</dd>
+      </dl>
       
    </section>
    
@@ -220,7 +126,7 @@
          <h3>Sufficient Techniques for Consistent Identification</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -233,7 +139,7 @@
                <a href="name-role-value#techniques" class="understanding">sufficient techniques for Success Criterion 4.1.2</a> for providing labels, names, and text alternatives.
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/consistent-navigation.html
+++ b/understanding/20/consistent-navigation.html
@@ -66,73 +66,22 @@
    <section id="examples">
       <h2>Examples of Consistent Navigation</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A consistently located control</strong>
-               							     
-            </p>
-            
-            <p>A search field is the last item on every Web page in a site. Users can quickly locate
-               the search function. 
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An expanding navigation menu</strong>
-               							     
-            </p>
-            
-            <p>A navigation menu includes a list of seven items with links to the main sections of
-               a site.
+      <dl>
+         <dt>A consistently located control</dt>
+         <dd>A search field is the last item on every Web page in a site. Users can quickly locate the search function.</dd>
+         <dt>An expanding navigation menu</dt>
+         <dd>A navigation menu includes a list of seven items with links to the main sections of a site.
                When a user selects one of these items, a list of sub-navigation items is inserted
-               into the top-level navigation menu.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Consistently positioned skip navigation controls</strong>
-               							     
-            </p>
-            
-            <p>A "skip navigation" (or "skip to main content") link is included as the first link
+               into the top-level navigation menu.</dd>
+         <dt>Consistently positioned skip navigation controls</dt>
+         <dd>A "skip navigation" (or "skip to main content") link is included as the first link
                on every page in a Web site. The link allows users to quickly bypass heading information
-               and navigational content and begin interacting with the main content of a page.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Skip to navigation link</strong>
-               							     
-            </p>
-            
-            <p>Navigational content is consistently located at the end of each page in a set of Web
+               and navigational content and begin interacting with the main content of a page.</dd>
+         <dt>Skip to navigation link</dt>
+         <dd>Navigational content is consistently located at the end of each page in a set of Web
                pages. A "skip to navigation" link is consistently located at the beginning of each
-               page so that keyboard users can easily locate it when needed. 
-            </p>
-            
-         </li>
-         
-      </ul>
+               page so that keyboard users can easily locate it when needed.</dd>
+      </dl>
       
    </section>
    
@@ -163,7 +112,7 @@
          <h3>Sufficient Techniques for Consistent Navigation</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -171,7 +120,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -312,7 +312,7 @@
             
             <h4>Situation A: text is less than 18 point if not bold and less than 14 point if bold</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G17" class="general">Ensuring that  contrast of at least 10:1 exists between text and background behind
@@ -332,7 +332,7 @@
                   </a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -340,7 +340,7 @@
             
             <h4>Situation B: text is as least 18 point if not bold and at least 14 point if bold</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G18" class="general">Ensuring that a contrast ratio of at least 4.5:1 exists between text and background
@@ -360,7 +360,7 @@
                   </a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -325,7 +325,7 @@
             
             <h4>Situation A: text is less than 18 point if not bold and less than 14 point if bold</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G18" class="general">Ensuring that  contrast of at least 4.5:1 exists between text (and images of text)
@@ -345,7 +345,7 @@
                   </a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -353,7 +353,7 @@
             
             <h4>Situation B: text is at least 18 point if not bold and at least 14 point if bold</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G145" class="general">Ensuring that a contrast ratio of at least 3:1 exists between text (and images of
@@ -373,7 +373,7 @@
                   </a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/error-identification.html
+++ b/understanding/20/error-identification.html
@@ -113,55 +113,27 @@
    <section id="examples">
       <h2>Examples of Error Identification</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Identifying errors in a form submission</strong>
-               							     
-            </p>
-            
-            <p>
-               An airline Web site offers a special promotion on discounted flights. The user is
+      <dl>
+         <dt>Identifying errors in a form submission</dt>
+         <dd>
+            <p>An airline Web site offers a special promotion on discounted flights. The user is
                asked to complete a simple form that asks for personal information such as name, address,
                phone number, seating preference and e-mail address. If any of the fields of the form
                are either not completed or completed incorrectly, an alert is displayed notifying
-               the user which field or fields were missing or incorrect. 
-               
-               
-            </p>
+               the user which field or fields were missing or incorrect.</p>
             
             <div class="note">
-               
                <p>This Success Criterion does not mean that color or text styles cannot be used to indicate
                   errors. It simply requires that errors also be identified using text. In this example,
                   two asterisks are used in addition to color.
                </p>
-               
             </div>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Providing multiple cues</strong>
-               							     
-            </p>
-            
-            <p>The user fails to fill in two fields on the form.  In addition to describing the error
+         </dd>
+         <dt>Providing multiple cues</dt>
+         <dd>The user fails to fill in two fields on the form.  In addition to describing the error
                and providing a unique character to make it easy to search for the fields, the fields
-               are highlighted in yellow to make it easier to visually search for them as well.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               are highlighted in yellow to make it easier to visually search for them as well.</dd>
+      </dl>
       
    </section>
    
@@ -184,7 +156,7 @@
             
             <h4>Situation A: If a form contains fields for which information from the user is mandatory.</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -210,7 +182,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -220,7 +192,7 @@
                format or of certain values.
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -274,7 +246,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/error-prevention-all.html
+++ b/understanding/20/error-prevention-all.html
@@ -65,14 +65,14 @@
          <h3>Sufficient Techniques for Error Prevention (All)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                	Following the 
                <a href="error-prevention-legal-financial-data#techniques" class="understanding">sufficient techniques for Success Criterion 3.3.4</a> for all forms that require the user to submit information.
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/error-prevention-legal-financial-data.html
+++ b/understanding/20/error-prevention-legal-financial-data.html
@@ -65,43 +65,19 @@
    <section id="examples">
       <h2>Examples of Error Prevention (Legal, Financial, Data)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <em>Order confirmation.</em>
-               							     
-            </p>
-            
-            <p>A Web retailer offers on-line shopping for customers. When an order is submitted,
+      <dl>
+         <dt>Order confirmation.</dt>
+         <dd>A Web retailer offers on-line shopping for customers. When an order is submitted,
                the order information—including items ordered, quantity of each ordered item, shipping
                address, and payment method—are displayed so that the user can inspect the order for
-               correctness. The user can either confirm the order or make changes.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <em>Stock sale:</em>
-               							     
-            </p>
-            
-            <p>A financial services Web site lets users buy and sell stock online. When a user submits
+               correctness. The user can either confirm the order or make changes.</dd>
+         <dt>Stock sale:</dt>
+         <dd>A financial services Web site lets users buy and sell stock online. When a user submits
                an order to buy or sell stock, the system checks to see whether or not the market
                is open. If it is after hours, the user is alerted that the transaction will be an
                after-hours transaction, is told about the risks of trading outside of regular market
-               hours, and given the opportunity to cancel or confirm the order.
-            </p>
-            
-         </li>
-         
-      </ul>
+               hours, and given the opportunity to cancel or confirm the order.</dd>
+      </dl>
       
    </section>
    
@@ -125,7 +101,7 @@
                a purchase or submitting an income tax return:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -147,7 +123,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -155,7 +131,7 @@
             
             <h4>Situation B: If an action causes information to be deleted:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -175,7 +151,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -183,7 +159,7 @@
             
             <h4>Situation C: If the Web page includes a testing application:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -197,7 +173,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/error-suggestion.html
+++ b/understanding/20/error-suggestion.html
@@ -55,53 +55,26 @@
    <section id="examples">
       <h2>Examples of Error Suggestion</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Additional Help for Correcting An Input Error</strong>
-               							     
-            </p>
-            
-            <p>The result of a form that was not successfully submitted describes an
+      <dl>
+         <dt>Additional Help for Correcting An Input Error</dt>
+         <dd>The result of a form that was not successfully submitted describes an
                input error in place in the page along with the correct input and offers additional
-               help for the form field that caused the input error. 
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Suggestions from a Limited Set of Values</strong>
-               							     
-            </p>
-            
-            <p> An input field requires that a month name be entered. If the user enters "12," suggestions
-               for correction may include 
-               
-            </p>
+               help for the form field that caused the input error.</dd>
+         <dt>Suggestions from a Limited Set of Values</dt>
+         <dd>
+            <p>An input field requires that a month name be entered. If the user enters "12," suggestions
+               for correction may include:</p>
             
             <ul>
-               
                <li>A list of the acceptable values, e.g., "Choose one of: January, February, March, April,
                   May, June, July, August, September, October, November, December."
                </li>
-               
                <li>The conversion of the input data interpreted as a different month format, e.g., "Do
                   you mean 'December'?"
                </li>
-               
             </ul>
-            
-         </li>
-         
-      </ul>
+         </dd>
+      </dl>
       
    </section>
    
@@ -133,7 +106,7 @@
             
             <h4>Situation A: If information for a field is required to be in a specific data format:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -161,7 +134,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -171,7 +144,7 @@
                of values:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -199,7 +172,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/extended-audio-description-prerecorded.html
+++ b/understanding/20/extended-audio-description-prerecorded.html
@@ -47,11 +47,9 @@
    <section id="examples">
       <h2>Examples of Extended Audio Description (Prerecorded)</h2>
       
-      
       <ul>
          
          <li>
-            								       
             <em>Example 1. Video of a lecture.</em> A physics professor is giving a lecture. He makes freehand sketches on the whiteboard,
             speaking rapidly as he draws. As soon as he has finished discussing one problem, he
             erases the drawing and makes another sketch while continuing to speak and gesture
@@ -111,7 +109,7 @@
          <h3>Sufficient Techniques for Extended Audio Description (Prerecorded)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -140,7 +138,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/focus-order.html
+++ b/understanding/20/focus-order.html
@@ -57,7 +57,7 @@
       
       <p>For clarity:</p>
       
-      <ol>
+      <ul>
          
          <li>Focusable components need to receive focus in an order that preserves meaning and
             operability only when navigation sequences affect meaning and operability.
@@ -71,7 +71,7 @@
             them needs to be provided.
          </li>
          
-      </ol>
+      </ul>
       
       
    </section>
@@ -110,8 +110,7 @@
    <section id="examples">
       <h2>Examples of Focus Order</h2>
       
-      
-      <ol>
+      <ul>
          
          <li>On a web page that contains a tree of interactive controls, the user can use the up
             and down arrow keys to move from tree node to tree node. Pressing the right arrow
@@ -153,9 +152,7 @@
          
          <li>
             
-            <p>The following example 
-               <strong>fails to meet the Success Criterion</strong>:
-            </p>
+            <p>The following example <strong>fails to meet the Success Criterion</strong>:</p>
             
             <p>A company's Web site includes a form that collects marketing data and allows users
                to subscribe to several newsletters published by the company. The section of the form
@@ -164,12 +161,10 @@
                so that users can indicate newsletters they want to receive. However, the tab order
                for the form skips between fields in different sections of the form, so that focus
                moves from the name field to a checkbox, then to the street address, then to another
-               checkbox.
-            </p>
-            
+               checkbox.</p>
          </li>
          
-      </ol>
+      </ul>
       
    </section>
    
@@ -187,7 +182,7 @@
          <h3>Sufficient Techniques for Focus Order</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -251,7 +246,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/focus-visible.html
+++ b/understanding/20/focus-visible.html
@@ -77,7 +77,7 @@
          <h3>Sufficient Techniques for Focus Visible</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -119,7 +119,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/headings-and-labels.html
+++ b/understanding/20/headings-and-labels.html
@@ -71,75 +71,28 @@
    <section id="examples">
       <h2>Examples of Headings and Labels</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A news site.</strong>
-               							     
-            </p>
-            
-            <p>The home page of a news site lists the headlines for the top stories of the hour.
+      <dl>
+         <dt>A news site.</dt>
+         <dd>The home page of a news site lists the headlines for the top stories of the hour.
                Under each heading are the first 35 words of the story and a link to the full article.
-               Each headline gives a clear idea of the article's subject.
-            </p>
-            
-         </li>
+               Each headline gives a clear idea of the article's subject.</dd>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>A guide on how to write well</strong>
-               							     
-            </p>
-            
-            <p>A guide on writing contains the following section titles: How To Write Well,  Cut
+         <dt>A guide on how to write well</dt>
+         <dd>A guide on writing contains the following section titles: How To Write Well,  Cut
                Out Useless Words,   Identify Unnecessary Words, etc.  The section headings are clear
                and concise and the structure of the information is reflected in the structure of
-               the headings.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Consistent headings in different articles</strong>
-               							     
-            </p>
-            
-            <p>A Web site contains papers from a conference. Submissions to the conference are required
+               the headings.</dd>
+         <dt>Consistent headings in different articles</dt>
+         <dd>A Web site contains papers from a conference. Submissions to the conference are required
                to have the following organization: Summary, Introduction, [other sections unique
                to this article], Conclusion, Author Biography, Glossary, and Bibliography. The title
                of each Web page clearly identifies the article it contains, creating a useful balance
-               between the uniqueness of the articles and the consistency of the section headings.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A form asking the name of the user</strong>
-               							     
-            </p>
-            
-            <p>A form asks the name of the user. It consists of two input fields to ask for the first
+               between the uniqueness of the articles and the consistency of the section headings.</dd>
+         <dt>A form asking the name of the user</dt>
+         <dd>A form asks the name of the user. It consists of two input fields to ask for the first
                and last name. The first field is labeled "First name", the second is labeled "Last
-               name"."
-            </p>
-            
-         </li>
-         
-      </ul>
+               name".</dd>
+      </dl>
       
    </section>
    
@@ -172,7 +125,7 @@
          <h3>Sufficient Techniques for Headings and Labels</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -186,7 +139,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/help.html
+++ b/understanding/20/help.html
@@ -55,24 +55,11 @@
    <section id="examples">
       <h2>Examples of Help</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>on-line job application</strong>
-               							     
-            </p>
-            
-            <p> Some of the questions may be hard for new job seekers to understand. A help link
-               next to each question provides instructions and explanations for each question.
-            </p>
-            
-         </li>
-         
-      </ul>
+      <dl>
+         <dt>on-line job application</dt>
+         <dd>Some of the questions may be hard for new job seekers to understand. A help link
+               next to each question provides instructions and explanations for each question.</dd>
+      </dl>
       
    </section>
    
@@ -94,7 +81,7 @@
             
             <h4>Situation A: If a form requires text input:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -125,7 +112,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -133,7 +120,7 @@
             
             <h4>Situation B: If a form requires text input in an expected data format:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -149,7 +136,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/images-of-text-no-exception.html
+++ b/understanding/20/images-of-text-no-exception.html
@@ -67,109 +67,41 @@
    <section id="examples">
       <h2>Examples of Images of Text (No Exception)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A quote</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains a quote. The quote itself is presented as italicized text, indented
+      <dl>
+         <dt>A quote</dt>
+         <dd>A Web page contains a quote. The quote itself is presented as italicized text, indented
                from the left margin. The name of the person to whom the quote is attributed is below
                the quote with 1.5x the line space and further indented from the left margin. CSS
                is used to position the text; set the spacing between lines; as well as display the
-               text's font family, size, color and decoration.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Navigation items</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains a menu of navigation links that have both an icon and text to
+               text's font family, size, color and decoration.</dd>
+         <dt>Navigation items</dt>
+         <dd>A Web page contains a menu of navigation links that have both an icon and text to
                describe their target. CSS is used to display the text's font family, size and foreground
-               and background colors; as well as the spacing between the navigation links.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A logo containing text</strong>
-               							     
-            </p>
-            
-            <p>A Web site contains the organization's logo in the top left corner of each Web page.
+               and background colors; as well as the spacing between the navigation links.</dd>
+         <dt>A logo containing text</dt>
+         <dd>A Web site contains the organization's logo in the top left corner of each Web page.
                The logo contains logotype (text as part, or all, of the logo). The visual presentation
                of the text is essential to the identity of the logo and is included as a gif image
                which does not allow the text characteristics to be changed. The image has a text
-               alternative.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Representation of a font family</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains information about a particular font family. Substituting the font
+               alternative.</dd>
+         <dt>Representation of a font family</dt>
+         <dd>A Web page contains information about a particular font family. Substituting the font
                family with another font would defeat the purpose of the representation. The representation
                is included as a jpeg image which does not allow the text characteristics to be changed.
-               The image has a text alternative.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A representation of a letter</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains a representation of an original letter. The depiction of the letter
+               The image has a text alternative.</dd>
+         <dt>A representation of a letter</dt>
+         <dd>A Web page contains a representation of an original letter. The depiction of the letter
                in its original format is essential to information being conveyed about the time period
                in which it was written. The letter is included as a gif image which does not allow
-               the text characteristics to be changed. The image has a text alternative.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Symbolic text characters</strong>
-               							     
-            </p>
-            
-            <p>A form allows users to enter blocks of text. The form provides a number of buttons,
+               the text characteristics to be changed. The image has a text alternative.</dd>
+         <dt>Symbolic text characters</dt>
+         <dd>A form allows users to enter blocks of text. The form provides a number of buttons,
                including functions to style the text and check spelling. Some of the buttons use
                text characters that do not form a sequence that expresses something in human language.
                For example "B" to increase font weight, "I" to italicize the text and "ABC" to check
                the spelling. The symbolic text characters are included as gif images which do not
-               allow the text characteristics to be changed. The buttons have text alternatives.
-            </p>
-            
-         </li>
-         
-      </ul>
+               allow the text characteristics to be changed. The buttons have text alternatives.</dd>
+      </dl>
       
    </section>
    
@@ -215,7 +147,7 @@
          <h3>Sufficient Techniques for Images of Text (No Exception)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -245,7 +177,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/images-of-text.html
+++ b/understanding/20/images-of-text.html
@@ -77,154 +77,51 @@
    <section id="examples">
       <h2>Examples of Images of Text</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Styled Headings </strong>
-               							     
-            </p>
-            
-            <p>Rather than using bitmap images to present headings in a specific font and size, an
-               author uses CSS to achieve the same result.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Dynamically Generated Images </strong>
-               							     
-            </p>
-            
-            <p>A Web page uses server-side scripting to present text as an an image. The page includes
+      <dl>
+         <dt>Styled Headings</dt>
+         <dd>Rather than using bitmap images to present headings in a specific font and size, an
+               author uses CSS to achieve the same result.</dd>
+         <dt>Dynamically Generated Images</dt>
+         <dd>A Web page uses server-side scripting to present text as an an image. The page includes
                controls that allow the user to adjust the font size and foreground and background
-               colors of the generated image.
-            </p>
-            
-         </li>
-         
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A quote</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains a quote. The quote itself is presented as italicized text, indented
+               colors of the generated image.</dd>
+         <dt>A quote</dt>
+         <dd>A Web page contains a quote. The quote itself is presented as italicized text, indented
                from the left margin. The name of the person to whom the quote is attributed is below
                the quote with 1.5x the line space and further indented from the left margin. CSS
                is used to position the text; set the spacing between lines; as well as display the
-               text's font family, size, color and decoration.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Navigation items</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains a menu of navigation links that have both an icon and text to
+               text's font family, size, color and decoration.</dd>
+         <dt>Navigation items</dt>
+         <dd>A Web page contains a menu of navigation links that have both an icon and text to
                describe their target. CSS is used to display the text's font family, size and foreground
-               and background colors; as well as the spacing between the navigation links.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A logo containing text</strong>
-               							     
-            </p>
-            
-            <p>A Web site contains the organization's logo in the top left corner of each Web page.
+               and background colors; as well as the spacing between the navigation links.</dd>
+         <dt>A logo containing text</dt>
+         <dd>A Web site contains the organization's logo in the top left corner of each Web page.
                The logo contains logotype (text as part, or all, of the logo). The visual presentation
                of the text is essential to the identity of the logo and is included as a gif image
                which does not allow the text characteristics to be changed. The image has a text
-               alternative.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Representation of a font family</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains information about a particular font family. Substituting the font
+               alternative.</dd>
+         <dt>Representation of a font family</dt>
+         <dd>A Web page contains information about a particular font family. Substituting the font
                family with another font would defeat the purpose of the representation. The representation
                is included as a jpeg image which does not allow the text characteristics to be changed.
-               The image has a text alternative.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A representation of a letter</strong>
-               							     
-            </p>
-            
-            <p>A Web page contains a representation of an original letter. The depiction of the letter
+               The image has a text alternative.</dd>
+         <dt>A representation of a letter</dt>
+         <dd>A Web page contains a representation of an original letter. The depiction of the letter
                in its original format is essential to information being conveyed about the time period
                in which it was written. The letter is included as a gif image which does not allow
-               the text characteristics to be changed. The image has a text alternative.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Symbolic text characters</strong>
-               							     
-            </p>
-            
-            <p>A form allows users to enter blocks of text. The form provides a number of buttons,
+               the text characteristics to be changed. The image has a text alternative.</dd>
+         <dt>Symbolic text characters</dt>
+         <dd>A form allows users to enter blocks of text. The form provides a number of buttons,
                including functions to style the text and check spelling. Some of the buttons use
                text characters that do not form a sequence that expresses something in human language.
                For example "B" to increase font weight, "I" to italicize the text and "ABC" to check
                the spelling. The symbolic text characters are included as gif images which do not
-               allow the text characteristics to be changed. The buttons have text alternatives.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Customizable font settings in images of text</strong>
-               							     
-            </p>
-            
-            <p>A Web site allows users to specify font settings and all images of text on the site
-               are then provided based on those settings. 
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               allow the text characteristics to be changed. The buttons have text alternatives.</dd>
+         <dt>Customizable font settings in images of text</dt>
+         <dd>A Web site allows users to specify font settings and all images of text on the site
+               are then provided based on those settings.</dd>
+      </dl>
       
    </section>
    
@@ -270,7 +167,7 @@
          <h3>Sufficient Techniques for Images of Text</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -300,7 +197,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       
@@ -312,7 +209,7 @@
             
             <h4>CSS Techniques</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -344,7 +241,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/info-and-relationships.html
+++ b/understanding/20/info-and-relationships.html
@@ -114,100 +114,33 @@
    <section id="examples">
       <h2>Examples of Info and Relationships</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  A form with required fields
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>
-               A form contains several required fields. The labels for the required fields are displayed
+      <dl>
+         <dt>A form with required fields</dt>
+         <dd>A form contains several required fields. The labels for the required fields are displayed
                in red. In addition, at the end of each label is an asterisk character, *. The instructions
                for completing the form indicate that "all required fields are displayed in red and
-               marked with an asterisk *", followed by an example.
-               
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A form that uses color and text to indicate required fields</strong>
-               							     
-            </p>
-            
-            <p>A form contains both required and optional fields. Instructions at the top of the
+               marked with an asterisk *", followed by an example.</dd>
+         <dt>A form that uses color and text to indicate required fields</dt>
+         <dd>A form contains both required and optional fields. Instructions at the top of the
                form explain that required fields are labeled with red text and also with an icon
                whose text alternative says, "Required." Both the red text and the icon are programmatically
                associated with the appropriate form fields so that assistive technology users can
-               determine the required fields. 
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A bus schedule table where the headers for each cell can be programmatically determined</strong>
-               							     
-            </p>
-            
-            <p>A bus schedule consists of a table with the bus stops listed vertically in the first
+               determine the required fields.</dd>
+         <dt>A bus schedule table where the headers for each cell can be programmatically determined</dt>
+         <dd>A bus schedule consists of a table with the bus stops listed vertically in the first
                column and the different buses listed horizontally across the first row. Each cell
                contains the time when the bus will be at that bus stop. The bus stop and bus cells
                are identified as headers for their corresponding row or column so that assistive
                technology can programmatically determine which bus and which bus stop are associated
-               with the time in each cell.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A form where the labels for the checkboxes can be programmatically determined</strong>
-               							     
-            </p>
-            
-            <p>In a form, the labels for each checkbox can be programmatically determined by assistive
-               technology.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A text document</strong>
-               							     
-            </p>
-            
-            <p>A simple text document is formatted with double blank lines before titles, asterisks
+               with the time in each cell.</dd>
+         <dt>A form where the labels for the checkboxes can be programmatically determined</dt>
+         <dd>In a form, the labels for each checkbox can be programmatically determined by assistive
+               technology.</dd>
+         <dt>A text document</dt>
+         <dd>A simple text document is formatted with double blank lines before titles, asterisks
                to indicate list items and other standard formatting conventions so that its structure
-               can be programmatically determined.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               can be programmatically determined.</dd>
+      </dl>
       
    </section>
    
@@ -247,7 +180,7 @@
                conveyed through presentation programmatically determinable:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -464,7 +397,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -474,7 +407,7 @@
                the information and relationships conveyed through presentation programmatically determinable:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -514,7 +447,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/interruptions.html
+++ b/understanding/20/interruptions.html
@@ -46,25 +46,11 @@
    <section id="examples">
       <h2>Examples of Interruptions</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 1. Setting user preferences</strong>
-               							     
-            </p>
-            
-            <p>The preferences page of a Web portal includes an option to postpone all updates and
-               alerts until the end of the current session, except for alerts concerning emergencies.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+      <dl>
+         <dt>Example 1. Setting user preferences</dt>
+         <dd>The preferences page of a Web portal includes an option to postpone all updates and
+               alerts until the end of the current session, except for alerts concerning emergencies.</dd>
+      </dl>
       
    </section>
    
@@ -82,7 +68,7 @@
          <h3>Sufficient Techniques for Interruptions</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -104,7 +90,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/keyboard.html
+++ b/understanding/20/keyboard.html
@@ -88,95 +88,25 @@
    <section id="examples">
       <h2>Examples of Keyboard</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 1: A drawing Program.</strong>
-               							     
-            </p>
-            
-            <p>A drawing program allows users to create, size, position and rotate objects from the
-               keyboard.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 2: A drag and Drop Feature.</strong>
-               							     
-            </p>
-            
-            <p>An application that uses drag and drop also supports "cut" and "paste" or form controls
-               to move objects.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 3: Moving between and connecting discrete points.</strong>
-               							     
-            </p>
-            
-            <p>A connect-the-dots program allows the user to move between dots on a screen and use
-               the spacebar to connect the current dot to the previous one.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 4: Exception - Painting Program.</strong>
-               							     
-            </p>
-            
-            <p>A watercolor painting program passes as an exception because the brush strokes vary
-               depending on the speed and duration of the movements.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 5: Exception - Model helicopter flight training simulator.</strong>
-               							     
-            </p>
-            
-            <p>A model helicopter flight training simulator passes as an exception because the nature
-               of the simulator is to teach real-time behavior of a model helicopter.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 6: A PDA with an optional keyboard</strong>
-               							     
-            </p>
-            
-            <p>A PDA device that is usually operated via a stylus has an optional keyboard that can
+      <dl>
+         <dt>Example 1: A drawing Program</dt>
+         <dd>A drawing program allows users to create, size, position and rotate objects from the keyboard.</dd>
+         <dt>Example 2: A drag and Drop Feature</dt>
+         <dd>An application that uses drag and drop also supports "cut" and "paste" or form controls to move objects.</dd>
+         <dt>Example 3: Moving between and connecting discrete points</dt>
+         <dd>A connect-the-dots program allows the user to move between dots on a screen and use
+               the spacebar to connect the current dot to the previous one.</dd>
+         <dt>Example 4: Exception - Painting Program</dt>
+         <dd>A watercolor painting program passes as an exception because the brush strokes vary
+               depending on the speed and duration of the movements.</dd>
+         <dt>Example 5: Exception - Model helicopter flight training simulator</dt>
+         <dd>A model helicopter flight training simulator passes as an exception because the nature
+               of the simulator is to teach real-time behavior of a model helicopter.</dd>
+         <dt>Example 6: A PDA with an optional keyboard</dt>
+         <dd>A PDA device that is usually operated via a stylus has an optional keyboard that can
                be attached.  The keyboard allows full Web browsing in standard fashion.  The Web
-               content is operable because it was designed to work with keyboard-only access.
-            </p>
-            
-         </li>
-         
-      </ul>
+               content is operable because it was designed to work with keyboard-only access.</dd>
+      </dl>
       
    </section>
    
@@ -194,7 +124,7 @@
          <h3>Sufficient Techniques for Keyboard</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -267,7 +197,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -76,7 +76,6 @@
    <section id="examples">
       <h2>Examples of Labels or Instructions</h2>
       
-      
       <ul>
          
          <li>A field which requires the user to enter the two character abbreviation for a US state
@@ -126,7 +125,7 @@
          <h3>Sufficient Techniques for Labels or Instructions</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -228,7 +227,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/language-of-page.html
+++ b/understanding/20/language-of-page.html
@@ -76,26 +76,12 @@
    <section id="examples">
       <h2>Examples of Language of Page</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 1. A Web page with content in two languages</strong>
-               							     
-            </p>
-            
-            <p>A Web page produced in Germany and written in HTML includes content in both German
+      <dl>
+         <dt>Example 1. A Web page with content in two languages</dt>
+         <dd>A Web page produced in Germany and written in HTML includes content in both German
                and English, but most of the content is in German. The default human language is identified
-               as German (de) by the lang attribute on the html element.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               as German (de) by the lang attribute on the html element.</dd>
+      </dl>
       
    </section>
    
@@ -124,7 +110,7 @@
          <h3>Sufficient Techniques for Language of Page</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -144,7 +130,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/language-of-parts.html
+++ b/understanding/20/language-of-parts.html
@@ -117,7 +117,7 @@
    <section id="examples">
       <h2>Examples of Language of Parts</h2>
       
-      <ol>   
+      <ul>   
          <li>  
             <p>  								       
                <strong>A German phrase in an English sentence.</strong>							     
@@ -152,7 +152,7 @@
                the following excerpt, "<span lang="fr">À l'occasion de l'exposition "Energie éternelle. 1500 ans d'art indien", le Palais des Beaux-Arts de Bruxelles a lancé son premier podcast. Vous pouvez télécharger ce podcast au format M4A et MP3</span>", no indication of language change is required.
             </p>
          </li>
-      </ol>
+      </ul>
    </section>
    
    <section id="resources">
@@ -178,14 +178,14 @@
       <section id="sufficient">
          <h3>Sufficient Techniques for Language of Parts</h3>
       
-         <ol> 
+         <ul> 
             <li>  									         
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/html/H58" class="html">Using the lang attribute to identify changes in the human language</a>.	       
             </li>
             <li>
                <a href="https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF19" class="pdf">Specifying the language for a passage or phrase with the Lang entry in PDF documents</a>.
             </li>
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/link-purpose-in-context.html
+++ b/understanding/20/link-purpose-in-context.html
@@ -118,97 +118,29 @@
    
    <section id="examples">
       <h2>Examples of Link Purpose (In Context)</h2>
-      
-      
-      <ul>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>A link contains text that gives a description of the information at that URI</strong>
-               							     
-            </p>
-            
-            <p>
-               A page contains the sentence "There was much bloodshed during the Medieval period
-               of history." Where "Medieval period of history" is a link.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A link is preceded by a text description of the information at that URI</strong>
-               							     
-            </p>
-            
-            <p>
-               A page contains the sentence "Learn more about the Government of Ireland's Commission
-               on Electronic Voting at Go Vote!" where "Go Vote!" is a link.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Both an icon and text are included in the same link</strong>
-               							     
-            </p>
-            
-            <p>
-               An icon of a voting machine and the text "Government of Ireland's Commission of Electronic
+      <dl>
+         <dt>A link contains text that gives a description of the information at that URI</dt>
+         <dd>A page contains the sentence "There was much bloodshed during the Medieval period
+               of history." Where "Medieval period of history" is a link.</dd>
+         <dt>A link is preceded by a text description of the information at that URI</dt>
+         <dd>A page contains the sentence "Learn more about the Government of Ireland's Commission
+               on Electronic Voting at Go Vote!" where "Go Vote!" is a link.</dd>
+         <dt>Both an icon and text are included in the same link</dt>
+         <dd>An icon of a voting machine and the text "Government of Ireland's Commission of Electronic
                Voting" are combined to make a single link. The alt text for the icon is null, since
-               the purpose of the link is already described by the text of the link next to the icon.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A list of book titles</strong>
-               							     
-            </p>
-            
-            <p>
-               A list of books is available in three formats: HTML, PDF, and mp3 (a recording of
+               the purpose of the link is already described by the text of the link next to the icon.</dd>
+         <dt>A list of book titles</dt>
+         <dd>A list of books is available in three formats: HTML, PDF, and mp3 (a recording of
                a person reading the book). To avoid hearing the title of each book three times (once
                for each format), the first link for each book is the title of the book, the second
-               link says "PDF" and the third says, "mp3."
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>News article summaries</strong>
-               							     
-            </p>
-            
-            <p>
-               A Web page contains a collection of news articles. The main page lists the first few
+               link says "PDF" and the third says, "mp3."</dd>
+         <dt>News article summaries</dt>
+         <dd>A Web page contains a collection of news articles. The main page lists the first few
                sentences of each article, followed by a "Read more" link. A screen reader command
                to read the current paragraph provides the context to interpret the purpose of the
-               link.
-               
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               link.</dd>
+      </dl>
       
    </section>
    
@@ -248,7 +180,7 @@
          <h3>Sufficient Techniques for Link Purpose (In Context)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -408,7 +340,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/link-purpose-link-only.html
+++ b/understanding/20/link-purpose-link-only.html
@@ -99,41 +99,17 @@
    <section id="examples">
       <h2>Examples of Link Purpose (Link Only)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Both an icon and text are included in the same link</strong>
-               							     
-            </p>
-            
-            <p>An icon of a voting machine and the text "Government of Ireland's Commission of Electronic
-               Voting" are combined to make a single link.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A list of book titles</strong>
-               							     
-            </p>
-            
-            <p>A list of books is available in three formats: HTML, PDF, and mp3 (a recording of
+      <dl>
+         <dt>Both an icon and text are included in the same link</dt>
+         <dd>An icon of a voting machine and the text "Government of Ireland's Commission of Electronic
+               Voting" are combined to make a single link.</dd>
+         <dt>A list of book titles</dt>
+         <dd>A list of books is available in three formats: HTML, PDF, and mp3 (a recording of
                a person reading the book). The title of the book is followed by links to the different
                formats. The rendered text for each link is just the format type, but the text associated
                with each link includes the title as well as the format; for instance, "Gulliver's
-               Travels, MP3."
-            </p>
-            
-         </li>
-         
-      </ul>
+               Travels, MP3."</dd>
+      </dl>
       
    </section>
    
@@ -173,7 +149,7 @@
          <h3>Sufficient Techniques for Link Purpose (Link Only)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -269,7 +245,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/location.html
+++ b/understanding/20/location.html
@@ -39,39 +39,15 @@
    <section id="examples">
       <h2>Examples of Location</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Links to help user determine their location in a site</strong>
-               							     
-            </p>
-            
-            <p>A research group is part of an educational department at a university. The group's
-               home page links to the department home page and the university's home page.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A breadcrumb trail</strong>
-               							     
-            </p>
-            
-            <p>A portal Web site organizes topics into categories. As the user navigates through
+      <dl>
+         <dt>Links to help user determine their location in a site</dt>
+         <dd>A research group is part of an educational department at a university. The group's
+               home page links to the department home page and the university's home page.</dd>
+         <dt>A breadcrumb trail</dt>
+         <dd>A portal Web site organizes topics into categories. As the user navigates through
                categories and subcategories, a breadcrumb trail shows the current location in the
-               hierarchy of categories. Each page also contains a link to the portal home page.
-            </p>
-            
-         </li>
-         
-      </ul>
+               hierarchy of categories. Each page also contains a link to the portal home page.</dd>
+      </dl>
       
    </section>
    
@@ -99,7 +75,7 @@
          <h3>Sufficient Techniques for Location</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -138,7 +114,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/low-or-no-background-audio.html
+++ b/understanding/20/low-or-no-background-audio.html
@@ -72,7 +72,7 @@
          <h3>Sufficient Techniques for Low or No Background Audio</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -82,7 +82,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/meaningful-sequence.html
+++ b/understanding/20/meaningful-sequence.html
@@ -49,7 +49,7 @@
       
       <p>For clarity:</p>
       
-      <ol>
+      <ul>
          
          <li>Providing a particular linear order is only required where it affects meaning.</li>
          
@@ -57,7 +57,7 @@
          
          <li>Only one correct order needs to be provided.</li>
          
-      </ol>
+      </ul>
       
       
    </section>
@@ -114,7 +114,7 @@
          <h3>Sufficient Techniques for Meaningful Sequence</h3>
          
          
-         <ol>
+         <ul>
             
             <li> 
                
@@ -177,7 +177,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/media-alternative-prerecorded.html
+++ b/understanding/20/media-alternative-prerecorded.html
@@ -88,28 +88,15 @@
    <section id="examples">
       <h2>Examples of Media Alternative (Prerecorded)</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 1. alternative for time-based media for a training video</strong>
-               							     
-            </p>
-            
-            <p>A community center purchases a Training video for use by its clients and puts it on
+      <dl>
+         <dt>Example 1. alternative for time-based media for a training video</dt>
+         <dd>A community center purchases a Training video for use by its clients and puts it on
                the center's intranet. The video involves explaining use of a new technology and has
                a person talking and showing things at the same time. The community center provides
                an alternative for time-based media that all clients, including those who can neither
                see the demonstrations nor hear the explanations in the synchronized media, can use
-               to better understand what is being presented. 
-            </p>
-            
-         </li>
-         
-      </ul>
+               to better understand what is being presented.</dd>
+      </dl>
       
    </section>
    
@@ -147,7 +134,7 @@
             
             <h4>Situation A: If the content is prerecorded synchronized media:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -186,7 +173,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -194,7 +181,7 @@
             
             <h4>Situation B: If the content is prerecorded video-only:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -202,7 +189,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/multiple-ways.html
+++ b/understanding/20/multiple-ways.html
@@ -53,72 +53,26 @@
    <section id="examples">
       <h2>Examples of Multiple Ways</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A search mechanism.</strong>
-               							     
-            </p>
-            
-            <p>A large food processing company provides a site containing recipes created using its
+      <dl>
+         <dt>A search mechanism.</dt>
+         <dd>A large food processing company provides a site containing recipes created using its
                products. The site provides a search mechanism to search for recipes using a particular
                ingredient. In addition, it provides a list box that lists several categories of foods.
                A user may type "soup" in to the search engine or may select "soup" from the list
-               box to go to a page with a list of recipes made from the company's soup products
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Links between Web pages.</strong>
-               							     
-            </p>
-            
-            <p>A local hair salon has created a Web site to promote its services. The site contains
+               box to go to a page with a list of recipes made from the company's soup products.</dd>
+         <dt>Links between Web pages.</dt>
+         <dd>A local hair salon has created a Web site to promote its services. The site contains
                only five Web pages. There are links on each Web page to sequentially move forward
                or backward through the Web pages. In addition, each Web page contains a list of links
-               to reach each of the other Web pages.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Where content is a result of a process or task - Funds transfer confirmation.</strong>
-               							     
-            </p>
-            
-            <p>An on-line banking site allows fund transfer between accounts via the Web. There is
+               to reach each of the other Web pages.</dd>
+         <dt>Where content is a result of a process or task - Funds transfer confirmation.</dt>
+         <dd>An on-line banking site allows fund transfer between accounts via the Web. There is
                no other way to locate the confirmation of fund transfer until the account owner completes
-               the transfer.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Where content is a result of a process or task - Search engine results.</strong>
-               							     
-            </p>
-            
-            <p>A search engine provides the search results based on user input. There is no other
-               way to locate the search results except to perform the search process itself.
-            </p>
-            
-         </li>
-         
-      </ul>
+               the transfer.</dd>
+         <dt>Where content is a result of a process or task - Search engine results.</dt>
+         <dd>A search engine provides the search results based on user input. There is no other
+               way to locate the search results except to perform the search process itself.</dd>
+      </dl>
       
    </section>
    
@@ -136,7 +90,7 @@
          <h3>Sufficient Techniques for Multiple Ways</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -184,7 +138,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/name-role-value.html
+++ b/understanding/20/name-role-value.html
@@ -66,22 +66,10 @@
    <section id="examples">
       <h2>Examples of Name, Role, Value</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Accessible APIs </strong>
-               							     
-            </p>
-            
-            <p>A Java applet uses the accessibility API defined by the language. </p>
-            
-         </li>
-         
-      </ul>
+      <dl>
+         <dt>Accessible APIs</dt>
+         <dd>A Java applet uses the accessibility API defined by the language.</dd>
+      </dl>
       
    </section>
    
@@ -133,7 +121,7 @@
                HTML):
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -194,7 +182,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -204,7 +192,7 @@
                in a markup language:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -224,7 +212,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -232,7 +220,7 @@
             
             <h4>Situation C: If using a standard user interface component in a programming technology:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -262,7 +250,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -270,7 +258,7 @@
             
             <h4>Situation D: If creating your own user interface component in a programming language:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -307,7 +295,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/no-keyboard-trap.html
+++ b/understanding/20/no-keyboard-trap.html
@@ -43,57 +43,22 @@
    <section id="examples">
       <h2>Examples of No Keyboard Trap</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A calendar widget</strong>
-               							     
-            </p>
-            
-            <p>A calendar widget allows users to add, remove or update items in their calendar using
+      <dl>
+         <dt>A calendar widget</dt>
+         <dd>A calendar widget allows users to add, remove or update items in their calendar using
                the keyboard. The controls in the widget are part of the tab order within the Web
                page, allowing users to tab through the controls in the widget as well as to any links
-               or controls that follow.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A puzzle applet</strong>
-               							     
-            </p>
-            
-            <p>Once a user tabs into an applet, further tabs and other keystrokes are handled by
+               or controls that follow.</dd>
+         <dt>A puzzle applet</dt>
+         <dd>Once a user tabs into an applet, further tabs and other keystrokes are handled by
                the applet. Instructions describing the keystroke used to exit the applet are provided
-               prior to the applet as well as within the applet itself.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A modal dialog box</strong>
-               							     
-            </p>
-            
-            <p>A Web application brings up a dialog box. At the bottom of the dialog are two buttons,
+               prior to the applet as well as within the applet itself.</dd>
+         <dt>A modal dialog box</dt>
+         <dd>A Web application brings up a dialog box. At the bottom of the dialog are two buttons,
                Cancel and OK. When the dialog has been opened, focus is trapped within the dialog;
                tabbing from the last control in the dialog takes focus to the first control in the
-               dialog. The dialog is dismissed by activating the Cancel button or the OK button.
-            </p>
-            
-         </li>
-         
-      </ul>
+               dialog. The dialog is dismissed by activating the Cancel button or the OK button.</dd>
+      </dl>
       
    </section>
    
@@ -111,7 +76,7 @@
          <h3>Sufficient Techniques for No Keyboard Trap</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -119,7 +84,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/no-timing.html
+++ b/understanding/20/no-timing.html
@@ -56,36 +56,13 @@
    <section id="examples">
       <h2>Examples of No Timing</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A test is designed so that time to complete the test does not affect the scoring</strong>
-               							     
-            </p>
-            
-            <p>Rather than calibrating an on-line test using a time limit, the test is calibrated
-               based on scores when users have no time limits.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A game is designed so that users take turns rather than competing in real-time</strong>
-               							     
-            </p>
-            
-            <p>One party can pause the game without invalidating the competitive aspect of it.</p>
-            
-         </li>
-         
-      </ul>
+      <dl>
+         <dt>A test is designed so that time to complete the test does not affect the scoring</dt>
+         <dd>Rather than calibrating an on-line test using a time limit, the test is calibrated
+               based on scores when users have no time limits.</dd>
+         <dt>A game is designed so that users take turns rather than competing in real-time</dt>
+         <dd>One party can pause the game without invalidating the competitive aspect of it.</dd>
+      </dl>
       
    </section>
    
@@ -103,7 +80,7 @@
          <h3>Sufficient Techniques for No Timing</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -111,7 +88,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/non-text-content.html
+++ b/understanding/20/non-text-content.html
@@ -228,105 +228,34 @@
    <section id="examples">
       <h2>Examples of Non-text Content</h2>
       
-      
-      <ol>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A data chart</strong>
-               							     
-            </p>
-            
-            <p>A bar chart compares how many widgets were sold in June, July, and August. The short
+      <dl>
+         <dt>A data chart</dt>
+         <dd>A bar chart compares how many widgets were sold in June, July, and August. The short
                label says, "Figure one - Sales in June, July and August." The longer description
                identifies the type of chart, provides a high-level summary of the data, trends and
                implications comparable to those available from the chart. Where possible and practical,
-               the actual data is provided in a table. 
-               
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An audio recording of a speech</strong>
-               							     
-            </p>
-            
-            <p>The link to an audio clip says, "Chairman's speech to the assembly." A link to a text
-               transcript is provided immediately after the link to the audio clip.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An animation that illustrates how a car engine works</strong>
-               							     
-            </p>
-            
-            <p>An animation shows how a car engine works. There is no audio and the animation is
+               the actual data is provided in a table.</dd>
+         <dt>An audio recording of a speech</dt>
+         <dd>The link to an audio clip says, "Chairman's speech to the assembly." A link to a text
+               transcript is provided immediately after the link to the audio clip.</dd>
+         <dt>An animation that illustrates how a car engine works</dt>
+         <dd>An animation shows how a car engine works. There is no audio and the animation is
                part of a tutorial that describes how an engine works. Since the text of the tutorial
                already provides a full explanation, the image is an alternative for text and the
                text alternative includes only a brief description of the animation and refers to
-               the tutorial text for more information. 
-               
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A traffic Web camera</strong>
-               							     
-            </p>
-            
-            <p>A Web site allows users to select from a variety of Web cameras positioned throughout
+               the tutorial text for more information.</dd>
+         <dt>A traffic Web camera</dt>
+         <dd>A Web site allows users to select from a variety of Web cameras positioned throughout
                a major city. After a camera is selected, the image updates every two minutes. A short
                text alternative identifies the Web camera as "traffic Web camera." The site also
                provides a table of travel times for each of the routes covered by the Web cameras.
-               The table is also updated every two minutes.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A photograph of an historic event in a news story</strong>
-               							     
-            </p>
-            
-            <p>A photograph of two world leaders shaking hands accompanies a news story about an
+               The table is also updated every two minutes.</dd>
+         <dt>A photograph of an historic event in a news story</dt>
+         <dd>A photograph of two world leaders shaking hands accompanies a news story about an
                international summit meeting. The text alternative says, "President X of Country X
-               shakes hands with Prime Minister Y of country Y."
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A photograph of a historic event in content discussing diplomatic relationships</strong>
-               							     
-            </p>
-            
-            <p> The same image is used in a different context intended to explain nuances in diplomatic
+               shakes hands with Prime Minister Y of country Y."</dd>
+         <dt>A photograph of a historic event in content discussing diplomatic relationships</dt>
+         <dd>The same image is used in a different context intended to explain nuances in diplomatic
                encounters. The image of the president shaking hands with the prime minister appears
                on a Web site discussing intricate diplomatic relationships. The first text alternative
                reads, "President X of country X shakes hands with Prime Minister Y of country Y on
@@ -334,112 +263,34 @@
                are standing as well as the expressions on the leaders' faces, and identifies the
                other people in the room. The additional description might be included on the same
                page as the photograph or in a separate file associated with the image through a link
-               or other standard programmatic mechanism.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An audio recording of a press conference </strong>
-               							     
-            </p>
-            
-            <p>A Web page includes a link to an audio recording of a press conference. The link text
+               or other standard programmatic mechanism.</dd>
+         <dt>An audio recording of a press conference </dt>
+         <dd>A Web page includes a link to an audio recording of a press conference. The link text
                identifies the audio recording. The page also links to a text transcript of the press
                conference. The transcript includes a verbatim record of everything the speakers say.
                It identifies who is speaking as well as noting other significant sounds that are
                part of the recording, such as applause, laughter, questions from the audience, and
-               so on.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  An e-learning application
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>
-               An e-learning application uses sound effects to indicate whether or not the answers
+               so on.</dd>
+         <dt>An e-learning application</dt>
+         <dd>An e-learning application uses sound effects to indicate whether or not the answers
                are correct. The chime sound indicates that the answer is correct and the beep sound
                indicates that the answer is incorrect. A text description is also included so that
                people who can't hear or understand the sound understand whether the answer is correct
-               or incorrect. 
-               
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  A linked thumbnail image
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>A thumbnail image of the front page of a newspaper links to the home page of the "Smallville
-               Times". The text alternative says "Smallville Times".
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  The same image used on different sites
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>Different alternatives for an image of the world: An image of the world that is used
+               or incorrect.</dd>
+         <dt>A linked thumbnail image</dt>
+         <dd>A thumbnail image of the front page of a newspaper links to the home page of the "Smallville
+               Times". The text alternative says "Smallville Times".</dd>
+         <dt>The same image used on different sites</dt>
+         <dd>Different alternatives for an image of the world: An image of the world that is used
                on a travel site as a link to the International Travel section has the text alternative
                "International Travel". The same image is used as a link on a university Web site
-               with the text alternative "International Campuses".
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  An image map
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>An image of a building floor plan is interactive, allowing the user to select a
+               with the text alternative "International Campuses".</dd>
+         <dt>An image map</dt>
+         <dd>An image of a building floor plan is interactive, allowing the user to select a
                particular room and navigate to a page containing information about that room.
                The short text alternative describes the image and its interactive purpose:
-               "Building floor plan. Select a room for more information."
-            </p>
-            
-         </li>
-         
-      </ol>
+               "Building floor plan. Select a room for more information."</dd>
+      </dl>
       
    </section>
    
@@ -503,7 +354,7 @@
                information as the non-text content:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -517,7 +368,7 @@
                   </strong>:
                </li>
                
-            </ol>
+            </ul>
             
             <p id="text-equiv-all-situation-a-shorttext">
                
@@ -585,7 +436,7 @@
                a chart or diagram):
             </h4>
             
-            <ol>
+            <ul>
                
                <li> 
                   
@@ -606,7 +457,7 @@
                   </strong>:
                </li>
                
-            </ol>
+            </ul>
             
             <p id="text-equiv-all-situation-b-shorttext">
                
@@ -716,7 +567,7 @@
             
             <h4>Situation C: If non-text content is a control or accepts user input:</h4>
             
-            <ol>
+            <ul>
                
                <li> 
                   
@@ -728,7 +579,7 @@
                   </strong>:
                </li>
                
-            </ol>
+            </ul>
             
             <p id="text-equiv-all-situation-c-controls">
                
@@ -790,7 +641,7 @@
                primarily intended to create a specific sensory experience:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>Providing a descriptive label using one of the following 
                   <strong>
@@ -822,7 +673,7 @@
                   </strong>:
                </li>
                
-            </ol>
+            </ul>
             
             <p id="text-equiv-all-situation-d-shorttext">
                
@@ -887,7 +738,7 @@
             
             <h4>Situation E: If non-text content is a CAPTCHA:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -901,7 +752,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -909,7 +760,7 @@
             
             <h4>Situation F: If the non-text content should be ignored by assistive technology:</h4>
             
-            <ol>
+            <ul>
                
                <li>Implementing or marking the non-text content so that it will be ignored by assistive
                   technology using one of the following 
@@ -920,7 +771,7 @@
                   </strong>:
                </li>
                
-            </ol>
+            </ul>
             
             <p id="text-equiv-all-situation-f-notrequired">
                

--- a/understanding/20/on-focus.html
+++ b/understanding/20/on-focus.html
@@ -63,48 +63,19 @@
    <section id="examples">
       <h2>Examples of On Focus</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Example 1:  A dropdown menu</strong>
-               							     
-            </p>
-            
-            <p>A dropdown menu on a page allows users to choose between jump destinations. If the
+      <dl>
+         <dt>Example 1: A dropdown menu</dt>
+         <dd>A dropdown menu on a page allows users to choose between jump destinations. If the
                person uses the keyboard to move down to a choice and activates it (with a spacebar
                or enter key) it will jump to a new page.  However, if the person moves down to a
                choice and either hits the escape or the tab key to move out of the pulldown menu
-               – it does not jump to a new screen as the focus shifts out of the dropdown menu. 
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  Example of a Failure:  A help dialog
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>
-               When a field receives focus, a help dialog window describing the field and providing
+               – it does not jump to a new screen as the focus shifts out of the dropdown menu.</dd>
+         <dt>Example of a Failure: A help dialog</dt>
+         <dd>When a field receives focus, a help dialog window describing the field and providing
                options opens. As a keyboard user tabs through the Web page, the dialog opens, moving
                the keyboard focus away from the control every time the user attempts to tab past
-               the field.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               the field.</dd>
+      </dl>
       
    </section>
    
@@ -122,7 +93,7 @@
          <h3>Sufficient Techniques for On Focus</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -130,7 +101,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/on-input.html
+++ b/understanding/20/on-input.html
@@ -132,7 +132,7 @@
          <h3>Sufficient Techniques for On Input</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -177,7 +177,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/page-titled.html
+++ b/understanding/20/page-titled.html
@@ -77,73 +77,30 @@
    <section id="examples">
       <h2>Examples of Page Titled</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An HTML Web page</strong>
-               							     
-            </p>
-            
-            <p>The descriptive title of an HTML Web page is marked up with the &lt;title&gt; element so
-               that it will be displayed in the title bar of the user agent.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A document collection.</strong>
-               							     
-            </p>
-            
-            <p>The title of 
-               <a href="https://www.w3.org/WAI/WCAG21/Understanding/">Understanding WCAG 2.1 </a> is "Understanding WCAG 2.1."
-            </p>
-            
+      <dl>
+         <dt>An HTML Web page</dt>
+         <dd>The descriptive title of an HTML Web page is marked up with the &lt;title&gt; element so
+               that it will be displayed in the title bar of the user agent.</dd>
+         <dt>A document collection.</dt>
+         <dd>
+            <p>The title of <a href="https://www.w3.org/WAI/WCAG21/Understanding/">Understanding WCAG 2.1 </a>
+               is "Understanding WCAG 2.1."</p>
             <ul>
-               
                <li>The introduction page has the title "Introduction to Understanding WCAG 2.0."</li>
-               
                <li>Major sections of the document are pages titled "Understanding Guideline X" and "Understanding
                   Success Criterion X." 
                </li>
-               
                <li>Appendix A has the title "Glossary."</li>
-               
                <li>Appendix B has the title "Acknowledgements."</li>
-               
                <li>Appendix C has the title "References."</li>
-               
             </ul>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A Web application.</strong>
-               							     
-            </p>
-            
-            <p>
-               A banking application lets a user inspect his bank accounts, view past statements,
+         </dd>
+         <dt>A Web application.</dt>
+         <dd>A banking application lets a user inspect his bank accounts, view past statements,
                and perform transactions. The Web application dynamically generates titles for each
                Web page, e.g., "Bank XYZ, accounts for John Smith" "Bank XYZ, December 2005 statement
-               for Account 1234-5678". 
-               
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               for Account 1234-5678".</dd>
+      </dl>
       
    </section>
    
@@ -180,7 +137,7 @@
          <h3>Sufficient Techniques for Page Titled</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -210,7 +167,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/parsing.html
+++ b/understanding/20/parsing.html
@@ -109,7 +109,7 @@
          <h3>Sufficient Techniques for Parsing</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -161,7 +161,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/pause-stop-hide.html
+++ b/understanding/20/pause-stop-hide.html
@@ -54,7 +54,7 @@
          point in the presentation where the user left off.
       </p>
       
-      <ol>
+      <ul>
          
          <li>
             
@@ -91,7 +91,7 @@
             
          </li>
          
-      </ol>
+      </ul>
       
       <p>For a mechanism to be considered "a mechanism for the user to pause," it must provide
          the user with a means to pause that does not tie up the user or the focus so that
@@ -153,131 +153,39 @@
    <section id="examples">
       <h2>Examples of Pause, Stop, Hide</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An essential animation can be paused without affecting the activity</strong>
-               							     
-            </p>
-            
-            <p>A Web site helps users understand 'how things work' through animations that demonstrate
-               processes. Animations have "pause" and "restart" buttons.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A stock ticker</strong>
-               							     
-            </p>
-            
-            <p>
-               A stock ticker has "pause" and "restart" buttons. Pausing the ticker causes it to
+      <dl>
+         <dt>An essential animation can be paused without affecting the activity</dt>
+         <dd>A Web site helps users understand 'how things work' through animations that demonstrate
+               processes. Animations have "pause" and "restart" buttons.</dd>
+         <dt>A stock ticker</dt>
+         <dd>A stock ticker has "pause" and "restart" buttons. Pausing the ticker causes it to
                pause on the currently displayed stock. Restarting causes the ticker to resume from
                the stopped point but with a notice that the display is delayed. Since the intent
                of the stock ticker is usually to provide realtime information, there might also be
-               a button that would advance the ticker to the most recently traded stock. 
-               
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A game is designed so that users take turns rather than competing in real-time</strong>
-               							     
-            </p>
-            
-            <p>One party can pause the game without invalidating the competitive aspect of it.</p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A Web advertisement</strong>
-               							     
-            </p>
-            
-            <p>An advertisement blinks to get viewers attention but stops after 5 seconds</p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A form prompt</strong>
-               							     
-            </p>
-            
-            <p>A form blinks an arrow near the submit button if a user finishes filling out the form
-               but does not activate the submit button. The blinking stops after 5 seconds.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>An animation</strong>
-               							     
-            </p>
-            
-            <p>An animation runs in the upper portion of the page but has a "freeze animation" button
-               near the bottom of the animation. 
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A "loading" animation</strong>
-               							     
-            </p>
-            
-            <p>A preloader animation is shown on a page which requires a certain percentage of a
+               a button that would advance the ticker to the most recently traded stock.</dd>
+         <dt>A game is designed so that users take turns rather than competing in real-time</dt>
+         <dd>One party can pause the game without invalidating the competitive aspect of it.</dd>
+         <dt>A Web advertisement</dt>
+         <dd>An advertisement blinks to get viewers attention but stops after 5 seconds</dd>
+         <dt>A form prompt</dt>
+         <dd>A form blinks an arrow near the submit button if a user finishes filling out the form
+               but does not activate the submit button. The blinking stops after 5 seconds.</dd>
+         <dt>An animation</dt>
+         <dd>An animation runs in the upper portion of the page but has a "freeze animation" button
+               near the bottom of the animation.</dd>
+         <dt>A "loading" animation</dt>
+         <dd>A preloader animation is shown on a page which requires a certain percentage of a
                large file to be downloaded before playback can begin. The animation is the only content
                on the page and instructs the user to please wait while the video loads. Because the
                moving content is not presented in parallel with other content, no mechanism to pause,
                stop or hide it needs to be provided, even though the animation may run for more than
-               5 seconds for users with slower connections.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A full-page advertisement</strong>
-               							     
-            </p>
-            
-            <p>A site requires that all users view a 15 second advertisement before they can access
+               5 seconds for users with slower connections.</dd>
+         <dt>A full-page advertisement</dt>
+         <dd>A site requires that all users view a 15 second advertisement before they can access
                free content available from their site. Because viewing the advertisement is a requirement
                for all users and because it is not presented in parallel with other content, no mechanism
-               to pause, stop or hide it needs to be provided.
-            </p>
-            
-         </li>
-         
-      </ul>
+               to pause, stop or hide it needs to be provided.</dd>
+      </dl>
       
    </section>
    
@@ -295,7 +203,7 @@
          <h3>Sufficient Techniques for Pause, Stop, Hide</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -349,7 +257,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/pronunciation.html
+++ b/understanding/20/pronunciation.html
@@ -63,98 +63,34 @@
    <section id="examples">
       <h2>Examples of Pronunciation</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Giving the reading of a person's name.</strong>
-               							     
-            </p>
-            
-            <p>Web content in Japanese provides kana (Japanese phonetic syllabary characters) written
+      <dl>
+         <dt>Giving the reading of a person's name.</dt>
+         <dd>Web content in Japanese provides kana (Japanese phonetic syllabary characters) written
                next to Han characters (Kanji)  show the pronunciation of a person's name. The kana
                is provided to users in parentheses right after the word. Giving the reading of the
                words written in Han characters (Kanji) allows both sighted users and screen readers
                to read/pronounce the words correctly. Note that screen readers will speak the word
                twice: the Han characters (Kanji) that can be pronounced in a wrong way are read first
-               and then kana is spoken in order to provide the correct reading.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Showing the reading of the words by ruby element.</strong>
-               							     
-            </p>
-            
-            <p>Web content using XHTML 1.1 provides kana (phonetic syllabary characters) written
+               and then kana is spoken in order to provide the correct reading.</dd>
+         <dt>Showing the reading of the words by ruby element.</dt>
+         <dd>Web content using XHTML 1.1 provides kana (phonetic syllabary characters) written
                above the characters to show the reading (pronunciation) of the words by using the
-               ruby element.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Providing sound files of the pronunciation.</strong>
-               							     
-            </p>
-            
-            <p>A document includes some words whose meaning cannot be determined without knowing
+               ruby element.</dd>
+         <dt>Providing sound files of the pronunciation.</dt>
+         <dd>A document includes some words whose meaning cannot be determined without knowing
                the correct pronunciation. Each word is linked to a sound file that gives the correct
-               pronunciation. Users can select these links to find out how to pronounce the words.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Including pronunciation information in the glossary.</strong>
-               							     
-            </p>
-            
-            <p>
-               A Web page includes a glossary section. Some items in the glossary include pronunciation
+               pronunciation. Users can select these links to find out how to pronounce the words.</dd>
+         <dt>Including pronunciation information in the glossary.</dt>
+         <dd>A Web page includes a glossary section. Some items in the glossary include pronunciation
                information as well as definitions. Words in the content whose meaning cannot be determined
-               without knowing their pronunciation are linked to the appropriate entries in the glossary.
-               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Text that includes pronunciation information for characters shared by several languages
-                  but pronounced differently in each language
-               </strong>
-               							     
-            </p>
-            
-            <p>A Japanese university Web site includes several short phrases quoted from scholarly
+               without knowing their pronunciation are linked to the appropriate entries in the glossary.</dd>
+         <dt>Text that includes pronunciation information for characters shared by several languages
+                  but pronounced differently in each language</dt>
+         <dd>A Japanese university Web site includes several short phrases quoted from scholarly
                texts in Chinese and Korean. The quotations are written using the same script as the
                Japanese text. Pronunciation information is provided to show the correct reading of
-               the Chinese and Korean characters.
-               
-            </p>
-            
-         </li>
-         
-      </ul>
+               the Chinese and Korean characters.</dd>
+      </dl>
       
       <div class="note">
          
@@ -180,7 +116,7 @@
          <h3>Sufficient Techniques for Pronunciation</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -213,7 +149,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/re-authenticating.html
+++ b/understanding/20/re-authenticating.html
@@ -59,67 +59,30 @@
    <section id="examples">
       <h2>Examples of Re-authenticating</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A shopping site checkout</strong>
-               							     
-            </p>
-            
-            <p>A user with extremely limited use of the hands is logged into a shopping site. It
+      <dl>
+         <dt>A shopping site checkout</dt>
+         <dd>A user with extremely limited use of the hands is logged into a shopping site. It
                takes so long to enter credit card information into the application that a time limit
                occurs while the user is performing the checkout process. When the user returns to
                the checkout process and submits the form, the site returns a login screen to re-authenticate.
                After the user logs in, the check out process is restored with the same information
                and at the same stage. The user did not lose any data because the server had temporarily
                accepted and stored the submission even though the session had timed out and restored
-               the user to the same state after re-authentication was completed.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Authentication in an email program</strong>
-               							     
-            </p>
-            
-            <p>An email program has an authentication time-out after 30 minutes. The program prompts
+               the user to the same state after re-authentication was completed.</dd>
+         <dt>Authentication in an email program</dt>
+         <dd>An email program has an authentication time-out after 30 minutes. The program prompts
                the user several minutes before the time-out occurs and provides a link to open a
                new window in order to re-authenticate. The original window with the in-progress email
-               remains intact and, after re-authentication, the user may send that data.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A questionnaire with a time limit
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>A long questionnaire provided within a single Web page has information at the beginning
+               remains intact and, after re-authentication, the user may send that data.</dd>
+         <dt>A questionnaire with a time limit</dt>
+         <dd>A long questionnaire provided within a single Web page has information at the beginning
                that indicates that the session will time out after 15 minutes. The user is also informed
                that the questionnaire can be saved at any point and completed at a later time. Within
                the Web page there are several buttons provided to save the partially completed form.
                In addition, with JavaScript in the list of accessibility-supported content technologies
                that are relied upon, the user can elect to be alerted via a pop-up if the session
-               is close to timing out. 
-            </p>
-            
-         </li>
-         
-      </ul>
+               is close to timing out.</dd>
+      </dl>
       
    </section>
    
@@ -137,7 +100,7 @@
          <h3>Sufficient Techniques for Re-authenticating</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                
@@ -163,7 +126,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/reading-level.html
+++ b/understanding/20/reading-level.html
@@ -106,31 +106,22 @@
          Readability formulas are available for at least some languages when running the spell
          checkers in popular software if you specify in the options of this engine that you
          want to have the statistics when it has finished checking your documents.
-         
-         
       </p>
       
-      Levels of education
+      <h3>Levels of education</h3>
       
+      <dl>
+         <dt>Primary education</dt>
+         <dd>First 6 years of school</dd>
+         <dt>Lower secondary education</dt>
+         <dd>7-9 years of school</dd>
+         <dt>Upper secondary education</dt>
+         <dd>10-12 years of school</dd>
+         <dt>Advanced education</dt>
+         <dd>More than 12 years of school</dd>
+      </dl>
       
-      Primary education 
-      Lower secondary education 
-      Upper secondary education 
-      Advanced education 
-      
-      
-      First 6 years of school
-      7-9 years of school
-      10-12 years of school
-      More than 12 years of school
-      
-      
-      
-      
-      <p>Adapted from International Standard Classification of Education
-         [[UNESCO]] 
-         
-      </p>
+      <p>Adapted from <a href="https://uis.unesco.org/en/topic/international-standard-classification-education-isced">International Standard Classification of Education (UNESCO)</a>.</p>
       
       <div class="note">
          
@@ -169,56 +160,30 @@
    <section id="examples">
       <h2>Examples of Reading Level</h2>
       
-      
-      <ol>
+      <ul>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>A scientific journal including readable summaries of complex research articles</strong>
-               							     
-            </p>
-            
-            <p>A scientific journal includes articles written in highly technical language aimed
+         <dt>A scientific journal including readable summaries of complex research articles</dt>
+<dd>A scientific journal includes articles written in highly technical language aimed
                at specialists in the field.  The journal's Table of Contents page includes a plain-language
                summary of each article. The summaries are intended for a general audience with eight
                years of school. The metadata for the journal uses the Dublin Core specification to
                identify the education level of the articles' intended audience as "advanced," and
                the education level of the intended audience for the summaries as "lower secondary
                education."
-            </p>
-            
-         </li>
+            </dd>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>Medical information for members of the public.</strong>
-               							     
-            </p>
-            
-            <p>A medical school operates a Web site that explains recent medical and scientific discoveries.
+         <dt>Medical information for members of the public.</dt>
+<dd>A medical school operates a Web site that explains recent medical and scientific discoveries.
                The articles on the site are written for people without medical training. Each article
                uses the Dublin Core metadata specification to identify the education level of the
                intended audience as "lower secondary education" and includes the Flesch Reading Ease
                score for the article. A link on each page displays the education level and other
                metadata. No supplemental content is required because people who read at the lower
                secondary education level can read the articles.
-            </p>
-            
-         </li>
+            </dd>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>An e-learning application. </strong>
-               							     
-            </p>
-            
-            <p>An on-line course about Spanish cultural history includes a unit on Moorish architecture.
+         <dt>An e-learning application. </dt>
+<dd>An on-line course about Spanish cultural history includes a unit on Moorish architecture.
                The unit includes text written for students with different reading abilities. Photographs
                and drawings of buildings illustrate architectural concepts and styles. Graphic organizers
                are used to illustrate complex relationships, and an audio version using synthetic
@@ -226,21 +191,12 @@
                the content and includes a readability score based on formulas developed for Spanish-language
                text. The learning application uses this metadata and metadata about the students
                to provide versions of instructional content that match the needs of individual students.
-            </p>
-            
-         </li>
+            </dd>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>Science information that requires a reading ability at the lower secondary education
+         <dt>Science information that requires a reading ability at the lower secondary education
                   level.
-               </strong>
-               							     
-            </p>
-            
-            <p>The text below (116 words total) requires a reading ability of grade 4.2 in the United
+               </dt>
+<dd>The text below (116 words total) requires a reading ability of grade 4.2 in the United
                States according to the Flesch-Kincaid formula. In the US, grade 4.2 is at the primary
                education level.
             </p>
@@ -268,11 +224,9 @@
             <p>
                (Source: Howard Hughes Medical Institute "CoolScience for Kids" Project)
                
-            </p>
-            
-         </li>
+            </dd>
          
-      </ol>
+      </ul>
       
    </section>
    
@@ -353,7 +307,7 @@
          <h3>Sufficient Techniques for Reading Level</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -391,7 +345,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
          <div class="note">
             

--- a/understanding/20/reading-level.html
+++ b/understanding/20/reading-level.html
@@ -160,73 +160,49 @@
    <section id="examples">
       <h2>Examples of Reading Level</h2>
       
-      <ul>
-         
+      <dl>
          <dt>A scientific journal including readable summaries of complex research articles</dt>
-<dd>A scientific journal includes articles written in highly technical language aimed
+         <dd>A scientific journal includes articles written in highly technical language aimed
                at specialists in the field.  The journal's Table of Contents page includes a plain-language
                summary of each article. The summaries are intended for a general audience with eight
                years of school. The metadata for the journal uses the Dublin Core specification to
                identify the education level of the articles' intended audience as "advanced," and
                the education level of the intended audience for the summaries as "lower secondary
-               education."
-            </dd>
-         
-         <dt>Medical information for members of the public.</dt>
-<dd>A medical school operates a Web site that explains recent medical and scientific discoveries.
+               education."</dd>
+         <dt>Medical information for members of the public</dt>
+         <dd>A medical school operates a Web site that explains recent medical and scientific discoveries.
                The articles on the site are written for people without medical training. Each article
                uses the Dublin Core metadata specification to identify the education level of the
                intended audience as "lower secondary education" and includes the Flesch Reading Ease
                score for the article. A link on each page displays the education level and other
                metadata. No supplemental content is required because people who read at the lower
-               secondary education level can read the articles.
-            </dd>
-         
-         <dt>An e-learning application. </dt>
-<dd>An on-line course about Spanish cultural history includes a unit on Moorish architecture.
+               secondary education level can read the articles.</dd>
+         <dt>An e-learning application</dt>
+         <dd>An on-line course about Spanish cultural history includes a unit on Moorish architecture.
                The unit includes text written for students with different reading abilities. Photographs
                and drawings of buildings illustrate architectural concepts and styles. Graphic organizers
                are used to illustrate complex relationships, and an audio version using synthetic
                speech is available. The metadata for each version describes the academic level of
                the content and includes a readability score based on formulas developed for Spanish-language
                text. The learning application uses this metadata and metadata about the students
-               to provide versions of instructional content that match the needs of individual students.
-            </dd>
-         
-         <dt>Science information that requires a reading ability at the lower secondary education
-                  level.
-               </dt>
-<dd>The text below (116 words total) requires a reading ability of grade 4.2 in the United
+               to provide versions of instructional content that match the needs of individual students.</dd>
+         <dt>Science information that requires a reading ability at the lower secondary education level</dt>
+         <dd>
+            <p>The text below (116 words total) requires a reading ability of grade 4.2 in the United
                States according to the Flesch-Kincaid formula. In the US, grade 4.2 is at the primary
-               education level.
-            </p>
-            
+               education level.</p>
             <p>Science is about testing — and about looking closely. Some scientists use microscopes
-               to take a close look. We're going to use a simple piece of paper.
-            </p>
-            
+               to take a close look. We're going to use a simple piece of paper.</p>
             <p>Here's what you do: Print this page and cut out the square to make a "window" one
-               inch square. (It's easiest to fold the page in half before you cut.)
-            </p>
-            
+               inch square. (It's easiest to fold the page in half before you cut.)</p>
             <p>Choose something interesting: a tree trunk, a leaf, flower, the soil surface, or a
-               slice of soil from a shovel.
-            </p>
-            
-            <p>Put your window over the thing and look at it closely. Take your time — this is not
-               a race.
-            </p>
-            
+               slice of soil from a shovel.</p>
+            <p>Put your window over the thing and look at it closely. Take your time — this is not a race.</p>
             <p>To help you see more details, draw a picture of what's inside your square.</p>
-            
             <p>Now let's think about what you've found. </p>
-            
-            <p>
-               (Source: Howard Hughes Medical Institute "CoolScience for Kids" Project)
-               
-            </dd>
-         
-      </ul>
+            <p>(Source: Howard Hughes Medical Institute "CoolScience for Kids" Project)</p>
+         </dd>
+      </dl>
       
    </section>
    

--- a/understanding/20/resize-text.html
+++ b/understanding/20/resize-text.html
@@ -188,7 +188,7 @@
          <h3>Sufficient Techniques for Resize Text</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -282,7 +282,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/section-headings.html
+++ b/understanding/20/section-headings.html
@@ -109,7 +109,7 @@
          <h3>Sufficient Techniques for Section Headings</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -123,7 +123,7 @@
                		
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/sensory-characteristics.html
+++ b/understanding/20/sensory-characteristics.html
@@ -66,55 +66,24 @@
    <section id="examples">
       <h2>Examples of Sensory Characteristics</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  Example 1: Instructions for interpreting a schedule of competitive events references
-                  colored icons in different shapes to indicate the venue for each event
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>
-                  A table presents a list of times across the top row and a list of events in the first
-                  vertical column and instructions are provided under the table: "Events marked with a
-                  blue diamond are played on field A and events marked with a green circle are played
-                  on field B." The instructions rely on color and shape only and result in a failure of
-                  this criterion.
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>
-                  Example 2: An online multi-page survey 
-                  
-               </strong>
-               							     
-            </p>
-            
-            <p>
-               An online multi-page survey uses a link implemented as a green arrow icon placed
+      <dl>
+         <dt>Example 1: Instructions for interpreting a schedule of competitive events references
+               colored icons in different shapes to indicate the venue for each event</dt>
+         <dd>A table presents a list of times across the top row and a list of events in the first
+               vertical column and instructions are provided under the table: "Events marked with a
+               blue diamond are played on field A and events marked with a green circle are played
+               on field B." The instructions rely on color and shape only and result in a failure of
+               this criterion.</dd>
+         <dt>Example 2: An online multi-page survey</dt>
+         <dd>An online multi-page survey uses a link implemented as a green arrow icon placed
                in the lower right hand corner of the content to move from one survey page to the
                next. The arrow is clearly labeled with "Next" and the instructions state, "To move
                to the next section of the survey, select the green arrow icon labeled 'Next' in the
                lower right corner below the last survey question." 
                The instruction uses positioning and color to help identify the icon; 
-               the instruction does not rely on these sensory characteristics since it also refers to the label, so it passes this criterion.
-            </p>
-            
-         </li>
-         
-      </ul>
+               the instruction does not rely on these sensory characteristics since it also refers to
+               the label, so it passes this criterion.</dd>
+      </dl>
       
    </section>
    
@@ -132,7 +101,7 @@
          <h3>Sufficient Techniques for Sensory Characteristics</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -142,7 +111,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/sign-language-prerecorded.html
+++ b/understanding/20/sign-language-prerecorded.html
@@ -136,7 +136,7 @@
          <h3>Sufficient Techniques for Sign Language (Prerecorded)</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -177,7 +177,7 @@
                
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/three-flashes-or-below-threshold.html
+++ b/understanding/20/three-flashes-or-below-threshold.html
@@ -192,7 +192,7 @@
          <h3>Sufficient Techniques for Three Flashes or Below Threshold</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -216,7 +216,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/three-flashes.html
+++ b/understanding/20/three-flashes.html
@@ -129,7 +129,7 @@
          <h3>Sufficient Techniques for Three Flashes</h3>
          
          
-         <ol>
+         <ul>
             
             <li>
                									         
@@ -139,7 +139,7 @@
                								       
             </li>
             
-         </ol>
+         </ul>
          
       </section>
       

--- a/understanding/20/timing-adjustable.html
+++ b/understanding/20/timing-adjustable.html
@@ -209,7 +209,7 @@
             
             <h4>Situation A: If there are session time limits:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -226,7 +226,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -234,7 +234,7 @@
             
             <h4>Situation B: If a time limit is controlled by a script on the page:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -262,7 +262,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -270,7 +270,7 @@
             
             <h4>Situation C: If there are time limits on reading:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -298,7 +298,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/understanding-metadata.html
+++ b/understanding/20/understanding-metadata.html
@@ -24,7 +24,7 @@
    			
    <p>In conjunction with WCAG, metadata can play a number of roles including: </p>
    			
-   <ol>
+   <ul>
       				
       <li> Metadata can be used to associate conforming alternate  versions of Web pages with
          Web pages which do not conform, in order to  allow users to find the conforming alternate
@@ -45,7 +45,7 @@
          which one would best meet the user's needs. 
       </li>
       			
-   </ol>
+   </ul>
    			
    <section>
       				

--- a/understanding/20/unusual-words.html
+++ b/understanding/20/unusual-words.html
@@ -57,26 +57,19 @@
       
       
       <dl>
-    <dt>Text that includes a definition for a word used in an unusual way</dt>
-<dd>Organize the list or "cascade" of dictionaries and other resources so that the definition
+         <dt>Text that includes a definition for a word used in an unusual way</dt>
+         <dd>Organize the list or "cascade" of dictionaries and other resources so that the definition
                search will find the intended definitions instead of displaying definitions from other
                sources in the "cascade." (The "cascade" lists the dictionaries and other reference
                materials in the order most likely to bring up the right definition. This controls
-               the order to follow when searching for definitions.)
-            </dd>
-         
+               the order to follow when searching for definitions.)</dd>
          <dt>Including definitions in the glossary</dt>
-<dd>WCAG 2.0 uses the word "text" in a specific way. Thus, when the word "text" is used
+         <dd>WCAG 2.0 uses the word "text" in a specific way. Thus, when the word "text" is used
                within WCAG 2.0 it is linked to the definition of "text" provided in a glossary within
-               the same Web page.
-            </dd>
-         
+               the same Web page.</dd>
          <dt>The specific definition of a word is provided at the bottom of the page</dt>
-<dd>The internal link from the word to the corresponding definition is also provided within
-               the page.
-               
-            </dd>
-</dl>
+         <dd>The internal link from the word to the corresponding definition is also provided within the page.</dd>
+      </dl>
       
    </section>
    

--- a/understanding/20/unusual-words.html
+++ b/understanding/20/unusual-words.html
@@ -56,56 +56,27 @@
       <h2>Examples of Unusual Words</h2>
       
       
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>Text that includes a definition for a word used in an unusual way.</strong>
-               							     
-            </p>
-            
-            <p>Organize the list or "cascade" of dictionaries and other resources so that the definition
+      <dl>
+    <dt>Text that includes a definition for a word used in an unusual way.</dt>
+<dd>Organize the list or "cascade" of dictionaries and other resources so that the definition
                search will find the intended definitions instead of displaying definitions from other
                sources in the "cascade." (The "cascade" lists the dictionaries and other reference
                materials in the order most likely to bring up the right definition. This controls
                the order to follow when searching for definitions.)
-            </p>
-            
-         </li>
+            </dd>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>Including definitions in the glossary.</strong>
-               							     
-            </p>
-            
-            <p>WCAG 2.0 uses the word "text" in a specific way. Thus, when the word "text" is used
+         <dt>Including definitions in the glossary.</dt>
+<dd>WCAG 2.0 uses the word "text" in a specific way. Thus, when the word "text" is used
                within WCAG 2.0 it is linked to the definition of "text" provided in a glossary within
                the same Web page.
-            </p>
-            
-         </li>
+            </dd>
          
-         <li>
-            
-            <p>
-               								       
-               <strong>The specific definition of a word is provided at the bottom of the page.</strong>
-               							     
-            </p>
-            
-            <p>The internal link from the word to the corresponding definition is also provided within
+         <dt>The specific definition of a word is provided at the bottom of the page.</dt>
+<dd>The internal link from the word to the corresponding definition is also provided within
                the page.
                
-            </p>
-            
-         </li>
-         
-      </ul>
+            </dd>
+</dl>
       
    </section>
    
@@ -157,7 +128,7 @@
             
             <h4>Situation A: If the word or phrase has a unique meaning within the Web page:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -263,7 +234,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -271,7 +242,7 @@
             
             <h4>Situation B: If the word or phrase means different things within the same Web page:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -328,7 +299,7 @@
                   
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/use-of-color.html
+++ b/understanding/20/use-of-color.html
@@ -85,7 +85,7 @@
       <div class="note">
 
          <p>Most user agents provide users with a color-only cue that a link has been previously activated by them ("visited"). However, several technical constraints result in authors having very limited control over these color-only indications of visited links.  The technical constraints are as follows:
-            <ol>
+            <ul>
                <li> 
                   User agents constrain the exposure of a link's visited state due to <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector">privacy concerns</a>. Author queries to user agents will indicate all links have not been visited.
                </li>
@@ -99,7 +99,7 @@
                   Authors also cannot set the visited state of links. The anchor element does not include a "visited" attribute; therefore the author has no ability to alter the state through an attribute setting. As such, authors cannot achieve <a href="info-and-relationships">1.3.1 Info and Relationships</a> or
                   <a href="name-role-value">4.1.2 Name, Role, Value</a> in regard to visited links.
                </li>            
-            </ol>
+            </ul>
          </p>
 
          <p>For these reasons, setting or conveying a link's visited status is not an author responsibility. Where color alone distinguishes between visited and unvisited links, it does not result in a failure of this Success Criterion, even where the contrast between the two link colors is below 3:1. Note that authors must continue to ensure that all text links meet contrast minimums against the page background (SC 1.4.3).</p>
@@ -135,44 +135,20 @@
    <section id="examples">
       <h2>Examples of Use of Color</h2>
       
-      
-      <ul>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong>A form that uses color and text to indicate required fields</strong>
-               							     
-            </p>
-            
-            <p>A form contains both required and optional fields. Instructions at the top of the
+      <dl>
+         <dt>A form that uses color and text to indicate required fields</dt>
+         <dd>A form contains both required and optional fields. Instructions at the top of the
                form explain that required fields are labeled with red text and also with an icon.
                Users who cannot perceive the difference between the optional field labels and the
                red labels for the required fields will still be able to see the icon next to the
-               red labels.               
-            </p>
-            
-         </li>
-         
-         <li>
-            
-            <p>
-               								       
-               <strong> An examination.</strong>
-               							     
-            </p>
-            
-            <p>Students view an SVG image of a chemical compound and identify the chemical elements
+               red labels.</dd>
+         <dt> An examination.</dt>
+         <dd>Students view an SVG image of a chemical compound and identify the chemical elements
                present based <strong>both</strong> on the colors used, as well as numbers next to each
                element. A legend shows the color and number for each type of element. Sighted users who
                cannot perceive all the color differences can still understand the image by relying on
-               the numbers.
-            </p>
-            
-         </li>
-         
-      </ul>
+               the numbers.</dd>
+      </dl>
       
    </section>
    
@@ -242,7 +218,7 @@
                to indicate information:
             </h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -272,7 +248,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
@@ -280,7 +256,7 @@
             
             <h4>Situation B: If color is used within an image to convey information:</h4>
             
-            <ol>
+            <ul>
                
                <li>
                   										           
@@ -294,7 +270,7 @@
                   									         
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/20/visual-presentation.html
+++ b/understanding/20/visual-presentation.html
@@ -288,7 +288,7 @@
          <section>
             
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C23" class="css">Specifying text and background colors of secondary content such as banners, features
@@ -317,14 +317,14 @@
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G175" class="general">Providing a multi color selection tool on the page for foreground and background colors</a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
          <section>
             
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G204" class="general">Not interfering with the user agent's reflow of text as the viewing window is narrowed</a> OR
@@ -334,14 +334,14 @@
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C20" class="css">Using ems to set the column width</a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
          <section>
             
             
-            <ol>
+            <ul>
                
                <li>
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C19" class="css">Specifying alignment either to the left OR right in CSS</a> OR
@@ -355,14 +355,14 @@
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G169" class="general">Aligning text on only one side</a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
          <section>
             
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -373,14 +373,14 @@
                   <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C21" class="css">C21: Specifying line spacing in CSS</a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          
          <section>
             
             
-            <ol>
+            <ul>
                
                <li>
                   
@@ -428,7 +428,7 @@
                   </a>
                </li>
                
-            </ol>
+            </ul>
             
          </section>
          

--- a/understanding/21/identify-input-purpose.html
+++ b/understanding/21/identify-input-purpose.html
@@ -42,11 +42,15 @@
   
 <section id="examples">
 <h2>Examples of Success Criterion 1.3.5</h2>
-<ul>
-  <li><strong>A contact form using autofill</strong><br />A contact form auto-fills in the fields for name, street, post code, city, telephone number and email address from autofill values stored in the user's browser. Assistive technology can offer a customized way of identifying particular input fields, for example drawing on a set of symbols / icons that is familiar to the user, to communicate the purpose of the fields visually.</li>
-  <li><strong>An order form with separate billing and shipping address</strong><br />A product order form fills in the address fields for billing address and a separate set of address fields for the shipping address, using the autofill detail tokens 'billing' and 'shipping'</li>
-  <li><strong>A contact form using icons</strong><br />A browser plugin to add icons inserts icons representing the person's name, home address, telephone number and email address to  identify the input purpose visually.</li>
-</ul>
+
+<dl>
+  <dt>A contact form using autofill</dt>
+  <dd>A contact form auto-fills in the fields for name, street, post code, city, telephone number and email address from autofill values stored in the user's browser. Assistive technology can offer a customized way of identifying particular input fields, for example drawing on a set of symbols / icons that is familiar to the user, to communicate the purpose of the fields visually.</dd>
+  <dt>An order form with separate billing and shipping address</dt>
+  <dd>A product order form fills in the address fields for billing address and a separate set of address fields for the shipping address, using the autofill detail tokens 'billing' and 'shipping'</dd>
+  <dt>A contact form using icons</dt>
+  <dd>A browser plugin to add icons inserts icons representing the person's name, home address, telephone number and email address to  identify the input purpose visually.</dd>
+</dl>
 </section>
     
 <section id="resources">

--- a/understanding/21/motion-actuation.html
+++ b/understanding/21/motion-actuation.html
@@ -44,10 +44,9 @@
 			<ul>
 				<li>A user can choose an application setting which turns off Shake to Undo and other motion-activated features.</li>
 				<li>After text is input in a field, shaking a device shows a dialog offering users to undo the input. A cancel button next to the text field offers the same functionality.</li>
-  <li>A user can tilt a device to advance to the next or a previous page. Buttons are also provided to perform the same function.</li>
-  <li>A user can move or pan a device to change the view in an interactive photo. A control is also available to perform these same functions.</li>
- <li>A user can gesture towards the device to navigate content. Controls are also available to navigate.</li>
-
+				<li>A user can tilt a device to advance to the next or a previous page. Buttons are also provided to perform the same function.</li>
+				<li>A user can move or pan a device to change the view in an interactive photo. A control is also available to perform these same functions.</li>
+				<li>A user can gesture towards the device to navigate content. Controls are also available to navigate.</li>
 			</ul>
 		</section>
 	

--- a/understanding/21/status-messages.html
+++ b/understanding/21/status-messages.html
@@ -23,10 +23,10 @@
 			<p>The intent of this Success Criterion is to make users aware of important changes in content that are not given focus, and to do so in a way that doesn't unnecessarily interrupt their work.</p>
 			<p>The intended beneficiaries are blind and low vision users of assistive technologies with screen reader capabilities. An additional benefit is that assistive technologies for users with cognitive disabilities may achieve an alternative means of indicating (or even delaying or supressing) status messages, as preferred by the user.</p>
 <p>The scope of this Success Criterion is specific to changes in content that involve status messages. A <a>status message</a> is a defined term in WCAG. There are two main criteria that determine whether something meets the definition of a status message:</p>
-	<ol>
+	<ul>
 		<li> the message <q>provides information to the user on the success or results of an action, on the waiting state of an application, on the progress of a process, or on the existence of errors;</q></li>
 		<li> the message is not delivered via a change in context.</li>
-	</ol>
+	</ul>
 <p>Information can be added to pages which does not meet the definition of a status message. For example, the list of results obtained from a search are not considered a status update and thus are not covered by this Success Criterion. However, brief text messages displayed <em>about</em> the completion or status of the search, such as "Searching...", "18 results returned" or "No results returned" would be status updates if they do not take focus. Examples of status messages are given in the section titled <a href="#status-examples">Status Message Examples</a> below.</p>
 
 <p>This Success Criterion specifically addresses scenarios where new content is added to the page without changing the user's context. <a>Changes of context</a>, by their nature, interrupt the user by taking focus. They are already surfaced by assistive technologies, and so have already met the goal to alert the user to new content. As such, messages that involve changes of context do not need to be considered and are not within the scope of this Success Criterion. Examples of scenarios that add new content by changing the context are given in the section titled <a href="#excepted-examples">Examples of Changes That Are Not Status Messages</a> below.</p>
@@ -44,16 +44,17 @@
 			
 			<section class="example" id="status-examples">
 				<h3>Status Message Examples</h3>
-			<ol>
-				<li>After a user presses a Search button, the page content is updated to include the results of the search, which are displayed in a section below the Search button. The change to content also includes the message "5 results returned" near the top of this new content. This text is given an appropriate role for a status message. A screen reader announces, "Five results returned".</li>
-				<li>After a user presses an Add to Shopping Cart button, a section of content near the Shopping Cart icon adds the text "5 items". A screen reader announces "Five items" or "Shopping cart, five items".</li>
-				<li>After a user enters incorrect text in an input called Postal Code, a message appears above the input reading "Invalid entry".  The screen reader announces, "Invalid entry" or "Postal code, invalid entry".</li>
-				<li>After a user activates a process, an icon symbolizing 'busy'  appears on the screen. The screen reader announces "application busy". </li>
-				<li>An application displays a progressbar to indicate the status of an upgrade. The element is assigned a suitable role. The screen reader provides intermittent announcements of the progress. </li>
-		        <li>After a user submits a form, text is added to the existing form which reads, "Your form was successfully submitted." The screen reader announces the same message.</li> 
-		        <li>After a user unsuccessfully fills in a form because some of the data is in the incorrect format, text is added to the existing form which reads "5 errors on page". The screen reader announces the same message.</li>
-		        <li>After a user puts a photo in an album in an online photo app, a <a href="https://material.io/design/components/snackbars.html#">snackbar </a> displays the message "Saved in 'Wedding' album", which is also read by a screen reader.</li>
-			</ol>
+
+				<ul>
+					<li>After a user presses a Search button, the page content is updated to include the results of the search, which are displayed in a section below the Search button. The change to content also includes the message "5 results returned" near the top of this new content. This text is given an appropriate role for a status message. A screen reader announces, "Five results returned".</li>
+					<li>After a user presses an Add to Shopping Cart button, a section of content near the Shopping Cart icon adds the text "5 items". A screen reader announces "Five items" or "Shopping cart, five items".</li>
+					<li>After a user enters incorrect text in an input called Postal Code, a message appears above the input reading "Invalid entry".  The screen reader announces, "Invalid entry" or "Postal code, invalid entry".</li>
+					<li>After a user activates a process, an icon symbolizing 'busy'  appears on the screen. The screen reader announces "application busy". </li>
+					<li>An application displays a progressbar to indicate the status of an upgrade. The element is assigned a suitable role. The screen reader provides intermittent announcements of the progress. </li>
+					<li>After a user submits a form, text is added to the existing form which reads, "Your form was successfully submitted." The screen reader announces the same message.</li> 
+					<li>After a user unsuccessfully fills in a form because some of the data is in the incorrect format, text is added to the existing form which reads "5 errors on page". The screen reader announces the same message.</li>
+					<li>After a user puts a photo in an album in an online photo app, a <a href="https://material.io/design/components/snackbars.html#">snackbar </a> displays the message "Saved in 'Wedding' album", which is also read by a screen reader.</li>
+				</ul>
 			</section>
 			<section class="example">
 				<h3>Examples of Status Messages that Do Not Add New Text to the Screen</h3>

--- a/understanding/22/accessible-authentication-enhanced.html
+++ b/understanding/22/accessible-authentication-enhanced.html
@@ -78,6 +78,7 @@
    <section id="examples">
       <h2>Examples of Accessible Authentication (Enhanced)</h2>
       <p>The examples of this Success Criterion are the same as the <a href="accessible-authentication.html#examples">Accessible Authentication</a> examples.</p>
+      
       <ul>
         <li>A web site uses a properly marked up username (or email) and password fields as the login authentication (meeting <a href="identify-input-purpose">Success Criterion 1.3.5 Input Purpose</a> and <a href="name-role-value">Success Criterion 4.1.2: Name, Role, Value</a>). The user's browser or integrated third-party password manager extension can identify the purpose of the inputs and automatically fill in the username and password.</li>
         <li>A web site does not block paste functionality. The user is able to use a third-party password manager to store credentials, copy them, and paste them directly into a login form.</li>

--- a/understanding/22/dragging-movements.html
+++ b/understanding/22/dragging-movements.html
@@ -97,12 +97,12 @@
       <h2>Examples of Dragging Movements with alternatives</h2>
 
       <ul>
-        <li>A map allows users to drag the view of the map around, and the map has up/down/left/right buttons to move the view as well.</li>
-        <li>A sortable list of elements may, after tapping or clicking on a list element, provide adjacent controls for moving the element up or down in the list by simply tapping or clicking on those controls.</li>
-        <li>A taskboard that allows users to drag and drop items between columns also provides an additional pop-up menu after tapping or clicking on items for moving the selected element to another column by tapping or clicking on pop-up menu entries.</li>
-        <li>A radial control widget (color wheel) where the value can be set by dragging the marker for the currently selected color to another position, also allows picking another color value by tapping or clicking on another place in the color wheel.</li>
-        <li> A linear slider control widget, where the value can be set by dragging the visual indicator (thumb) showing the current value, allows tapping or clicking on any point of the slider track to change the value and set the thumb to that position. </li>  
-        <li>A widget where you can drag a gift to one person in a photo of a group of people also has a menu alternative where users can select the person that should receive the gift from the menu.</li>
+         <li>A map allows users to drag the view of the map around, and the map has up/down/left/right buttons to move the view as well.</li>
+         <li>A sortable list of elements may, after tapping or clicking on a list element, provide adjacent controls for moving the element up or down in the list by simply tapping or clicking on those controls.</li>
+         <li>A taskboard that allows users to drag and drop items between columns also provides an additional pop-up menu after tapping or clicking on items for moving the selected element to another column by tapping or clicking on pop-up menu entries.</li>
+         <li>A radial control widget (color wheel) where the value can be set by dragging the marker for the currently selected color to another position, also allows picking another color value by tapping or clicking on another place in the color wheel.</li>
+         <li>A linear slider control widget, where the value can be set by dragging the visual indicator (thumb) showing the current value, allows tapping or clicking on any point of the slider track to change the value and set the thumb to that position. </li>  
+         <li>A widget where you can drag a gift to one person in a photo of a group of people also has a menu alternative where users can select the person that should receive the gift from the menu.</li>
       </ul>
       
    </section>

--- a/understanding/22/focus-not-obscured-enhanced.html
+++ b/understanding/22/focus-not-obscured-enhanced.html
@@ -45,6 +45,7 @@
 </section>
 <section id="examples">
   <h2>Examples of Focus Not Obscured (Enhanced)</h2>
+  
   <ul>
     <li>A page has a sticky footer (attached to the bottom of the viewport). When tabbing down the page the focused item is not at all hidden by the footer because content in the viewport scrolls up to always display the item with keyboard focus using <a href="https://www.w3.org/TR/css-scroll-snap/#propdef-scroll-padding" rel="nofollow">scroll padding</a>.</li>
     <li>A page has a large (30% wide) cookie approval dialog. The dialog is modal, preventing access to the other controls in the page until it has been dismissed. Focus is not obscured because the cookie approval dialog (including the focus indicator) remains on screen until selections are made and submitted.</li>


### PR DESCRIPTION
* seems back in the WCAG 2.0 days, definition lists weren't used. This retrospectively fixes it
* `<ol>` used instead of `<ul>` when no order is intended/necessary
* fix the completely broken listing of education levels for Reading Level understanding