### PR TITLE
Update Input Purposes list to remove `transaction-amount`

### DIFF
--- a/guidelines/input-purposes.html
+++ b/guidelines/input-purposes.html
@@ -40,8 +40,6 @@
 		<li><strong>cc-exp-year</strong> - Year component of the expiration date of the payment instrument</li>
 		<li><strong>cc-csc</strong> - Security code for the payment instrument (also known as the card security code (CSC), card validation code (CVC), card verification value (CVV), signature panel code (SPC), credit card ID (CCID), etc)</li>
 		<li><strong>cc-type</strong> - Type of payment instrument</li>
-		<li><strong>transaction-currency</strong> - The currency that the user would prefer the transaction to use</li>
-		<li><strong>transaction-amount</strong> - The amount that the user would like for the transaction (e.g., when entering a bid or sale price)</li>
 		<li><strong>language</strong> - Preferred language</li>
 		<li><strong>bday</strong> - Birthday</li>
 		<li><strong>bday-day</strong> - Day component of birthday</li>

--- a/guidelines/input-purposes.html
+++ b/guidelines/input-purposes.html
@@ -40,6 +40,7 @@
 		<li><strong>cc-exp-year</strong> - Year component of the expiration date of the payment instrument</li>
 		<li><strong>cc-csc</strong> - Security code for the payment instrument (also known as the card security code (CSC), card validation code (CVC), card verification value (CVV), signature panel code (SPC), credit card ID (CCID), etc)</li>
 		<li><strong>cc-type</strong> - Type of payment instrument</li>
+		<li><strong>transaction-currency</strong> - The currency that the user would prefer the transaction to use</li>
 		<li><strong>language</strong> - Preferred language</li>
 		<li><strong>bday</strong> - Birthday</li>
 		<li><strong>bday-day</strong> - Day component of birthday</li>


### PR DESCRIPTION
It is hard to argue that `transaction-currency` and `transaction-amount` in any meaningful way "relate to the user of the content and pertain only to information related to that individual". (the first one, just at a stretch perhaps, but both are clearly scoped towards a specific transaction the user is carrying out)

UPDATE: after discussion, decided to only remove `transaction-amount`

Closes https://github.com/w3c/wcag/issues/3537


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3539.html" title="Last updated on Nov 13, 2023, 12:33 PM UTC (c7cc5e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3539/afbf9ee...c7cc5e3.html" title="Last updated on Nov 13, 2023, 12:33 PM UTC (c7cc5e3)">Diff</a>