### PR TITLE
Add paragraph about non-transcribed CAPTCHA audio

### DIFF
--- a/understanding/22/accessible-authentication-minimum.html
+++ b/understanding/22/accessible-authentication-minimum.html
@@ -72,7 +72,7 @@
             
             <p>Remembering a site-specific password is a <a>cognitive function test</a>. Such tests are known to be problematic for many people with cognitive disabilities. Whether it is remembering random strings of characters, or a pattern gesture to perform on a touch screen, cognitive function tests will exclude some people. When a cognitive function test is used, at least one other authentication method must be available which is not a cognitive function test.</p>
 
-            <p>Some <abbr title="Completely Automated Public Turing test to tell Computers and Humans Apart">CAPTCHA</abbr> systems have an audio alternative of the visible text that the user needs to transcribe. Unless the audio has been been transcribed, it can't be used as an alternative method.</p>            
+            <p>Some <abbr title="Completely Automated Public Turing test to tell Computers and Humans Apart">CAPTCHA</abbr> systems have an audio alternative of the visible text. If the user needs to transcribe this audio, it cannot be used to meet the Alternative exception.</p>            
 
             <p>If there is more than one step in the authentication process, such as with multi-factor authentication, all steps need to comply with this Success Criterion to pass. There needs to be a path through authentication that does not rely on cognitive function tests.</p>
 

--- a/understanding/22/accessible-authentication-minimum.html
+++ b/understanding/22/accessible-authentication-minimum.html
@@ -72,6 +72,7 @@
             
             <p>Remembering a site-specific password is a <a>cognitive function test</a>. Such tests are known to be problematic for many people with cognitive disabilities. Whether it is remembering random strings of characters, or a pattern gesture to perform on a touch screen, cognitive function tests will exclude some people. When a cognitive function test is used, at least one other authentication method must be available which is not a cognitive function test.</p>
 
+            <p>Some <abbr title="Completely Automated Public Turing test to tell Computers and Humans Apart">CAPTCHA</abbr> systems have an audio alternative of the visible text that the user needs to transcribe. Unless the audio has been been transcribed, it can't be used as an alternative method.</p>            
 
             <p>If there is more than one step in the authentication process, such as with multi-factor authentication, all steps need to comply with this Success Criterion to pass. There needs to be a path through authentication that does not rely on cognitive function tests.</p>
 


### PR DESCRIPTION
Closes #3198

Note: Issue #323, from 2018, does bring up the issue of what generated on the fly audio is (live? prerecorded?) and it wasn’t resolved. It’s not clear to me whether this fits under 1.2.1 (pre-recorded audio only) or 1.2.9 (audio-only live), but I’m not sure it matters as both require an alternative.