### PR TITLE
Update guidelines.css for translations

### DIFF
--- a/guidelines/guidelines.css
+++ b/guidelines/guidelines.css
@@ -59,3 +59,35 @@ a.internalDFN[title]:hover, .internalDFN[title]:active, a.internalDFN[title]:foc
 	cursor: help;
 }
 span.screenreader {position: absolute; left: -10000px}
+
+/* Translation Header Styles */
+
+div.transheader {
+  display: block;
+  border: solid #ccccbb;
+  padding: 2%;
+  background: #eeeedd;
+  margin-bottom: 2em;
+}
+
+.transtitle {
+  color: #555555;
+  background: #eeeedd;
+  font-weight: bolder;
+}
+
+.transheader ul { /* compact for transheader */
+  margin-top: 0;
+}
+
+.transheader ul li {  /* compact for transheader */
+  margin: 0.25em 0 0 0;
+}
+
+.transheader dd + dd { /* compact for transheader */
+  margin-top: -.5em
+}
+
+.transheader>h2.transtitle { /* counteract Respec style */
+  margin-left:0.5em;
+}


### PR DESCRIPTION
### Current situation:
Guidelines.css does not include styles for transheader. Translators must add them manually in `<head>` when preparing the file.

### Proposed changes:
Transheader styles are directly included in `guidelines.css`. Translators do not need to add styles manually.

Includes:
- `.transheader` styling (from https://www.w3.org/2005/02/TranslationPolicy.html source code & https://www.w3.org/Translations/WCAG21-fr source code)
- Transheader headings styling (`.transtitle`) (from https://www.w3.org/2005/02/TranslationPolicy.html source code)
- Make unordered lists more compact in transheader: used to list translation coordinators.
- Make definition lists more compact in transheader (same CSS used for `head` section): used to describe Lead translating organisation.
- Avoid transheader h2 from being too far to the left.