### PR TITLE
Increase space around Understanding/QuickRef links to meet 2.5.8 Target Size

### DIFF
--- a/guidelines/guidelines.css
+++ b/guidelines/guidelines.css
@@ -34,6 +34,11 @@ dd.new, dd.proposed, dd.changed {
 	display: block;
 	width: 25%;
 	hyphens: none;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: .5em;
+  margin-left: 2em;
 }
 .sc dt {
 	display: list-item;


### PR DESCRIPTION
fixes #3399

This PR adds whitespace around and between the links

<img width="250" alt="understanding and quickref links in a box with 1px border, around and in between is about 1em of space" src="https://github.com/w3c/wcag/assets/178782/afbb70d7-db4d-44cf-abba-3e59a41ec12d">

