### PR TITLE
Update definition for single pointer

### DIFF
--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,7 +1,5 @@
 <dt><dfn>single pointer</dfn></dt>
 <dd>
-   	
-   <p>pointer input that operates with one point of contact with the screen, including single taps and clicks, double-taps and clicks, long presses, and path-based gestures</p>
-  				
+   <p>a single mouse, stylus, or finger on a touch screen, that only targets a single point on the screen (as opposed to multi-pointer/multi-touch scenarios)</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,5 +1,5 @@
 <dt><dfn>single pointer</dfn></dt>
 <dd>
-   <p>a single mouse, stylus, or finger on a touch screen, that only targets a single point on the screen (as opposed to multi-pointer/multi-touch scenarios)</p>
+   <p>an input – such as a mouse, stylus, or finger on a touch screen – that only targets a single point on the screen (as opposed to multi-pointer/multi-touch scenarios)</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,5 +1,6 @@
 <dt><dfn>single pointer</dfn></dt>
 <dd>
-   <p>an input that only targets a single point on the page/screen at a time – such as a mouse, stylus, or single finger on a touch screen – as opposed to multi-pointer/multi-touch scenarios</p>
+   <p>an input that only targets a single point on the page/screen at a time – such as a mouse, stylus, or single finger on a touch screen.</p>
+   <p class="note">In contrast to single pointer inputs, multipoint interactions involve the use of two or more pointers at the same time – such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn>single pointer</dfn></dt>
 <dd>
-   <p>an input that only targets a single point on the page/screen at a time – such as a mouse, stylus, or single finger on a touch screen.</p>
+   <p>an input that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
    <p class="note">In contrast to single pointer inputs, multipoint interactions involve the use of two or more pointers at the same time – such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,5 +1,5 @@
 <dt><dfn>single pointer</dfn></dt>
 <dd>
-   <p>an input – such as a mouse, stylus, or finger on a touch screen – that only targets a single point on the screen (as opposed to multi-pointer/multi-touch scenarios)</p>
+   <p>an input that only targets a single point on the page/screen at a time – such as a mouse, stylus, or single finger on a touch screen – as opposed to multi-pointer/multi-touch scenarios</p>
 </dd>
 


### PR DESCRIPTION
The definition for "single pointer" has had issues for a long time, as it mixes the idea of what a pointer *is* with the action(s) *performed* using a pointer.

I originally tried to fix this, but there was no appetite for it once 2.1 was released. However, with 2.2 and the new 2.5.7 Dragging Movement SC, the broken definition is causing actual misunderstandings/illogical non-sequiturs.

See https://github.com/w3c/wcag/issues/749#issuecomment-494146357 and the recent https://github.com/w3c/wcag/issues/3535 where this is once again causing a non-sequitur

Closes https://github.com/w3c/wcag/issues/3535

(this is effectively a follow-up to https://github.com/w3c/wcag/pull/809 which had disambiguated things, but the definition had since been changed further/again to reintroduce the ambiguous wording we have at this point which confuses input with action)

This would be applied to WCAG 2.1 and 2.2, unless there is a decision to only apply it to 2.2.

EDIT: Also closes https://github.com/w3c/wcag/issues/394


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3536.html" title="Last updated on Mar 8, 2024, 7:30 PM UTC (6c36df1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3536/afbf9ee...6c36df1.html" title="Last updated on Mar 8, 2024, 7:30 PM UTC (6c36df1)">Diff</a>