### PR TITLE
Update mention of "list" to "list item" in programmatically-determine…

### DIFF
--- a/guidelines/terms/20/programmatically-determined-link-context.html
+++ b/guidelines/terms/20/programmatically-determined-link-context.html
@@ -5,8 +5,8 @@
    </p>
    
    <aside class="example"><p>In HTML, information that is programmatically determinable from a link in English
-      includes text that is in the same paragraph, list, or table cell as the link or in
-      a table header cell that is associated with the table cell that contains the link.
+      includes text that is in the same <a href="https://html.spec.whatwg.org/multipage/dom.html#paragraph">paragraph</a>, 
+      list item, or table cell as the link or in a table header cell that is associated with the table cell that contains the link.
    </p></aside>
    
    <p class="note">Since screen readers interpret punctuation, they can also provide the context from


### PR DESCRIPTION
closes #3361

updates the term example to mention "list item" instead of "list" to be more accurate to what the intent of that likely was trying to convey.

Additionally, links to the HTML term of 'paragraph', which I would submit could resolve issues such as #2109


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3362.html" title="Last updated on Aug 25, 2023, 7:14 PM UTC (44450fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3362/6b2b211...44450fb.html" title="Last updated on Aug 25, 2023, 7:14 PM UTC (44450fb)">Diff</a>