### PR TITLE
notes in text-spacing

### DIFF
--- a/guidelines/sc/21/text-spacing.html
+++ b/guidelines/sc/21/text-spacing.html
@@ -15,10 +15,8 @@
  
  <p>Exception: Human languages and scripts that do not make use of one or more of these text style properties in written text can conform using only the properties that exist for that combination of language and script.</p>
 
- <p class="note">It is not required that content use the values specified. The requirement is to ensure no loss of content or functionality when a user overrides the authored styles with the values.</p>
+ <p class="note">Content is not required to use these text spacing values. The requirement is to ensure that <strong>when a user overrides</strong> the authored text spacing, content or functionality is not lost.</p>
 
-<p class="note">Some human languages or writing systems have different needs and may adjust other values (such as paragraph start indent) in order to improve legibility. This success criterion might not be sufficient for those needs.</p>
-
-<p class="note">It is beneficial for users if authors use any locally available guidance for improving readability in the local language or writing system. If the user chooses to go beyond the metrics specified, any resulting loss of content or functionality is the user's responsibility.</p>
+ <p class="note">Some language writing systems do not use all of the text spacing settings in this success criterion. Some use different types of spacing to improve readability and legibility, such as paragraph start indent.</p>
  
 </section>

--- a/guidelines/sc/21/text-spacing.html
+++ b/guidelines/sc/21/text-spacing.html
@@ -17,6 +17,6 @@
 
  <p class="note">Content is not required to use these text spacing values. The requirement is to ensure that when a user overrides the authored text spacing, content or functionality is not lost.</p>
 
- <p class="note">Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system.</p>
+ <p class="note">Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow locally available guidance for improving readability and legibility of text in their writing system.</p>
  
 </section>

--- a/guidelines/sc/21/text-spacing.html
+++ b/guidelines/sc/21/text-spacing.html
@@ -15,7 +15,7 @@
  
  <p>Exception: Human languages and scripts that do not make use of one or more of these text style properties in written text can conform using only the properties that exist for that combination of language and script.</p>
 
- <p class="note">Content is not required to use these text spacing values. The requirement is to ensure that <strong>when a user overrides</strong> the authored text spacing, content or functionality is not lost.</p>
+ <p class="note">Content is not required to use these text spacing values. The requirement is to ensure that when a user overrides the authored text spacing, content or functionality is not lost.</p>
 
  <p class="note">Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system.</p>
  

--- a/guidelines/sc/21/text-spacing.html
+++ b/guidelines/sc/21/text-spacing.html
@@ -17,6 +17,6 @@
 
  <p class="note">Content is not required to use these text spacing values. The requirement is to ensure that <strong>when a user overrides</strong> the authored text spacing, content or functionality is not lost.</p>
 
- <p class="note">Some language writing systems do not use all of the text spacing settings in this success criterion. Some use different types of spacing to improve readability and legibility, such as paragraph start indent.</p>
+ <p class="note">Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system.</p>
  
 </section>


### PR DESCRIPTION
First note: More direct language focused on the common misunderstanding.

The rest trying to be succinct covering minimum needed in /TR and rest in Understanding.

Rationale: The goal is in the TR/WCAG wording to clearly and succinctly:
- clarify that you don’t have to do this in your content
- fyi, there are other things in other languages/scripts/writing systems

Can everything else can go in the Understanding docs, and needn't complicate TR/WCAG? Do we need to say these in the TR doc?
* might not be sufficient for all languages
* use any locally available guidance for improving readability in the local language or writing system
If the user chooses to go beyond the metrics specified, any resulting loss of content or functionality is the user's responsibility

If we need to cover those in these notes, I would like to suggest similar copy edits for clarity.

@alastc @aphillips @iadawn


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3437.html" title="Last updated on Oct 3, 2023, 8:52 AM UTC (b2ae658)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3437/723e202...b2ae658.html" title="Last updated on Oct 3, 2023, 8:52 AM UTC (b2ae658)">Diff</a>