### PR TITLE
Fix minor typo error in SC 2.5.8: Target Size (Minimum) - Editorial

### DIFF
--- a/understanding/22/target-size-minimum.html
+++ b/understanding/22/target-size-minimum.html
@@ -122,7 +122,7 @@
             </figure>
             <p>The next two illustrations show sets of buttons which are only 16 CSS pixels tall. In the first set, there are no targets immediately above or below the buttons, so they pass. In the second illustration, there are further buttons, and they have been stacked on top of one another, resulting in a fail.</p>
             <figure id="target-text-buttons-one-row">
-                <img src="img/target-text-buttons-single-row.svg" width="785" height="105" alt="A row of buttons which are more that 44px wide and 16 CSS pixels high. There are no close targets above or below. The buttons are overlaid with the 24 CSS pixel diameter circles, and do not intersect each other nor any other targets." />
+                <img src="img/target-text-buttons-single-row.svg" width="785" height="105" alt="A row of buttons which are more than 44px wide and 16 CSS pixels high. There are no close targets above or below. The buttons are overlaid with the 24 CSS pixel diameter circles, and do not intersect each other nor any other targets." />
                 <figcaption>While the height of the targets is only 16 CSS pixels, the lack of adjacent targets above and below means that the targets pass this Success Criterion (image shown to scale - <a href="img/target-text-buttons-single-row.svg">see the scalable original version</a>)</figcaption>
             </figure>
 


### PR DESCRIPTION
Closes: #3497

Fixed minor typo error in Figure 5 alt text (replaced "that" with "than").

Editorial