### PR TITLE
Enabling the JS highlighting

### DIFF
--- a/script/highlight.min.js
+++ b/script/highlight.min.js
@@ -494,3 +494,10 @@
     illegal:null,className:null,contains:null,skip:!0
     }),n.inherit(n.QUOTE_STRING_MODE,{illegal:null,className:null,contains:null,
     skip:!0})]}]})})());
+
+    document.addEventListener('DOMContentLoaded', (event) => {
+			document.querySelectorAll('pre').forEach((el) => {
+			hljs.highlightElement(el);
+			});
+			});
+			var translationStrings = {}; /* fix WAI JS */

--- a/xslt/base.xslt
+++ b/xslt/base.xslt
@@ -394,14 +394,6 @@
 	<xsl:template name="waiscript">
 		<link rel="stylesheet" href="../a11y-light.css" />
 		<script src="../highlight.min.js" />
-		<script>
-			document.addEventListener('DOMContentLoaded', (event) => {
-			document.querySelectorAll('pre').forEach((el) => {
-			hljs.highlightElement(el);
-			});
-			});
-			var translationStrings = {}; /* fix WAI JS */
-		</script>
 		<script src="https://www.w3.org/WAI/assets/scripts/main.js"></script>
     <!-- Matomo -->
     <script>


### PR DESCRIPTION
Moving the JS activation into the script, rather than the XSL template.