### PR TITLE
Fixed Figure 10 broken link to Focus Appearance on the Understanding Document for Non-text contrast

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -78,7 +78,7 @@
 
 				<h4 id="related-color">Relationship with Use of Color</h4>
 
-				<p>The <a href="use-of-color">Use of Color</a> success criterion addresses changing <strong>only the color</strong> (hue) of an object or text without otherwise altering the object's form. The principle is that contrast ratio (the difference in brightness) can be used to distinguish text or graphics. For example, <a href="../../techniques/general/G183.html">G183</a> is a technique to use a contrast ratio of 3:1 with surrounding text to distinguish links and controls. In that case the Working Group regards a link color that meets the 3:1 contrast ratio relative to the non-linked text color as satisfying the Success Criterion <a href="use-of-color">1.4.1 Use of color</a> since it is relying on contrast ratio as well as color (hue) to convey that the text is a link.</p>
+				<p>The <a href="use-of-color">Use of Color</a> success criterion addresses changing <strong>only the color</strong> (hue) of an object or text without otherwise altering the object's form. The principle is that contrast ratio (the difference in brightness) can be used to distinguish text or graphics. For example, <a href="../Techniques/general/G183.html">G183</a> is a technique to use a contrast ratio of 3:1 with surrounding text to distinguish links and controls. In that case the Working Group regards a link color that meets the 3:1 contrast ratio relative to the non-linked text color as satisfying the Success Criterion <a href="use-of-color">1.4.1 Use of color</a> since it is relying on contrast ratio as well as color (hue) to convey that the text is a link.</p>
 
 				<p>Non-text information within controls that uses a change of hue alone to convey the value or state of an input, such as a 1-5 star indicator with a black outline for each star filled with either yellow (full) or white (empty) is likely to fail the Use of color criterion rather than this one.</p>
 
@@ -95,7 +95,7 @@
 					</figcaption>
 				</figure>
 
-				<p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../../techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
+				<p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../Techniques/general/G195.html" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
 
 
 				<h4 id="related-focus">Relationship with Focus Visible</h4>
@@ -514,15 +514,15 @@
 				<section class="situation">
 						<h4>Situation A: Color is used to identify user interface components or used to identify user interface component states</h4>
 						<ul>
-							<li><a href="../../techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
-							<li><a href="../../techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
+							<li><a href="../Techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
+							<li><a href="../Techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
 						</ul>
 				</section>
 				<section class="situation">
 					<h4>Situation B: Color is required to understand graphical content</h4>
 					<ul>
-						<li><a href="../../techniques/general/G207" class="general">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>
-						<li><a href="../../techniques/general/G209" class="general">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>
+						<li><a href="../Techniques/general/G207" class="general">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>
+						<li><a href="../Techniques/general/G209" class="general">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>
 					</ul>
 				</section>
 
@@ -536,7 +536,7 @@
 			<section id="failure">
 				<h3>Failures</h3>
 				<ul>
-					<li><a href="../../techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
+					<li><a href="../Techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
 				</ul>
 			</section>
 		</section>

--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -95,12 +95,12 @@
 					</figcaption>
 				</figure>
 
-				<p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
+				<p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../../techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
 
 
 				<h4 id="related-focus">Relationship with Focus Visible</h4>
 				
-				<p>In combination with <a href="https://www.w3.org/TR/WCAG21/#focus-visible">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
+				<p>In combination with <a href="focus-visible" class="sc">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
 
 				<p>Most focus indicators appear outside the component - in that case it needs to contrast with the background that the component is on. Other cases include focus indicators which are:</p>
 
@@ -131,7 +131,7 @@
 						The external green indicator (#008000) does contrast with the white background (#FFF) which the component is on, <strong>passing</strong> the criterion. It does not need to contrast with both the component background and the component.
 					</figcaption>
 				</figure>
-				<p>Although the figure above with a dark outline passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag22">There is a criterion in WCAG 2.2 that addresses this aspect, <a href="../22/focus-appearance-minimum.html">Focus Appearance</a>.</span></p>
+				<p>Although the figure above with a dark outline passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag22">There is a criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance" class="sc">Focus Appearance</a>.</span></p>
 
 				<p>If an indicator is partly inside and partly outside the component, either part of the indicator could provide contrast.</p>
 
@@ -359,7 +359,7 @@
 				<ul>
 					<li>
 						<p>A graphic with text embedded or overlayed conveys the same information, such as labels <em>and</em> values on a chart.</p>
-						<p class="note">Text within a graphic must meet <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">1.4.3 Contrast (Minimum)</a>.</p>
+						<p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
 					</li>
 					<li> The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
 					<li> The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
@@ -393,10 +393,10 @@
 				<p>Infographics often fail to meet several WCAG level AA criteria including:</p>
 
 				<ul>
-					<li><a href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html">1.1.1 Non-text Content</a></li>
-					<li><a href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html">1.4.1 Use of Color</a></li>
-					<li><a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html">1.4.3 (Text) Contrast</a></li>
-					<li><a href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html">1.4.5 Images of Text</a></li>
+					<li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
+					<li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
+					<li><a href="contrast-minimum" class="sc">1.4.3 (Text) Contrast</a></li>
+					<li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
 				</ul>
 
 				<p>An infographic can use text which meets the other criteria to minimise the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infograph is not relied upon for understanding.</p>
@@ -516,7 +516,7 @@
 						<h4>Situation A: Color is used to identify user interface components or used to identify user interface component states</h4>
 						<ul>
 							<li><a href="../../techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
-							<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
+							<li><a href="../../techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
 						</ul>
 				</section>
 				<section class="situation">
@@ -537,7 +537,7 @@
 			<section id="failure">
 				<h3>Failures</h3>
 				<ul>
-					<li><a href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
+					<li><a href="../../techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
 				</ul>
 			</section>
 		</section>


### PR DESCRIPTION
Closes: #3561

Fixed Figure 10 broken link to Focus Appearance on the Understanding Document for [Non-text contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast).

I've also updated links pointing to WCAG 2.1, replacing the absolute URLs with a relative one.