### PR TITLE
3.2.6 Consistent Help Understanding: clarify "change initiated by the user"

### DIFF
--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -70,7 +70,7 @@
          <section id="limitations">
             <h3>Limitations and Exceptions</h3>
 
-            <p>It is not the intent of this Success Criterion to require authors to provide help / access to help. The Criterion only requires that <em>when</em> one of the listed forms of help is available across multiple pages that it be in a consistent location. It does not require authors to provide help information on PDFs or other static documents that may be available for viewing/download from the Web pages. PDFs and other static documents are not considered part of the "set of web pages" from which they are downloaded.</p>
+            <p>It is not the intent of this Success Criterion to require authors to provide help or access to help. The Criterion only requires that <em>when</em> one of the listed forms of help is available across multiple pages that it be in a consistent location. It does not require authors to provide help information on PDFs or other static documents that may be available for viewing/download from the Web pages. PDFs and other static documents are not considered part of the "<a>set of web pages</a>" from which they are downloaded.</p>
 
             <p>It is also not the intent of this Success Criterion to require a human be available at all times. Ideally, if the human contact is not available during certain hours or certain days then information would be provided so the user can tell when it will be available. </p>
 

--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -62,16 +62,26 @@
 
          <p>If the help item is visually in a different location, but in the same serial order, that is not helpful from a user's point of view, but it would not fail this criterion.</p>
 
-         <p>The location in a smaller viewport may be different than in a larger viewport, but it is best if the mechanism or link is consistent across a set of web pages. A consistent location, both visually and programmatically, is the most usable.</p>
-
          <p>When having problems completing a task on a Web site (or part of a Web site, what we call a <a>set of Web pages</a>), people with some types of disabilities may not be able to work through the issue without further help.  Issues could include difficulty:
          completing a form, or finding a document or page which provides information required to complete a task.</p>
 
          <p>Without help, some users may abandon the task. They may also fail to correctly complete a task, or they may require assistance from people who do not necessarily keep private information secure.</p>
 
-         <p>It is not the intent of this Success Criterion to require authors to provide help / access to help. The Criterion only requires that <em>when</em> one of the listed forms of help is available across multiple pages that it be in a consistent location. It does not require authors to provide help information on PDFs or other static documents that may be available for viewing/download from the Web pages. PDFs and other static documents are not considered part of the "set of web pages" from which they are downloaded.</p>
+         <section id="limitations">
+            <h3>Limitations and Exceptions</h3>
 
-         <p>It is also not the intent of this Success Criterion to require a human be available at all times. Ideally, if the human contact is not available during certain hours or certain days then information would be provided so the user can tell when it will be available. </p>
+            <p>It is not the intent of this Success Criterion to require authors to provide help / access to help. The Criterion only requires that <em>when</em> one of the listed forms of help is available across multiple pages that it be in a consistent location. It does not require authors to provide help information on PDFs or other static documents that may be available for viewing/download from the Web pages. PDFs and other static documents are not considered part of the "set of web pages" from which they are downloaded.</p>
+
+            <p>It is also not the intent of this Success Criterion to require a human be available at all times. Ideally, if the human contact is not available during certain hours or certain days then information would be provided so the user can tell when it will be available. </p>
+
+            <p>This Success Criterion only requires help mechanisms to be consistent <em>within</em> a particular <a>set of web pages</a>. Some complex Web sites consist of multiple different sets of web pages with different purposes. For example, a web-based spreadsheet application might have one set of pages for editing spreadsheets and a separate set of pages for marketing the application. This Success Criterion would allow the different sets of web pages to use different help mechanism locations. However, it is best if help mechanisms are located as consistently as possible even among different related sets of web pages.</p>
+
+            <p>This Success Criterion contains an exception when "a change is initiated by the user." This exception is intended to cover cases where a user performs an action with the intent of changing the display or layout of a page, such as changing the zoom level, orientation, or viewport size. Help mechanism locations may change in response to such a user-initiated change; as the criterion's second note clarifies, "this criterion is concerned with relative order across pages displayed in the same page variation (e.g., same zoom level and orientation)."</p>
+
+            <p>This exception allows the location in a smaller viewport to be different than in a larger viewport. However, it is best if the mechanism or link is consistent across a set of web pages. A consistent location, both visually and programmatically, is the most usable.</p>
+            
+            <p>This exception is <em>not</em> intended to treat every action that a user might initiate as a "change"; to qualify for the exception, the user must be initiating an action that would reasonably be expected to change the relative order of components within a page. For example, merely navigating between pages within a set of web pages is not a "change initiated by the user" for the purposes of this exception. Similarly, logging into or out of a page would not typically qualify, unless logging in would present the user with a distinct <a>set of web pages</a>.</p>
+         </section>
 
          <section id="help-mechansisms">
             <h3>Help Mechanisms</h3>

--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -83,7 +83,7 @@
             <p>This exception is <em>not</em> intended to treat every action that a user might initiate as a "change"; to qualify for the exception, the user must be initiating an action that would reasonably be expected to change the relative order of components within a page. For example, merely navigating between pages within a set of web pages is not a "change initiated by the user" for the purposes of this exception. Similarly, logging into or out of a page would not typically qualify, unless logging in would present the user with a distinct <a>set of web pages</a>.</p>
          </section>
 
-         <section id="help-mechansisms">
+         <section id="help-mechanisms">
             <h3>Help Mechanisms</h3>
 
             <p>Typical help mechanisms include:</p>


### PR DESCRIPTION
[Rendered version](https://raw.githack.com/dbjorge/wcag/3226-consistent-help-set-of-web-pages/understanding/22/consistent-help.html#limitations) (see mostly-new "Limitations and Exceptions" section)

This PR is intended to address #3226 by adding some additional clarification and examples based on WCAG 2 backlog meeting discussion + these two comments [[1]](https://github.com/w3c/wcag/issues/3226#issuecomment-1572066047) [[2]](https://github.com/w3c/wcag/issues/3226#issuecomment-1594897338).

Summary of the new explanations:

* Different "sets of web pages" *are* allowed to have different help mechanism locations (but it's best to be as consistent as possible)
* The SC text excepting cases where "a change is initiated by a user" is intended to cover cases where a user performs an action with the intent of changing the display or layout of a page, such as changing the zoom level, orientation, or viewport size
* That exception is *not* intended to treat treat every action that a user might take as a "user-initiated change" - specifically, navigating between pages within a set of web pages doesn't count, and neither does logging into a page (unless doing so would present the user with a new set of web pages)

The main "intent" section was getting pretty long with these additions, so I created a new "Limitations and Exceptions" subsection. I moved a few other existing paragraphs that felt relevant to the new section.