### PR TITLE
notes for i18n issues in visual-presentation

### DIFF
--- a/guidelines/sc/20/visual-presentation.html
+++ b/guidelines/sc/20/visual-presentation.html
@@ -16,6 +16,6 @@
 
 <p class="note">Content is not required to use these values. The requirement is that a mechanism is available for users to change these presentation aspects. The mechanism can be provided by the browser or other user agent. Content is not required to provide the mechanism.</p>
 
-<p class="note">Writing systems for some languages use different presentation aspects to improve readability and legibility, such as paragraph start indent. If a presentation aspect in this success criterion is not used in a writing system (for example, it does not use paragraph spacing), content in that writing system can conform without it.</p>
+<p class="note">Writing systems for some languages use different presentation aspects to improve readability and legibility. If a presentation aspect in this success criterion is not used in a writing system to improve accessibility, content in that writing system does not need to use that presentation setting and can conform without it. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system.</p>
   
 </section>

--- a/guidelines/sc/20/visual-presentation.html
+++ b/guidelines/sc/20/visual-presentation.html
@@ -16,6 +16,6 @@
 
 <p class="note">Content is not required to use these values. The requirement is that a mechanism is available for users to change these presentation aspects. The mechanism can be provided by the browser or other user agent. Content is not required to provide the mechanism.</p>
 
-<p class="note">Some language writing systems use different presentation aspects to improve readability and legibility, such as paragraph start indent. Some do not use all of the presentation aspects in this success criterion. If a presentation aspect is not used in a writing system (for example, it does not use paragraph spacing), content in that writing system can conform without it.</p>
+<p class="note">Writing systems for some languages use different presentation aspects to improve readability and legibility, such as paragraph start indent. If a presentation aspect in this success criterion is not used in a writing system (for example, it does not use paragraph spacing), content in that writing system can conform without it.</p>
   
 </section>

--- a/guidelines/sc/20/visual-presentation.html
+++ b/guidelines/sc/20/visual-presentation.html
@@ -14,6 +14,8 @@
      <li>Text can be resized without assistive technology up to 200 percent in a way that does not require the user to scroll horizontally to read a line of text <a>on a full-screen window</a>.</li>   
   </ul>
 
-<p class="note">The 'mechanism' for achieving the presentation can be provided by the user-agent, which can manipulate the content on behalf of the user. It is not a requirement for the author to provide the mechanism. Some writing systems have additional or different requirements, or do not customarily use features such as paragraph spacing. When a specific feature is inapplicable to a writing system, this criterion does not require a mechanism to achieve that feature for content authored in that writing system.</p>
+<p class="note">Content is not required to use these values. The requirement is that a mechanism is available for users to change these presentation aspects. The mechanism can be provided by the browser or other user agent. Content is not required to provide the mechanism.</p>
+
+<p class="note">Some language writing systems use different presentation aspects to improve readability and legibility, such as paragraph start indent. Some do not use all of the presentation aspects in this success criterion. If a presentation aspect is not used in a writing system (for example, it does not use paragraph spacing), content in that writing system can conform without it.</p>
   
 </section>

--- a/guidelines/sc/20/visual-presentation.html
+++ b/guidelines/sc/20/visual-presentation.html
@@ -16,6 +16,6 @@
 
 <p class="note">Content is not required to use these values. The requirement is that a mechanism is available for users to change these presentation aspects. The mechanism can be provided by the browser or other user agent. Content is not required to provide the mechanism.</p>
 
-<p class="note">Writing systems for some languages use different presentation aspects to improve readability and legibility. If a presentation aspect in this success criterion is not used in a writing system to improve accessibility, content in that writing system does not need to use that presentation setting and can conform without it. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system.</p>
+<p class="note">Writing systems for some languages use different presentation aspects to improve readability and legibility. If a presentation aspect in this success criterion is not used in a writing system, content in that writing system does not need to use that presentation setting and can conform without it. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system.</p>
   
 </section>


### PR DESCRIPTION
I think these should be two separate notes.

The first is a needed clarification for all languages.

Open issue related to "language writing systems" is in [Terminology, WCAG 2 wording for 1.4.8 and 1.4.12 i18n (google doc)](https://docs.google.com/document/d/1BoPr_AXLoSTAvcm6OOGVm-2FmbIKC7rKTifhnxucQ6Q/edit#heading=h.44dg3kfvfw5g)

@aphillips @alastc @iadawn


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3439.html" title="Last updated on Oct 3, 2023, 8:52 AM UTC (4f0c7c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3439/723e202...4f0c7c4.html" title="Last updated on Oct 3, 2023, 8:52 AM UTC (4f0c7c4)">Diff</a>