### PR TITLE
Adding informative link - HTML

### DIFF
--- a/biblio.js
+++ b/biblio.js
@@ -30,12 +30,6 @@ respecConfig.localBiblio = {
         "title": "Ergonomics of human-system interaction -- Part 112: Principles for the presentation of information",
         "publisher": "International Standards Organization"
     },
-
-	"HTML-Living": {
-        "uri": "https://html.spec.whatwg.org/multipage/",
-        "title": "HTML Living Standard",
-        "publisher": "The Web Hypertext Application Technology Working Group (WHATWG)"
-    },
       	
       	"UNESCO": {
       		"date": "1997",

--- a/biblio.js
+++ b/biblio.js
@@ -30,6 +30,12 @@ respecConfig.localBiblio = {
         "title": "Ergonomics of human-system interaction -- Part 112: Principles for the presentation of information",
         "publisher": "International Standards Organization"
     },
+
+	"HTML-Living": {
+        "uri": "https://html.spec.whatwg.org/multipage/",
+        "title": "HTML Living Standard",
+        "publisher": "The Web Hypertext Application Technology Working Group (WHATWG)"
+    },
       	
       	"UNESCO": {
       		"date": "1997",

--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -13,7 +13,7 @@
    <p class="note">This Success Criterion should be considered as always satisfied for any content using HTML or XML.</p>
 
    <div class="note">
-      <p>Since this criterion was written, the HTML Standard has adopted specific requirements governing how user agents must handle incomplete tags, incorrect element nesting, duplicate attributes, and non-unique IDs.</p>
+      <p>Since this criterion was written, the HTML Living Standard has adopted specific requirements governing how user agents must handle incomplete tags, incorrect element nesting, duplicate attributes, and non-unique IDs. [[HTML-Living]]</p>
       
       <p>Although the HTML Standard treats some of these cases as non-conforming for authors, it is considered to "allow these features" for the purposes of this Success Criterion because the specification requires that user agents support handling these cases consistently. In practice, this criterion no longer provides any benefit to people with disabilities in itself.</p>
       


### PR DESCRIPTION
This is going into the 2.1 branch, not main (there will be a separate PR for that).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3404.html" title="Last updated on Sep 19, 2023, 12:50 PM UTC (3b601db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3404/a05d653...3b601db.html" title="Last updated on Sep 19, 2023, 12:50 PM UTC (3b601db)">Diff</a>