### PR TITLE
Update public comments email subject

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -23,7 +23,7 @@
             Although the proposed Success Criteria in this document reference issues tracking
             discussion, the Working Group requests that public comments be filed as new issues,
             one issue per discrete comment. It is free to create a GitHub account to file issues.
-            If filing issues in GitHub is not feasible, send email to <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%202.1%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>).</p>
+            If filing issues in GitHub is not feasible, send email to <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%202.2%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>).</p>
         </section>
         <section class="informative introductory" id="intro">
 			<h2>Introduction</h2>


### PR DESCRIPTION
Public comments email subject has not been updated with WCAG 2.2.

Current version: `WCAG 2.1 public comment`
Updated version: `WCAG 2.2 public comment`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/remibetin/wcag/pull/3574.html" title="Last updated on Nov 29, 2023, 9:05 AM UTC (913f695)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3574/0c1ca5f...remibetin:913f695.html" title="Last updated on Nov 29, 2023, 9:05 AM UTC (913f695)">Diff</a>