### PR TITLE
Update broken Accessible Authentication link in 3.3.7 Redundant Entry Understanding document

### DIFF
--- a/understanding/22/redundant-entry.html
+++ b/understanding/22/redundant-entry.html
@@ -59,7 +59,7 @@
 
         <p>This Success Criterion does not apply if data is provided by the user with a different method, such as uploading a resume in a document format.</p>
 
-        <p>This Success Criterion does not impact <a href="accessible-authentication.html">Accessible Authentication</a>, for which allowing auto-filling of passwords is a sufficient technique. In that case the filling is performed by the user's browser. Redundant Entry is asking for the website content to make the previous entry available, but not between sessions or for essential purposes such as asking for a password.</p>
+        <p>This Success Criterion does not impact <a href="accessible-authentication-minimum.html">Accessible Authentication</a>, for which allowing auto-filling of passwords is a sufficient technique. In that case the filling is performed by the user's browser. Redundant Entry is asking for the website content to make the previous entry available, but not between sessions or for essential purposes such as asking for a password.</p>
 
         <p>This criterion does not include requirements or exceptions specific to privacy or personally identifiable information (PII), but when implementing techniques such as auto-population, authors should ensure data protection when storing information even temporarily during a process. It is possible to eliminate redundant entry in ways that do not introduce additional privacy risks, but it is also possible that a poor implementation (for meeting this criterion) could leak additional PII.</p>
 


### PR DESCRIPTION
Closes: #3519

Updated broken href attribute value of Accessible Authentication link in SC [3.3.7 Redundant Entry](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry) Understanding document

Editorial