### PR TITLE
Fixing "1.4.11 Non-text Contrast" link in SC 2.4.13 Focus Appearance Understanding document - Editorial

### DIFF
--- a/understanding/22/focus-appearance.html
+++ b/understanding/22/focus-appearance.html
@@ -285,7 +285,7 @@
         <section id="relationship-with-non-text-contrast">
             <h3>Relationship with Non-text Contrast</h3>
 
-            <p>Focus indicators are visual information required to identify a state of a user interface component. That means that they are subject to <a>1.4.11 Non-text Contrast</a>, in addition to 2.4.13 Focus Appearance.</p>
+            <p>Focus indicators are visual information required to identify a state of a user interface component. That means that they are subject to <a href="non-text-contrast" class="sc">1.4.11 Non-text Contrast</a>, in addition to 2.4.13 Focus Appearance.</p>
 
             <p>In combination with <a href="focus-visible">2.4.7 Focus Visible</a>, <a href="non-text-contrast" class="sc">1.4.11 Non-text Contrast</a> requires that the visual focus indicator for a component must have sufficient contrast against the adjacent colors when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
                     


### PR DESCRIPTION
Closes #3527

**Description**: In [Relationship with Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html#relationship-with-non-text-contrast) section of success criterion 2.4.13 Focus Appearance, the link to SC 1.4.11 Non-text Contrast is pointing to 2.4.13 Focus Appearance.