### PR TITLE
Update identify-input-purpose.html

### DIFF
--- a/guidelines/sc/21/identify-input-purpose.html
+++ b/guidelines/sc/21/identify-input-purpose.html
@@ -7,7 +7,7 @@
 	<p>The purpose of each input field collecting information about the user can be <a>programmatically determined</a> when:</p>
   
   <ul>
-    <li>The input field serves a purpose identified in the <a href="#input-purposes">Input Purposes for user interface components section</a>; and</li>
+    <li>The input field serves a purpose identified in the <a href="https://www.w3.org/TR/WCAG21/#input-purposes">Input Purposes for user interface components section</a>; and</li>
     <li>The content is implemented using technologies with support for identifying the expected meaning for form input data.</li>
   </ul>
   


### PR DESCRIPTION
Replaced relative link with FQDN link https://www.w3.org/TR/WCAG21/#input-purposes since the existing one is triggering nothing when it appears at the top of the Understanding document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3310.html" title="Last updated on Jul 28, 2023, 2:16 PM UTC (388cad8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3310/66c5fec...388cad8.html" title="Last updated on Jul 28, 2023, 2:16 PM UTC (388cad8)">Diff</a>