### PR TITLE
Updating "minimum bounding box" term, so anchor in 2.5.8 Target Size (Minimum) understanding works - Editorial

### DIFF
--- a/guidelines/terms/22/minimum-bounding-box.html
+++ b/guidelines/terms/22/minimum-bounding-box.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn data-lt="bounding boxes">minimum bounding box</dfn></dt>
+<dt class="new"><dfn data-lt="bounding boxes|bounding box">minimum bounding box</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>	
    <p>the smallest enclosing rectangle aligned to the horizontal axis within which all the points of a shape lie. For components which wrap onto multiple lines as part of a sentence or block of text (such as hypertext links), the bounding box is based on how the component would appear on a single line.</p>


### PR DESCRIPTION
Closes: #3491

Desc: updating "minimum bounding box" term so "bounding box" anchor in the Understanding of SC [2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html) works as expected.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/wcag/pull/3492.html" title="Last updated on Oct 19, 2023, 11:55 AM UTC (cd66b09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3492/2fbcec0...giacomo-petri:cd66b09.html" title="Last updated on Oct 19, 2023, 11:55 AM UTC (cd66b09)">Diff</a>