### PR TITLE
Link in Related Resources not working as expected in Understanding SC 3.3.8: Accessible Authentication (Minimum)

### DIFF
--- a/understanding/22/accessible-authentication-minimum.html
+++ b/understanding/22/accessible-authentication-minimum.html
@@ -210,8 +210,7 @@
         <ul>
             <li><a href="https://www.w3.org/TR/coga-gap-analysis/#table1">Cognitive Accessibility Gap Analysis Topic 1: Authentication and Safety</a></li>
             <li><a href="https://w3c.github.io/coga/issue-papers/#web-security-and-privacy-technologies">Cognitive Accessibility Issue Papers 4. Web Security and Privacy Technologies</a> and <a href="https://w3c.github.io/coga/issue-papers/privacy-security.html">Web Security and Privacy Technologies</a></li>
-            <li><a href="https://www.w3.org/TR/coga-usable/#provide-a-login-that-does-not-rely-on-memory-or-other-
-            cognitive-skills-pattern">Making Content Usable for People with Cognitive and Learning Disabilities 4.7.1 Provide a Login that Does Not Rely on Memory or Other Cognitive Skills</a></li>
+            <li><a href="https://www.w3.org/TR/coga-usable/#provide-a-login-that-does-not-rely-on-memory-or-other-cognitive-skills-pattern">Making Content Usable for People with Cognitive and Learning Disabilities 4.7.1 Provide a Login that Does Not Rely on Memory or Other Cognitive Skills</a></li>
             <li><a href="https://rawgit.com/w3c/coga/master/issue-papers/privacy-security.html">Security and Privacy Technologies issue paper from the Cognitive Task Force</a>.</li>
             <li><a href="https://www.w3.org/TR/webauthn/">WebAuthN specification</a>.</li>
             <li><a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API">Web Authentication API on MDN</a>.</li>

--- a/understanding/22/accessible-authentication-minimum.html
+++ b/understanding/22/accessible-authentication-minimum.html
@@ -211,7 +211,7 @@
             <li><a href="https://www.w3.org/TR/coga-gap-analysis/#table1">Cognitive Accessibility Gap Analysis Topic 1: Authentication and Safety</a></li>
             <li><a href="https://w3c.github.io/coga/issue-papers/#web-security-and-privacy-technologies">Cognitive Accessibility Issue Papers 4. Web Security and Privacy Technologies</a> and <a href="https://w3c.github.io/coga/issue-papers/privacy-security.html">Web Security and Privacy Technologies</a></li>
             <li><a href="https://www.w3.org/TR/coga-usable/#provide-a-login-that-does-not-rely-on-memory-or-other-
-            cognitive-skills-pattern">Making Content Usable for People with Cogntive and Learning Disabilities 4.7.1 Provide a Login that Does Not Rely on Memory or Other Cognitive Skills</a></li>
+            cognitive-skills-pattern">Making Content Usable for People with Cognitive and Learning Disabilities 4.7.1 Provide a Login that Does Not Rely on Memory or Other Cognitive Skills</a></li>
             <li><a href="https://rawgit.com/w3c/coga/master/issue-papers/privacy-security.html">Security and Privacy Technologies issue paper from the Cognitive Task Force</a>.</li>
             <li><a href="https://www.w3.org/TR/webauthn/">WebAuthN specification</a>.</li>
             <li><a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API">Web Authentication API on MDN</a>.</li>


### PR DESCRIPTION
Closes: #3594

- URL: https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html
- Fixes: 
    - In the Understanding document of SC 3.3.8: Accessible Authentication (Minimum), the link in Realted Resources [Making Content Usable for People with Cogntive and Learning Disabilities 4.7.1 Provide a Login that Does Not Rely on Memory or Other Cognitive Skills](https://www.w3.org/TR/coga-usable/#provide-a-login-that-does-not-rely-on-memory-or-other-%20%20%20%20%20%20%20%20%20%20%20%20%20cognitive-skills-pattern) is not working as expected.
The anchor is broken and fails to navigate the user to the intended section of the page.
    - Together with this I'll also fix a typo in this link ("Cogntive").