### PR TITLE
Updating "mechanism" term, so anchor in 3.2.6 Consistent Help understanding works - Editorial

### DIFF
--- a/guidelines/terms/20/mechanism.html
+++ b/guidelines/terms/20/mechanism.html
@@ -1,4 +1,4 @@
-<dt><dfn>mechanism</dfn></dt>
+<dt><dfn data-lt="mechanisms">mechanism</dfn></dt>
 <dd>
    
    <p><a>process</a> or technique for achieving a result


### PR DESCRIPTION
Closes: #3508

Desc: updating "mechanism" term so "mechanisms" anchor in the Understanding of SC [3.2.6 Consistent Help](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help) works as expected.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/giacomo-petri/wcag/pull/3509.html" title="Last updated on Oct 20, 2023, 6:40 AM UTC (645db95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3509/2fbcec0...giacomo-petri:645db95.html" title="Last updated on Oct 20, 2023, 6:40 AM UTC (645db95)">Diff</a>