### PR TITLE
Remove leftover references to Flash techniques

### DIFF
--- a/guidelines/wcag.json
+++ b/guidelines/wcag.json
@@ -4765,14 +4765,6 @@
 		"title": 
 		"Using scripts to change the link text"
 		}
-		,
-		{
-		"id":
-		"TECH:FLASH7"
-		,
-		"title": 
-		""
-		}
 		
 		]
 	
@@ -4914,14 +4906,6 @@
 		,
 		"title": 
 		"Combining adjacent image and text links for the same resource"
-		}
-		,
-		{
-		"id":
-		"TECH:FLASH5"
-		,
-		"title": 
-		""
 		}
 		,
 		{
@@ -5319,14 +5303,6 @@
 		"title": 
 		"Using scripts to change the link text"
 		}
-		,
-		{
-		"id":
-		"TECH:FLASH7"
-		,
-		"title": 
-		""
-		}
 		
 		]
 	
@@ -5391,14 +5367,6 @@
 		,
 		"title": 
 		"Combining adjacent image and text links for the same resource"
-		}
-		,
-		{
-		"id":
-		"TECH:FLASH5"
-		,
-		"title": 
-		""
 		}
 		,
 		{

--- a/understanding/20/link-purpose-in-context.html
+++ b/understanding/20/link-purpose-in-context.html
@@ -228,12 +228,6 @@
                      										           
                   </li>
                   
-                  <li>
-                     											             
-                     <a href="../Techniques/flash/FLASH7" class="flash">Using scripting to change control labels</a>
-                     										           
-                  </li>
-                  
                </ul>
                
             </li>
@@ -362,12 +356,6 @@
             <li>
                									         
                <a href="../Techniques/html/H2" class="html">Combining adjacent image and text links for the same resource</a>
-               								       
-            </li>
-            
-            <li>
-               									         
-               <a href="../Techniques/flash/FLASH5" class="flash">Combining adjacent image and text buttons for the same resource</a>
                								       
             </li>
             

--- a/understanding/20/link-purpose-link-only.html
+++ b/understanding/20/link-purpose-link-only.html
@@ -203,12 +203,6 @@
                      										           
                   </li>
                   
-                  <li>
-                     											             
-                     <a href="../Techniques/flash/FLASH7" class="flash">Using scripting to change control labels</a>
-                     										           
-                  </li>
-                  
                </ul>
                
             </li>
@@ -267,12 +261,6 @@
             <li>
                									         
                <a href="../Techniques/html/H2" class="html">Combining adjacent image and text links for the same resource</a>
-               								       
-            </li>
-            
-            <li>
-               									         
-               <a href="../Techniques/flash/FLASH5" class="flash">Combining adjacent image and text buttons for the same resource</a>
                								       
             </li>
             


### PR DESCRIPTION
A few references to FLASH5 and FLASH7 were missed when #1142 resolved #1140.

The leftovers seem to have resulted in broken FLASH# links appearing in some of WCAG 2.1 and 2.2's understanding pages:
* Understanding SC 2.4.4: Link Purpose (In Context) (Level A)
  * WCAG 2.1: https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context#sufficient
  * WCAG 2.2: https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context#sufficient
* Understanding SC 2.4.9: Link Purpose (Link Only) (Level AAA)
  * WCAG 2.1: https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only.html#sufficient
  * WCAG 2.2: https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-link-only.html#sufficient

This should resolve it by removing the leftovers from the HTML and JSON versions of affected understanding pages.

Closes https://github.com/w3c/wcag/issues/3928