### PR TITLE
Update G78.html - remove broken links

### DIFF
--- a/techniques/general/G78.html
+++ b/techniques/general/G78.html
@@ -36,19 +36,10 @@
       
          <ul>
             <li>
-                  <a href="https://www.w3.org/TR/REC-smil/">Synchronized Multimedia Integration Language (SMIL) 1.0</a>
-                </li>
-            <li>
-                  <a href="https://www.w3.org/TR/SMIL/">Synchronized Multimedia Integration Language (SMIL 2.0)</a>
+                  <a href="https://www.w3.org/TR/REC-smil/">Synchronized Multimedia Integration Language (SMIL)</a>
                 </li>
             <li>
                   <a href="https://www.w3.org/TR/SMIL-access/">Accessibility Features of SMIL</a>
-                </li>
-            <li>
-                  <a href="http://ncam.wgbh.org/invent_build/web_multimedia/accessible-digital-media-guide/guideline-h-multimedia#techH12">NCAM Rich Media Accessibility, Accessible SMIL Templates</a>
-                </li>
-            <li>
-                  <a href="https://msdn.microsoft.com/en-us/library/ms971327.aspx">SAMI 1.0</a>
                 </li>
          </ul>
       


### PR DESCRIPTION
closes #3483 

note:
1. I couldn't find anything to replace the NCAM link with, so I removed that.
2. Looking at Microsoft's site, it looks like SAMI isn't supported anymore, so I removed the link for that.