### PR TITLE
Add IDs to avoid rewriting during translations

### DIFF
--- a/acknowledgements/funders.html
+++ b/acknowledgements/funders.html
@@ -1,4 +1,4 @@
-<section>
+<section id="enabling-funders">
 	<h2>Enabling funders</h2>
 	<p>This publication has been funded in part with U.S. Federal funds from the Health and Human Services, National Institute on Disability, Independent Living, and Rehabilitation Research (NIDILRR), initially under contract number ED-OSE-10-C-0067, then under contract number HHSP23301500054C, and now under HHS75P00120P00168. The content of this publication does not necessarily reflect the views or policies of the U.S. Department of Health and Human Services or the U.S. Department of Education, nor does mention of trade names, commercial products, or organizations imply endorsement by the U.S. Government.</p>
 </section>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -27,7 +27,7 @@
         </section>
         <section class="informative introductory" id="intro">
 			<h2>Introduction</h2>
-			<section>
+			<section id="background-on-wcag-2">
 				<h3>Background on WCAG 2</h3>
 				<p>Web Content Accessibility Guidelines (WCAG) 2.2 defines how to make Web content more accessible to people with disabilities. Accessibility involves a wide range of disabilities, including visual, auditory, physical, speech, cognitive, language, learning, and neurological disabilities. Although these guidelines cover a wide range of issues, they are not able to address the needs of people with all types, degrees, and combinations of disability. These guidelines also make Web content more usable by older individuals with changing abilities due to aging and often improve usability for users in general.</p>
 				<p>WCAG 2.2 is developed through the <a href="https://www.w3.org/WAI/standards-guidelines/w3c-process/">W3C process</a> in cooperation with individuals and organizations around the world, with a goal of providing a shared standard for Web content accessibility that meets the needs of individuals, organizations, and governments internationally. WCAG 2.2 builds on WCAG 2.0 [[WCAG20]] and WCAG 2.1 [[WCAG21]], which in turn built on WCAG 1.0 [[WAI-WEBCONTENT]] and is designed to apply broadly to different Web technologies now and in the future, and to be testable with a combination of automated testing and human evaluation. For an introduction to WCAG, see the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a>.</p>
@@ -42,7 +42,7 @@
                 </ul>
                 <p>Where this document refers to <q>WCAG 2</q> it is intended to mean any and all versions of WCAG that start with 2.</p>
 			</section>
-			<section>
+			<section id="wcag-2-layers-of-guidance">
 				<h3>WCAG 2 Layers of Guidance</h3>
 				<p>The individuals and organizations that use WCAG vary widely and include Web designers and developers, policy makers, purchasing agents, teachers, and students. In order to meet the varying needs of this audience, several layers of guidance are provided including overall <em>principles</em>, general <em>guidelines</em>, testable <em>success criteria</em> and a rich collection of <em>sufficient techniques</em>, <em>advisory techniques</em>, and <em>documented common failures</em> with examples, resource links and code.</p>
 				<ul>
@@ -62,7 +62,7 @@
 				<p>All of these layers of guidance (principles, guidelines, success criteria, and sufficient and advisory techniques) work together to provide guidance on how to make content more accessible. Authors are encouraged to view and apply all layers that they are able to, including the advisory techniques, in order to best address the needs of the widest possible range of users.</p>
 				<p>Note that even content that conforms at the highest level (AAA) will not be accessible to individuals with all types, degrees, or combinations of disability, particularly in the cognitive, language, and learning areas. Authors are encouraged to consider the full range of techniques, including the advisory techniques, <a href="https://www.w3.org/TR/coga-usable/">Making Content Usable for People with Cognitive and Learning Disabilities</a>, as well as to seek relevant advice about current best practice to ensure that Web content is accessible, as far as possible, to this community. <a href="https://www.w3.org/WAI/WCAG22/Understanding/understanding-metadata">Metadata</a> may assist users in finding content most suitable for their needs. </p>
 			</section>
-			<section>
+			<section id="wcag-2-2-supporting-documents">
 				<h3>WCAG 2.2 Supporting Documents</h3>
 				<p>The WCAG 2.2 document is designed to meet the needs of those who need a stable, referenceable technical standard. Other documents, called supporting documents, are based on the WCAG 2.2 document and address other important purposes, including the ability to be updated to describe how WCAG would be applied with new technologies. Supporting documents include: </p>
 				<ol class="enumar">
@@ -82,16 +82,16 @@
 				</ol>
 				<p>See <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines (WCAG) Overview</a> for a description of the WCAG 2.2 supporting material, including education resources related to WCAG 2. Additional resources covering topics such as the business case for Web accessibility, planning implementation to improve the accessibility of Web sites, and accessibility policies are listed in <a href="https://www.w3.org/WAI/Resources/Overview">WAI Resources</a>.</p>
 			</section>
-        	<section>
+        	<section id="requirements-for-wcag-2-2">
         		<h3>Requirements for WCAG 2.2</h3>
                 <p>WCAG 2.2 meets a set of <a href="https://w3c.github.io/wcag/requirements/22/">requirements for WCAG 2.2</a> which, in turn, inherit requirements from previous WCAG 2 versions. Requirements structure the overall framework of guidelines and ensure backwards compatibility. The Working Group also used a less formal set of acceptance criteria for success criteria, to help ensure success criteria are similar in style and quality to those in WCAG 2.0. These requirements constrained what could be included in WCAG 2.2. This constraint was important to preserve its nature as a dot-release of WCAG 2.</p>
         	</section>
-    		<section>
+    		<section id="comparison-with-wcag-2-1">
                 <h3>Comparison with WCAG 2.1</h3>
                 <p>WCAG 2.2 was initiated with the goal to continue the work of WCAG 2.1: Improving accessibility guidance for three major groups: users with cognitive or learning disabilities, users with low vision, and users with disabilities on mobile devices. Many ways to meet these needs were proposed and evaluated, and a set of these were refined by the Working Group. Structural requirements inherited from WCAG 2.0, clarity and impact of proposals, and timeline led to the final set of success criteria included in this version. The Working Group considers that WCAG 2.2 incrementally advances web content accessibility guidance for all these areas, but underscores that not all user needs are met by these guidelines.</p>
 
 				<p>WCAG 2.2 builds on and is backwards compatible with WCAG 2.1, meaning web pages that conform to WCAG 2.2 are at least as accessible as pages that conform to WCAG 2.1. Requirements have been added that build on 2.1 and 2.0. WCAG 2.2 has removed one success criterion, <a href="#parsing">4.1.1 Parsing</a>. Authors that are required by policy to conform with WCAG 2.0 or 2.1 will be able to update content to WCAG 2.2, but may need to continue to test and report 4.1.1. Authors following more than one version of the guidelines should be aware of the following additions.</p>
-				<section>
+				<section id="new-features-in-wcag-2-2">
 					<h4>New Features in WCAG 2.2</h4>
 					<p>WCAG 2.2 extends WCAG 2.1 by adding new success criteria, definitions to support them, and guidelines to organize the additions. This additive approach helps to make it clear that sites which conform to WCAG 2.2 also conform to WCAG 2.1. The Accessibility Guidelines Working Group recommends that sites adopt WCAG 2.2 as their new conformance target, even if formal obligations mention previous versions, to provide improved accessibility and to anticipate future policy changes.</p>
           <p>The following success criteria are new in WCAG 2.2:</p>
@@ -110,16 +110,16 @@
           <p>WCAG 2.2 also introduces new sections detailing aspects of the specification which may impact <a href="#privacy-summary">privacy</a> and <a href="#security-summary">security</a>.</p>
           
 				</section>
-				<section>
+				<section id="numbering-in-wcag-2-2">
 					<h4>Numbering in WCAG 2.2</h4>
 					<p>In order to avoid confusion for implementers for whom backwards compatibility to WCAG 2 versions is important, new success criteria in WCAG 2.2 have been appended to the end of the set of success criteria within their guideline. This avoids the need to change the section number of success criteria from WCAG 2, which would be caused by inserting new success criteria between existing success criteria in the guideline, but it means success criteria in each guideline are no longer grouped by conformance level. The order of success criteria within each guideline does not imply information about conformance level; only the conformance level indicator (A / AA / AAA) on the success criterion itself indicates this. The <a href="https://www.w3.org/WAI/WCAG22/quickref/">WCAG 2.2 Quick Reference</a> will provide a way to view success criteria grouped by conformance level, along with many other filter and sort options.</p>
 				</section>
-				<section>
+				<section id="conformance-to-wcag-2-2">
 					<h4>Conformance to WCAG 2.2</h4>
 					<p>WCAG 2.2 uses the same conformance model as WCAG 2.0. It is intended that sites that conform to WCAG 2.2 also conform to WCAG 2.0 and WCAG 2.1, which means they meet the requirements of any policies that reference WCAG 2.0 or WCAG 2.1, while also better meeting the needs of users on the current Web. </p>
 				</section>
 			</section>
-        	<section>
+        	<section id="later-versions-of-accessibility-guidelines">
         		<h3>Later Versions of Accessibility Guidelines</h3>
         		<p>In parallel with WCAG 2.2, the Accessibility Guidelines Working Group is developing another major version of accessibility guidelines. The result of this work is expected to be a more substantial restructuring of web accessibility guidance than would be realistic for dot-releases of WCAG 2. The work follows a research-focused, user-centered design methodology to produce the most effective and flexible outcome, including the roles of content authoring, user agent support, and authoring tool support. This is a multi-year effort, so WCAG 2.2 is needed as an interim measure to provide updated web accessibility guidance to reflect changes on the web since the publication of WCAG 2.0. The Working Group might also develop additional interim versions, continuing with WCAG 2.2, on a similar short timeline to provide additional support while the major version is completed. </p>
         	</section>
@@ -128,14 +128,14 @@
             <h2> Perceivable </h2>
             <p>Information and user interface components must be presentable to users in ways they can perceive.</p>
 
-            <section class="guideline">
+            <section class="guideline" id="text-alternatives">
                 <h3>Text Alternatives</h3>
                 <p>Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.</p>
 
                 <section data-include="sc/20/non-text-content.html" data-include-replace="true"></section>
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="time-based-media">
                 <h3>Time-based Media</h3>
                 <p>Provide alternatives for time-based media.</p>
 
@@ -158,7 +158,7 @@
                 <section data-include="sc/20/audio-only-live.html" data-include-replace="true"></section>
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="adaptable">
                 <h3>Adaptable</h3>
                 <p>Create content that can be presented in different ways (for example simpler layout) without losing information or structure.</p>
 
@@ -176,7 +176,7 @@
 
           </section>
 
-            <section class="guideline">
+            <section class="guideline" id="distinguishable">
                 <h3>Distinguishable</h3>
                 <p>Make it easier for users to see and hear content including separating foreground from background.</p>
 
@@ -213,7 +213,7 @@
             <h2>Operable </h2>
             <p>User interface components and navigation must be operable.</p>
 
-            <section class="guideline">
+            <section class="guideline" id="keyboard-accessible">
                 <h3>Keyboard Accessible</h3>
                 <p>Make all functionality available from a keyboard.</p>
 
@@ -227,7 +227,7 @@
                 
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="enough-time">
                 <h3>Enough Time</h3>
                 <p>Provide users enough time to read and use content.</p>
 
@@ -245,7 +245,7 @@
 
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="seizures-and-physical-reactions">
                 <h3>Seizures and Physical Reactions</h3>
                 <p>Do not design content in a way that is known to cause seizures or physical reactions.</p>
 
@@ -257,7 +257,7 @@
 
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="navigable">
                 <h3>Navigable</h3>
                 <p>Provide ways to help users navigate, find content, and determine where they are.</p>
 
@@ -289,7 +289,7 @@
 
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="input-modalities">
                 <h3>Input Modalities</h3>
                 <p>Make it easier for users to operate functionality through various inputs beyond keyboard.</p>
 
@@ -316,7 +316,7 @@
             <h2> Understandable </h2>
             <p>Information and the operation of the user interface must be understandable.</p>
 
-            <section class="guideline">
+            <section class="guideline" id="readable">
                 <h3>Readable</h3>
                 <p>Make text content readable and understandable.</p>
 
@@ -334,7 +334,7 @@
 
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="predictable">
                 <h3>Predictable</h3>
                 <p>Make Web pages appear and operate in predictable ways.</p>
 
@@ -352,7 +352,7 @@
 
             </section>
 
-            <section class="guideline">
+            <section class="guideline" id="input-assistance">
                 <h3>Input Assistance</h3>
                 <p>Help users avoid and correct mistakes.</p>
 
@@ -381,7 +381,7 @@
             <h2> Robust </h2>
             <p>Content must be robust enough that it can be interpreted by a wide variety of user agents, including assistive technologies.</p>
 
-            <section class="guideline">
+            <section class="guideline" id="compatible">
                 <h3>Compatible</h3>
                 <p>Maximize compatibility with current and future user agents, including assistive technologies.</p>
 
@@ -394,12 +394,12 @@
            </section>
 
         </section>
-        <section>
+        <section id="conformance">
             <h1>Conformance</h1>
 
             <p>This section lists requirements for <a>conformance</a> to WCAG 2.2. It also gives information about how to make conformance claims, which are optional. Finally, it describes what it means to be <a>accessibility supported</a>, since only accessibility-supported ways of using technologies can be <a>relied upon</a> for conformance. <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance">Understanding Conformance</a> includes further explanation of the accessibility-supported concept.</p>
         	
-        	<section>
+        	<section id="interpreting-normative-requirements">
         		<h2>Interpreting Normative Requirements</h2>
         		
         		<p>The main content of WCAG 2.2 is <a>normative</a> and defines requirements that impact conformance claims. Introductory material, appendices, sections marked as "non-normative", diagrams, examples, and notes are <a>informative</a> (non-normative). Non-normative material provides advisory information to help interpret the guidelines but does not create requirements that impact a conformance claim.</p>

--- a/guidelines/sc/20/abbreviations.html
+++ b/guidelines/sc/20/abbreviations.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="abbreviations" class="sc">
    
    <h4>Abbreviations</h4>
    

--- a/guidelines/sc/20/audio-control.html
+++ b/guidelines/sc/20/audio-control.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="audio-control" class="sc">
    
    <h4>Audio Control</h4>
    

--- a/guidelines/sc/20/audio-description-or-media-alternative-prerecorded.html
+++ b/guidelines/sc/20/audio-description-or-media-alternative-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="audio-description-or-media-alternative-prerecorded" class="sc">
    
    <h4>Audio Description or Media Alternative (Prerecorded)</h4>
    

--- a/guidelines/sc/20/audio-description-prerecorded.html
+++ b/guidelines/sc/20/audio-description-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="audio-description-prerecorded" class="sc">
    
    <h4>Audio Description (Prerecorded)</h4>
    

--- a/guidelines/sc/20/audio-only-and-video-only-prerecorded.html
+++ b/guidelines/sc/20/audio-only-and-video-only-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="audio-only-and-video-only-prerecorded" class="sc">
    
    <h4>Audio-only and Video-only (Prerecorded)</h4>
    

--- a/guidelines/sc/20/audio-only-live.html
+++ b/guidelines/sc/20/audio-only-live.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="audio-only-live" class="sc">
    
    <h4>Audio-only (Live)</h4>
    

--- a/guidelines/sc/20/bypass-blocks.html
+++ b/guidelines/sc/20/bypass-blocks.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="bypass-blocks" class="sc">
    
    <h4>Bypass Blocks</h4>
    

--- a/guidelines/sc/20/captions-live.html
+++ b/guidelines/sc/20/captions-live.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="captions-live" class="sc">
    
    <h4>Captions (Live)</h4>
    

--- a/guidelines/sc/20/captions-prerecorded.html
+++ b/guidelines/sc/20/captions-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="captions-prerecorded" class="sc">
    
    <h4>Captions (Prerecorded)</h4>
    

--- a/guidelines/sc/20/change-on-request.html
+++ b/guidelines/sc/20/change-on-request.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="change-on-request" class="sc">
    
    <h4>Change on Request</h4>
    

--- a/guidelines/sc/20/consistent-identification.html
+++ b/guidelines/sc/20/consistent-identification.html
@@ -1,5 +1,5 @@
-<section class="sc">
-   
+<section id="consistent-identification" class="sc">
+
    <h4>Consistent Identification</h4>
    
    <p class="conformance-level">AA</p>

--- a/guidelines/sc/20/consistent-navigation.html
+++ b/guidelines/sc/20/consistent-navigation.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="consistent-navigation" class="sc">
    
    <h4>Consistent Navigation</h4>
    

--- a/guidelines/sc/20/contrast-enhanced.html
+++ b/guidelines/sc/20/contrast-enhanced.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="contrast-enhanced" class="sc">
    
    <h4>Contrast (Enhanced)</h4>
    

--- a/guidelines/sc/20/contrast-minimum.html
+++ b/guidelines/sc/20/contrast-minimum.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="contrast-minimum" class="sc">
    
    <h4>Contrast (Minimum)</h4>
    

--- a/guidelines/sc/20/error-identification.html
+++ b/guidelines/sc/20/error-identification.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="error-identification" class="sc">
    
    <h4>Error Identification</h4>
    

--- a/guidelines/sc/20/error-prevention-all.html
+++ b/guidelines/sc/20/error-prevention-all.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="error-prevention-all" class="sc">
    
    <h4>Error Prevention (All)</h4>
    

--- a/guidelines/sc/20/error-prevention-legal-financial-data.html
+++ b/guidelines/sc/20/error-prevention-legal-financial-data.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="error-prevention-legal-financial-data" class="sc">
    
    <h4>Error Prevention (Legal, Financial, Data)</h4>
    

--- a/guidelines/sc/20/error-suggestion.html
+++ b/guidelines/sc/20/error-suggestion.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="error-suggestion" class="sc">
    
    <h4>Error Suggestion</h4>
    

--- a/guidelines/sc/20/extended-audio-description-prerecorded.html
+++ b/guidelines/sc/20/extended-audio-description-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="extended-audio-description-prerecorded" class="sc">
    
    <h4>Extended Audio Description (Prerecorded)</h4>
    

--- a/guidelines/sc/20/focus-order.html
+++ b/guidelines/sc/20/focus-order.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="focus-order" class="sc">
    
    <h4>Focus Order</h4>
    

--- a/guidelines/sc/20/focus-visible.html
+++ b/guidelines/sc/20/focus-visible.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="focus-visible" class="sc">
    
    <h4>Focus Visible</h4>
    

--- a/guidelines/sc/20/headings-and-labels.html
+++ b/guidelines/sc/20/headings-and-labels.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="headings-and-labels" class="sc">
    
    <h4>Headings and Labels</h4>
    

--- a/guidelines/sc/20/help.html
+++ b/guidelines/sc/20/help.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="help" class="sc">
    
    <h4>Help</h4>
    

--- a/guidelines/sc/20/images-of-text-no-exception.html
+++ b/guidelines/sc/20/images-of-text-no-exception.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="images-of-text-no-exception" class="sc">
    
    <h4>Images of Text (No Exception)</h4>
    

--- a/guidelines/sc/20/images-of-text.html
+++ b/guidelines/sc/20/images-of-text.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="images-of-text" class="sc">
    
    <h4>Images of Text</h4>
    

--- a/guidelines/sc/20/info-and-relationships.html
+++ b/guidelines/sc/20/info-and-relationships.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="info-and-relationships" class="sc">
    
    <h4>Info and Relationships</h4>
    

--- a/guidelines/sc/20/interruptions.html
+++ b/guidelines/sc/20/interruptions.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="interruptions" class="sc">
    
    <h4>Interruptions</h4>
    

--- a/guidelines/sc/20/keyboard-no-exception.html
+++ b/guidelines/sc/20/keyboard-no-exception.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="keyboard-no-exception" class="sc">
    
    <h4>Keyboard (No Exception)</h4>
    

--- a/guidelines/sc/20/keyboard.html
+++ b/guidelines/sc/20/keyboard.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="keyboard" class="sc">
    
    <h4>Keyboard</h4>
    

--- a/guidelines/sc/20/labels-or-instructions.html
+++ b/guidelines/sc/20/labels-or-instructions.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="labels-or-instructions" class="sc">
    
    <h4>Labels or Instructions</h4>
    

--- a/guidelines/sc/20/language-of-page.html
+++ b/guidelines/sc/20/language-of-page.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="language-of-page" class="sc">
    
    <h4>Language of Page</h4>
    

--- a/guidelines/sc/20/language-of-parts.html
+++ b/guidelines/sc/20/language-of-parts.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="language-of-parts" class="sc">
    
    <h4>Language of Parts</h4>
    

--- a/guidelines/sc/20/link-purpose-in-context.html
+++ b/guidelines/sc/20/link-purpose-in-context.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="link-purpose-in-context" class="sc">
    
    <h4>Link Purpose (In Context)</h4>
    

--- a/guidelines/sc/20/link-purpose-link-only.html
+++ b/guidelines/sc/20/link-purpose-link-only.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="link-purpose-link-only" class="sc">
    
    <h4>Link Purpose (Link Only)</h4>
    

--- a/guidelines/sc/20/location.html
+++ b/guidelines/sc/20/location.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="location" class="sc">
    
    <h4>Location</h4>
    

--- a/guidelines/sc/20/low-or-no-background-audio.html
+++ b/guidelines/sc/20/low-or-no-background-audio.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="low-or-no-background-audio" class="sc">
    
    <h4>Low or No Background Audio</h4>
    

--- a/guidelines/sc/20/meaningful-sequence.html
+++ b/guidelines/sc/20/meaningful-sequence.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="meaningful-sequence" class="sc">
    
    <h4>Meaningful Sequence</h4>
    

--- a/guidelines/sc/20/media-alternative-prerecorded.html
+++ b/guidelines/sc/20/media-alternative-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="media-alternative-prerecorded" class="sc">
    
    <h4>Media Alternative (Prerecorded)</h4>
    

--- a/guidelines/sc/20/multiple-ways.html
+++ b/guidelines/sc/20/multiple-ways.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="multiple-ways" class="sc">
    
    <h4>Multiple Ways</h4>
    

--- a/guidelines/sc/20/name-role-value.html
+++ b/guidelines/sc/20/name-role-value.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="name-role-value" class="sc">
    
    <h4>Name, Role, Value</h4>
    

--- a/guidelines/sc/20/no-keyboard-trap.html
+++ b/guidelines/sc/20/no-keyboard-trap.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="no-keyboard-trap" class="sc">
    
    <h4>No Keyboard Trap</h4>
    

--- a/guidelines/sc/20/no-timing.html
+++ b/guidelines/sc/20/no-timing.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="no-timing" class="sc">
    
    <h4>No Timing</h4>
    

--- a/guidelines/sc/20/non-text-content.html
+++ b/guidelines/sc/20/non-text-content.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="non-text-content" class="sc">
    
    <h4>Non-text Content</h4>
    

--- a/guidelines/sc/20/on-focus.html
+++ b/guidelines/sc/20/on-focus.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="on-focus" class="sc">
    
    <h4>On Focus</h4>
    

--- a/guidelines/sc/20/on-input.html
+++ b/guidelines/sc/20/on-input.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="on-input" class="sc">
    
    <h4>On Input</h4>
    

--- a/guidelines/sc/20/page-titled.html
+++ b/guidelines/sc/20/page-titled.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="page-titled" class="sc">
    
    <h4>Page Titled</h4>
    

--- a/guidelines/sc/20/parsing.html
+++ b/guidelines/sc/20/parsing.html
@@ -1,4 +1,4 @@
-<section class="sc" id="parsing">
+<section id="parsing" class="sc" id="parsing">
    
    <h4>Parsing (Obsolete and removed)</h4>
 

--- a/guidelines/sc/20/pause-stop-hide.html
+++ b/guidelines/sc/20/pause-stop-hide.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="pause-stop-hide" class="sc">
    
    <h4>Pause, Stop, Hide</h4>
    

--- a/guidelines/sc/20/pronunciation.html
+++ b/guidelines/sc/20/pronunciation.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="pronunciation" class="sc">
    
    <h4>Pronunciation</h4>
    

--- a/guidelines/sc/20/re-authenticating.html
+++ b/guidelines/sc/20/re-authenticating.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="re-authenticating" class="sc">
    
    <h4>Re-authenticating</h4>
    

--- a/guidelines/sc/20/reading-level.html
+++ b/guidelines/sc/20/reading-level.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="" class="sc">
    
    <h4>Reading Level</h4>
    

--- a/guidelines/sc/20/reading-level.html
+++ b/guidelines/sc/20/reading-level.html
@@ -1,4 +1,4 @@
-<section id="" class="sc">
+<section id="reading-level" class="sc">
    
    <h4>Reading Level</h4>
    

--- a/guidelines/sc/20/resize-text.html
+++ b/guidelines/sc/20/resize-text.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="resize-text" class="sc">
    
    <h4>Resize Text</h4>
    

--- a/guidelines/sc/20/section-headings.html
+++ b/guidelines/sc/20/section-headings.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="section-headings" class="sc">
    
    <h4>Section Headings</h4>
    

--- a/guidelines/sc/20/sensory-characteristics.html
+++ b/guidelines/sc/20/sensory-characteristics.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="sensory-characteristics" class="sc">
    
    <h4>Sensory Characteristics</h4>
    

--- a/guidelines/sc/20/sign-language-prerecorded.html
+++ b/guidelines/sc/20/sign-language-prerecorded.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id=sign-language-prerecorded" class="sc">
    
    <h4>Sign Language (Prerecorded)</h4>
    

--- a/guidelines/sc/20/three-flashes-or-below-threshold.html
+++ b/guidelines/sc/20/three-flashes-or-below-threshold.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="three-flashes-or-below-threshold" class="sc">
    
    <h4>Three Flashes or Below Threshold</h4>
    

--- a/guidelines/sc/20/three-flashes.html
+++ b/guidelines/sc/20/three-flashes.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="three-flashes" class="sc">
    
    <h4>Three Flashes</h4>
    

--- a/guidelines/sc/20/timing-adjustable.html
+++ b/guidelines/sc/20/timing-adjustable.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="timing-adjustable" class="sc">
    
    <h4>Timing Adjustable</h4>
    

--- a/guidelines/sc/20/unusual-words.html
+++ b/guidelines/sc/20/unusual-words.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="unusual-words" class="sc">
    
    <h4>Unusual Words</h4>
    

--- a/guidelines/sc/20/use-of-color.html
+++ b/guidelines/sc/20/use-of-color.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="use-of-color" class="sc">
    
    <h4>Use of Color</h4>
    

--- a/guidelines/sc/20/visual-presentation.html
+++ b/guidelines/sc/20/visual-presentation.html
@@ -1,5 +1,5 @@
-<section class="sc">
-   
+<section id="visual-presentation" class="sc">
+
    <h4>Visual Presentation</h4>
    
    <p class="conformance-level">AAA</p>

--- a/guidelines/sc/21/animation-from-interactions.html
+++ b/guidelines/sc/21/animation-from-interactions.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="animation-from-interactions" class="sc">
    					
    <h4>Animation from Interactions</h4>
    					

--- a/guidelines/sc/21/change-of-content.html
+++ b/guidelines/sc/21/change-of-content.html
@@ -1,4 +1,4 @@
-<section id="" class="sc">
+<section id="change-of-content" class="sc">
    					
    <h4>Change of Content</h4>
    					

--- a/guidelines/sc/21/change-of-content.html
+++ b/guidelines/sc/21/change-of-content.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="" class="sc">
    					
    <h4>Change of Content</h4>
    					

--- a/guidelines/sc/21/character-key-shortcuts.html
+++ b/guidelines/sc/21/character-key-shortcuts.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="character-key-shortcuts" class="sc">
    					
    <h4>Character Key Shortcuts</h4>
    					

--- a/guidelines/sc/21/concurrent-input-mechanisms.html
+++ b/guidelines/sc/21/concurrent-input-mechanisms.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="concurrent-input-mechanisms" class="sc">
    <h4>Concurrent Input Mechanisms</h4>
    <p class="conformance-level">AAA</p>
   <p>Web content does not restrict use of input modalities available on a platform except where the restriction is <a>essential</a>, required to ensure the security of the content, or required to respect user settings.</p>   					

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -1,5 +1,5 @@
-    <section class="sc">
-   					
+    <section id="content-on-hover-or-focus" class="sc">
+
    <h4>Content on Hover or Focus</h4>
    					
    <p class="conformance-level">AA</p>

--- a/guidelines/sc/21/identify-input-purpose.html
+++ b/guidelines/sc/21/identify-input-purpose.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="identify-input-purpose" class="sc">
 	
 	<h4>Identify Input Purpose</h4>
 	

--- a/guidelines/sc/21/identify-purpose.html
+++ b/guidelines/sc/21/identify-purpose.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="identify-purpose" class="sc">
    					
    <h4>Identify Purpose</h4>
    					

--- a/guidelines/sc/21/label-in-name.html
+++ b/guidelines/sc/21/label-in-name.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="label-in-name" class="sc">
    <h4>Label in Name</h4>
    <p class="conformance-level">A</p>
 	

--- a/guidelines/sc/21/motion-actuation.html
+++ b/guidelines/sc/21/motion-actuation.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="motion-actuation" class="sc">
    					
    <h4>Motion Actuation</h4>
   

--- a/guidelines/sc/21/non-text-contrast.html
+++ b/guidelines/sc/21/non-text-contrast.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="non-text-contrast" class="sc">
    					
    <h4>Non-text Contrast</h4>
    					

--- a/guidelines/sc/21/orientation.html
+++ b/guidelines/sc/21/orientation.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="orientation" class="sc">
    					
    <h4>Orientation</h4>
    					

--- a/guidelines/sc/21/pointer-cancellation.html
+++ b/guidelines/sc/21/pointer-cancellation.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="pointer-cancellation" class="sc">
    					
    <h4>Pointer Cancellation</h4>
    					

--- a/guidelines/sc/21/pointer-gestures.html
+++ b/guidelines/sc/21/pointer-gestures.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="pointer-gestures" class="sc">
    					
    <h4>Pointer Gestures</h4>
    					

--- a/guidelines/sc/21/reflow.html
+++ b/guidelines/sc/21/reflow.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="reflow" class="sc">
    					
    <h4>Reflow</h4>
    					

--- a/guidelines/sc/21/status-messages.html
+++ b/guidelines/sc/21/status-messages.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="status-messages" class="sc">
    					
    <h4>Status Messages</h4>
    					

--- a/guidelines/sc/21/target-size-enhanced.html
+++ b/guidelines/sc/21/target-size-enhanced.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="target-size-enhanced" class="sc">
    					
    <h4>Target Size (Enhanced)</h4>
    					

--- a/guidelines/sc/21/text-spacing.html
+++ b/guidelines/sc/21/text-spacing.html
@@ -1,4 +1,4 @@
- <section class="sc">
+ <section id="text-spacing" class="sc">
    					
    <h4>Text Spacing</h4>
    					

--- a/guidelines/sc/21/timeouts.html
+++ b/guidelines/sc/21/timeouts.html
@@ -1,4 +1,4 @@
-<section class="sc">
+<section id="timeouts" class="sc">
    					
    <h4>Timeouts</h4>
    					

--- a/guidelines/sc/22/accessible-authentication-enhanced.html
+++ b/guidelines/sc/22/accessible-authentication-enhanced.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="accessible-authentication-enhanced" class="sc new">
    
     <h4>Accessible Authentication (Enhanced)</h4>
     

--- a/guidelines/sc/22/accessible-authentication-minimum.html
+++ b/guidelines/sc/22/accessible-authentication-minimum.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="accessible-authentication-minimum" class="sc new">
    
     <h4>Accessible Authentication (Minimum)</h4>
     

--- a/guidelines/sc/22/consistent-help.html
+++ b/guidelines/sc/22/consistent-help.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="consistent-help" class="sc new">
    
     <h4>Consistent Help</h4>
     

--- a/guidelines/sc/22/dragging-movements.html
+++ b/guidelines/sc/22/dragging-movements.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="dragging-movements" class="sc new">
    
     <h4>Dragging Movements</h4>
     

--- a/guidelines/sc/22/focus-appearance.html
+++ b/guidelines/sc/22/focus-appearance.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="focus-appearance" class="sc new">
    
     <h4>Focus Appearance</h4>
     

--- a/guidelines/sc/22/focus-not-obscured-enhanced.html
+++ b/guidelines/sc/22/focus-not-obscured-enhanced.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="focus-not-obscured-enhanced" class="sc new">
    
     <h4>Focus Not Obscured (Enhanced)</h4>
     

--- a/guidelines/sc/22/focus-not-obscured-minimum.html
+++ b/guidelines/sc/22/focus-not-obscured-minimum.html
@@ -1,4 +1,4 @@
- <section class="sc new">
+ <section id="focus-not-obscured-minimum" class="sc new">
    
     <h4>Focus Not Obscured (Minimum)</h4>
     

--- a/guidelines/sc/22/redundant-entry.html
+++ b/guidelines/sc/22/redundant-entry.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="redundant-entry" class="sc new">
    
     <h4>Redundant Entry</h4>
     

--- a/guidelines/sc/22/target-size-minimum.html
+++ b/guidelines/sc/22/target-size-minimum.html
@@ -1,4 +1,4 @@
-<section class="sc new">
+<section id="target-size-minimum" class="sc new">
    
     <h4>Target Size (Minimum)</h4>
     

--- a/guidelines/terms/20/abbreviation.html
+++ b/guidelines/terms/20/abbreviation.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="abbreviations">abbreviation</dfn></dt>
+<dt><dfn id="dfn-abbreviations" data-lt="abbreviations">abbreviation</dfn></dt>
 <dd>
    
    <p>shortened form of a word, phrase, or name where the abbreviation has not become part

--- a/guidelines/terms/20/accessibility-supported.html
+++ b/guidelines/terms/20/accessibility-supported.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="accessibility-supported|accessibility support">accessibility supported</dfn></dt>
+<dt><dfn id="dfn-accessibility-supported" data-lt="accessibility-supported|accessibility support">accessibility supported</dfn></dt>
 <dd>
    
    <p>supported by users' <a>assistive technologies</a> as well as the accessibility features in browsers and other <a>user agents</a></p>

--- a/guidelines/terms/20/alternative-for-time-based-media.html
+++ b/guidelines/terms/20/alternative-for-time-based-media.html
@@ -1,4 +1,4 @@
-<dt><dfn>alternative for time-based media</dfn></dt>
+<dt><dfn id="dfn-alternative-for-time-based-media">alternative for time-based media</dfn></dt>
 <dd>
    
    <p>document including correctly sequenced text descriptions of time-based visual and

--- a/guidelines/terms/20/ambiguous-to-users-in-general.html
+++ b/guidelines/terms/20/ambiguous-to-users-in-general.html
@@ -1,4 +1,4 @@
-<dt><dfn>ambiguous to users in general</dfn></dt>
+<dt><dfn id="dfn-ambiguous-to-users-in-general">ambiguous to users in general</dfn></dt>
 <dd>
    
    <p>the purpose cannot be determined from the link and all information of the Web page

--- a/guidelines/terms/20/ascii-art.html
+++ b/guidelines/terms/20/ascii-art.html
@@ -1,4 +1,4 @@
-<dt><dfn>ASCII art</dfn></dt>
+<dt><dfn id="dfn-ascii-art">ASCII art</dfn></dt>
 <dd>
    
    <p>picture created by a spatial arrangement of characters or glyphs (typically from the

--- a/guidelines/terms/20/assistive-technology.html
+++ b/guidelines/terms/20/assistive-technology.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="assistive technologies">assistive technology</dfn> (as used in this document)
+<dt><dfn id="dfn-assistive-technologies" data-lt="assistive technologies">assistive technology</dfn> (as used in this document)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/audio-description.html
+++ b/guidelines/terms/20/audio-description.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="audio descriptions">audio description</dfn></dt>
+<dt><dfn id="dfn-audio-descriptions" data-lt="audio descriptions">audio description</dfn></dt>
 <dd>
    
    <p>narration added to the soundtrack to describe important visual details that cannot

--- a/guidelines/terms/20/audio-only.html
+++ b/guidelines/terms/20/audio-only.html
@@ -1,4 +1,4 @@
-<dt><dfn>audio-only</dfn></dt>
+<dt><dfn id="dfn-audio-only">audio-only</dfn></dt>
 <dd>
    
    <p>a time-based presentation that contains only <a>audio</a> (no <a>video</a> and no interaction)

--- a/guidelines/terms/20/audio.html
+++ b/guidelines/terms/20/audio.html
@@ -1,4 +1,4 @@
-<dt><dfn>audio</dfn></dt>
+<dt><dfn id="dfn-audio">audio</dfn></dt>
 <dd>
    
    <p>the technology of sound reproduction</p>

--- a/guidelines/terms/20/blinking.html
+++ b/guidelines/terms/20/blinking.html
@@ -1,4 +1,4 @@
-<dt><dfn>blinking</dfn></dt>
+<dt><dfn id="dfn-blinking">blinking</dfn></dt>
 <dd>
    
    <p>switch back and forth between two visual states in a way that is meant to draw attention</p>

--- a/guidelines/terms/20/blocks-of-text.html
+++ b/guidelines/terms/20/blocks-of-text.html
@@ -1,4 +1,4 @@
-<dt><dfn>blocks of text</dfn></dt>
+<dt><dfn id="dfn-blocks-of-text">blocks of text</dfn></dt>
 <dd>
    
    <p>more than one sentence of text</p>

--- a/guidelines/terms/20/captcha.html
+++ b/guidelines/terms/20/captcha.html
@@ -1,4 +1,4 @@
-<dt><dfn>CAPTCHA</dfn></dt>
+<dt><dfn id="dfn-captcha">CAPTCHA</dfn></dt>
 <dd>
    
    <p>initialism for "Completely Automated Public Turing test to tell Computers and Humans

--- a/guidelines/terms/20/captions.html
+++ b/guidelines/terms/20/captions.html
@@ -1,4 +1,4 @@
-<dt><dfn>captions</dfn></dt>
+<dt><dfn id="dfn-captions">captions</dfn></dt>
 <dd>
    
    <p>synchronized visual and/or <a>text alternative</a> for both speech and non-speech audio information needed to understand the media content

--- a/guidelines/terms/20/changes-of-context.html
+++ b/guidelines/terms/20/changes-of-context.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="change of context">changes of context</dfn></dt>
+<dt><dfn id="dfn-change-of-context" data-lt="change of context">changes of context</dfn></dt>
 <dd>
    
    <p>major changes that, if made without user awareness, can disorient users who are not able to view

--- a/guidelines/terms/20/conformance.html
+++ b/guidelines/terms/20/conformance.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="conform">conformance</dfn></dt>
+<dt><dfn id="dfn-conform" data-lt="conform">conformance</dfn></dt>
 <dd>
    
    <p>satisfying all the requirements of a given standard, guideline or specification</p>

--- a/guidelines/terms/20/conforming-alternate-version.html
+++ b/guidelines/terms/20/conforming-alternate-version.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="conforming alternate versions">conforming alternate version</dfn></dt>
+<dt><dfn id="dfn-conforming-alternate-versions" data-lt="conforming alternate versions">conforming alternate version</dfn></dt>
 <dd>
    
    <p>version that</p>

--- a/guidelines/terms/20/content.html
+++ b/guidelines/terms/20/content.html
@@ -1,4 +1,4 @@
-<dt><dfn>content</dfn> (Web content)
+<dt><dfn id="dfn-content">content</dfn> (Web content)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/context-sensitive-help.html
+++ b/guidelines/terms/20/context-sensitive-help.html
@@ -1,4 +1,4 @@
-<dt><dfn>context-sensitive help</dfn></dt>
+<dt><dfn id="dfn-context-sensitive-help">context-sensitive help</dfn></dt>
 <dd>
    
    <p>help text that provides information related to the function currently being performed</p>

--- a/guidelines/terms/20/contrast-ratio.html
+++ b/guidelines/terms/20/contrast-ratio.html
@@ -1,4 +1,4 @@
-<dt><dfn>contrast ratio</dfn></dt>
+<dt><dfn id="dfn-contrast-ratio">contrast ratio</dfn></dt>
 <dd>
    
    <p>(L1 + 0.05) / (L2 + 0.05), where</p>

--- a/guidelines/terms/20/correct-reading-sequence.html
+++ b/guidelines/terms/20/correct-reading-sequence.html
@@ -1,4 +1,4 @@
-<dt><dfn>correct reading sequence</dfn></dt>
+<dt><dfn id="dfn-correct-reading-sequence">correct reading sequence</dfn></dt>
 <dd>
    
    <p>any sequence where words and paragraphs are presented in an order that does not change

--- a/guidelines/terms/20/emergency.html
+++ b/guidelines/terms/20/emergency.html
@@ -1,4 +1,4 @@
-<dt><dfn>emergency</dfn></dt>
+<dt><dfn id="dfn-emergency">emergency</dfn></dt>
 <dd>
    
    <p>a sudden, unexpected situation or occurrence that requires immediate action to preserve

--- a/guidelines/terms/20/essential.html
+++ b/guidelines/terms/20/essential.html
@@ -1,4 +1,4 @@
-<dt><dfn>essential</dfn></dt>
+<dt><dfn id="dfn-essential">essential</dfn></dt>
 <dd>
    					
    <p>if removed, would fundamentally change the information or functionality of the content,

--- a/guidelines/terms/20/extended-audio-description.html
+++ b/guidelines/terms/20/extended-audio-description.html
@@ -1,4 +1,4 @@
-<dt><dfn>extended audio description</dfn></dt>
+<dt><dfn id="dfn-extended-audio-description">extended audio description</dfn></dt>
 <dd>
    
    <p>audio description that is added to an audiovisual presentation by pausing the <a>video</a> so that there is time to add additional description

--- a/guidelines/terms/20/flash.html
+++ b/guidelines/terms/20/flash.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="flashes">flash</dfn></dt>
+<dt><dfn id="dfn-flashes" data-lt="flashes">flash</dfn></dt>
 <dd>
    
    <p>a pair of opposing changes in <a>relative luminance</a> that can cause seizures in some people if it is large enough and in the right frequency

--- a/guidelines/terms/20/functionality.html
+++ b/guidelines/terms/20/functionality.html
@@ -1,4 +1,4 @@
-<dt><dfn>functionality</dfn></dt>
+<dt><dfn id="dfn-functionality">functionality</dfn></dt>
 <dd>
    
    <p><a>processes</a> and outcomes achievable through user action

--- a/guidelines/terms/20/general-flash-and-red-flash-thresholds.html
+++ b/guidelines/terms/20/general-flash-and-red-flash-thresholds.html
@@ -1,4 +1,4 @@
-<dt><dfn>general flash and red flash thresholds</dfn></dt>
+<dt><dfn id="dfn-general-flash-and-red-flash-thresholds">general flash and red flash thresholds</dfn></dt>
 <dd>
    
    <p>a <a>flash</a> or rapidly changing image sequence is below the threshold (i.e., content <strong>passes</strong>) if any of the following are true:

--- a/guidelines/terms/20/human-language.html
+++ b/guidelines/terms/20/human-language.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="human language(s)">human language</dfn></dt>
+<dt><dfn id="dfn-human-language-s" data-lt="human language(s)">human language</dfn></dt>
 <dd>
    
    <p>language that is spoken, written or signed (through visual or tactile means) to communicate

--- a/guidelines/terms/20/idiom.html
+++ b/guidelines/terms/20/idiom.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="idioms">idiom</dfn></dt>
+<dt><dfn id="dfn-idioms" data-lt="idioms">idiom</dfn></dt>
 <dd>
    
    <p>phrase whose meaning cannot be deduced from the meaning of the individual words and

--- a/guidelines/terms/20/image-of-text.html
+++ b/guidelines/terms/20/image-of-text.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="images of text">image of text</dfn></dt>
+<dt><dfn id="dfn-images-of-text" data-lt="images of text">image of text</dfn></dt>
 <dd>
    
    <p>text that has been rendered in a non-text form (e.g., an image) in order to achieve

--- a/guidelines/terms/20/informative.html
+++ b/guidelines/terms/20/informative.html
@@ -1,4 +1,4 @@
-<dt><dfn>informative</dfn></dt>
+<dt><dfn id="dfn-informative">informative</dfn></dt>
 <dd>
    
    <p>for information purposes and not required for conformance</p>

--- a/guidelines/terms/20/input-error.html
+++ b/guidelines/terms/20/input-error.html
@@ -1,4 +1,4 @@
-<dt><dfn>input error</dfn></dt>
+<dt><dfn id="dfn-input-error">input error</dfn></dt>
 <dd>
    
    <p>information provided by the user that is not accepted</p>

--- a/guidelines/terms/20/jargon.html
+++ b/guidelines/terms/20/jargon.html
@@ -1,4 +1,4 @@
-<dt><dfn>jargon</dfn></dt>
+<dt><dfn id="dfn-jargon">jargon</dfn></dt>
 <dd>
    
    <p>words used in a particular way by people in a particular field</p>

--- a/guidelines/terms/20/keyboard-interface.html
+++ b/guidelines/terms/20/keyboard-interface.html
@@ -1,4 +1,4 @@
-<dt><dfn>keyboard interface</dfn></dt>
+<dt><dfn id="dfn-keyboard-interface">keyboard interface</dfn></dt>
 <dd>
    
    <p>interface used by software to obtain keystroke input</p>

--- a/guidelines/terms/20/label.html
+++ b/guidelines/terms/20/label.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="labels">label</dfn></dt>
+<dt><dfn id="dfn-labels" data-lt="labels">label</dfn></dt>
 <dd>
    
    <p><a>text</a> or other component with a <a>text alternative</a> that is presented to a user to identify a component within Web <a>content</a></p>

--- a/guidelines/terms/20/large-scale.html
+++ b/guidelines/terms/20/large-scale.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="large-scale">large scale</dfn> (text)
+<dt><dfn id="dfn-large-scale" data-lt="large-scale">large scale</dfn> (text)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/legal-commitments.html
+++ b/guidelines/terms/20/legal-commitments.html
@@ -1,4 +1,4 @@
-<dt><dfn>legal commitments</dfn></dt>
+<dt><dfn id="dfn-legal-commitments">legal commitments</dfn></dt>
 <dd>
    
    <p>transactions where the person incurs a legally binding obligation or benefit</p>

--- a/guidelines/terms/20/link-purpose.html
+++ b/guidelines/terms/20/link-purpose.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="purpose of each link">link purpose</dfn></dt>
+<dt><dfn id="" data-lt="purpose of each link">link purpose</dfn></dt>
 <dd>
    
    <p>nature of the result obtained by activating a hyperlink</p>

--- a/guidelines/terms/20/link-purpose.html
+++ b/guidelines/terms/20/link-purpose.html
@@ -1,4 +1,4 @@
-<dt><dfn id="" data-lt="purpose of each link">link purpose</dfn></dt>
+<dt><dfn id="dfn-purpose-of-each-link" data-lt="purpose of each link">link purpose</dfn></dt>
 <dd>
    
    <p>nature of the result obtained by activating a hyperlink</p>

--- a/guidelines/terms/20/live.html
+++ b/guidelines/terms/20/live.html
@@ -1,4 +1,4 @@
-<dt><dfn>live</dfn></dt>
+<dt><dfn id="dfn-live">live</dfn></dt>
 <dd>
    
    <p>information captured from a real-world event and transmitted to the receiver with

--- a/guidelines/terms/20/lower-secondary-education-level.html
+++ b/guidelines/terms/20/lower-secondary-education-level.html
@@ -1,4 +1,4 @@
-<dt><dfn>lower secondary education level</dfn></dt>
+<dt><dfn id="dfn-lower-secondary-education-level">lower secondary education level</dfn></dt>
 <dd>
    
    <p>the two or three year period of education that begins after completion of six years

--- a/guidelines/terms/20/mechanism.html
+++ b/guidelines/terms/20/mechanism.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="mechanisms">mechanism</dfn></dt>
+<dt><dfn id="dfn-mechanism" data-lt="mechanisms">mechanism</dfn></dt>
 <dd>
    
    <p><a>process</a> or technique for achieving a result

--- a/guidelines/terms/20/media-alternative-for-text.html
+++ b/guidelines/terms/20/media-alternative-for-text.html
@@ -1,4 +1,4 @@
-<dt><dfn>media alternative for text</dfn></dt>
+<dt><dfn id="dfn-media-alternative-for-text">media alternative for text</dfn></dt>
 <dd>
    
    <p>media that presents no more information than is already presented in text (directly

--- a/guidelines/terms/20/name.html
+++ b/guidelines/terms/20/name.html
@@ -1,4 +1,4 @@
-<dt><dfn>name</dfn></dt>
+<dt><dfn id="dfn-name">name</dfn></dt>
 <dd>
    
    <p>text by which software can identify a component within Web content to the user</p>

--- a/guidelines/terms/20/navigated-sequentially.html
+++ b/guidelines/terms/20/navigated-sequentially.html
@@ -1,4 +1,4 @@
-<dt><dfn>navigated sequentially</dfn></dt>
+<dt><dfn id="dfn-navigated-sequentially">navigated sequentially</dfn></dt>
 <dd>
    
    <p>navigated in the order defined for advancing focus (from one element to the next)

--- a/guidelines/terms/20/non-text-content.html
+++ b/guidelines/terms/20/non-text-content.html
@@ -1,4 +1,4 @@
-<dt><dfn>non-text content</dfn></dt>
+<dt><dfn id="dfn-non-text-content">non-text content</dfn></dt>
 <dd>
    
    <p>any content that is not a sequence of characters that can be <a>programmatically determined</a> or where the sequence is not expressing something in <a>human language</a></p>

--- a/guidelines/terms/20/normative.html
+++ b/guidelines/terms/20/normative.html
@@ -1,4 +1,4 @@
-<dt><dfn>normative</dfn></dt>
+<dt><dfn id="dfn-normative">normative</dfn></dt>
 <dd>
    
    <p>required for conformance</p>

--- a/guidelines/terms/20/on-a-full-screen-window.html
+++ b/guidelines/terms/20/on-a-full-screen-window.html
@@ -1,4 +1,4 @@
-<dt><dfn>on a full-screen window</dfn></dt>
+<dt><dfn id="dfn-on-a-full-screen-window">on a full-screen window</dfn></dt>
 <dd>
    
    <p>on the most common sized desktop/laptop display with the viewport maximized</p>

--- a/guidelines/terms/20/paused.html
+++ b/guidelines/terms/20/paused.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="pause">paused</dfn></dt>
+<dt><dfn id="dfn-pause" data-lt="pause">paused</dfn></dt>
 <dd>
    
    <p>stopped by user request and not resumed until requested by user</p>

--- a/guidelines/terms/20/prerecorded.html
+++ b/guidelines/terms/20/prerecorded.html
@@ -1,4 +1,4 @@
-<dt><dfn>prerecorded</dfn></dt>
+<dt><dfn id="dfn-prerecorded">prerecorded</dfn></dt>
 <dd>
    
    <p>information that is not <a>live</a></p>

--- a/guidelines/terms/20/presentation.html
+++ b/guidelines/terms/20/presentation.html
@@ -1,4 +1,4 @@
-<dt><dfn>presentation</dfn></dt>
+<dt><dfn id="dfn-presentation">presentation</dfn></dt>
 <dd>
    
    <p>rendering of the <a>content</a> in a form to be perceived by users

--- a/guidelines/terms/20/primary-education-level.html
+++ b/guidelines/terms/20/primary-education-level.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="primary education">primary education level</dfn></dt>
+<dt><dfn id="dfn-primary-education" data-lt="primary education">primary education level</dfn></dt>
 <dd>
    
    <p>six year time period that begins between the ages of five and seven, possibly without

--- a/guidelines/terms/20/process.html
+++ b/guidelines/terms/20/process.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="processes">process</dfn></dt>
+<dt><dfn id="dfn-processes" data-lt="processes">process</dfn></dt>
 <dd>
    
    <p>series of user actions where each action is required in order to complete an activity</p>

--- a/guidelines/terms/20/programmatically-determined-link-context.html
+++ b/guidelines/terms/20/programmatically-determined-link-context.html
@@ -1,4 +1,4 @@
-<dt><dfn>programmatically determined link context</dfn></dt>
+<dt><dfn id="dfn-programmatically-determined-link-context">programmatically determined link context</dfn></dt>
 <dd>
    
    <p>additional information that can be <a>programmatically determined</a> from <a>relationships</a> with a link, combined with the link text, and presented to users in different modalities

--- a/guidelines/terms/20/programmatically-determined.html
+++ b/guidelines/terms/20/programmatically-determined.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="programmatically determinable">programmatically determined</dfn> (programmatically determinable)
+<dt><dfn id=dfn-programmatically-determinable" data-lt="programmatically determinable">programmatically determined</dfn> (programmatically determinable)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/programmatically-determined.html
+++ b/guidelines/terms/20/programmatically-determined.html
@@ -1,4 +1,4 @@
-<dt><dfn id=dfn-programmatically-determinable" data-lt="programmatically determinable">programmatically determined</dfn> (programmatically determinable)
+<dt><dfn id="dfn-programmatically-determinable" data-lt="programmatically determinable">programmatically determined</dfn> (programmatically determinable)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/programmatically-set.html
+++ b/guidelines/terms/20/programmatically-set.html
@@ -1,4 +1,4 @@
-<dt><dfn>programmatically set</dfn></dt>
+<dt><dfn id="dfn-programmatically-set">programmatically set</dfn></dt>
 <dd>
    
    <p>set by software using methods that are supported by user agents, including assistive

--- a/guidelines/terms/20/pure-decoration.html
+++ b/guidelines/terms/20/pure-decoration.html
@@ -1,4 +1,4 @@
-<dt><dfn>pure decoration</dfn></dt>
+<dt><dfn id="">pure decoration</dfn></dt>
 <dd>
    
    <p>serving only an aesthetic purpose, providing no information, and having no functionality</p>

--- a/guidelines/terms/20/pure-decoration.html
+++ b/guidelines/terms/20/pure-decoration.html
@@ -1,4 +1,4 @@
-<dt><dfn id="">pure decoration</dfn></dt>
+<dt><dfn id="dfn-pure-decoration">pure decoration</dfn></dt>
 <dd>
    
    <p>serving only an aesthetic purpose, providing no information, and having no functionality</p>

--- a/guidelines/terms/20/real-time-event.html
+++ b/guidelines/terms/20/real-time-event.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="real-time events">real-time event</dfn></dt>
+<dt><dfn id="dfn-real-time-events" data-lt="real-time events">real-time event</dfn></dt>
 <dd>
    
    <p>event that a) occurs at the same time as the viewing and b) is not completely generated

--- a/guidelines/terms/20/relationships.html
+++ b/guidelines/terms/20/relationships.html
@@ -1,4 +1,4 @@
-<dt><dfn>relationships</dfn></dt>
+<dt><dfn id="dfn-relationships">relationships</dfn></dt>
 <dd>
    
    <p>meaningful associations between distinct pieces of content</p>

--- a/guidelines/terms/20/relative-luminance.html
+++ b/guidelines/terms/20/relative-luminance.html
@@ -1,4 +1,4 @@
-<dt><dfn>relative luminance</dfn></dt>
+<dt><dfn id="dfn-relative-luminance">relative luminance</dfn></dt>
 <dd>
    
    <p>the relative brightness of any point in a colorspace, normalized to 0 for darkest

--- a/guidelines/terms/20/relied-upon.html
+++ b/guidelines/terms/20/relied-upon.html
@@ -1,4 +1,4 @@
-<dt><dfn>relied upon</dfn> (technologies that are)
+<dt><dfn id="dfn-relied-upon">relied upon</dfn> (technologies that are)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/role.html
+++ b/guidelines/terms/20/role.html
@@ -1,4 +1,4 @@
-<dt><dfn>role</dfn></dt>
+<dt><dfn id="dfn-role">role</dfn></dt>
 <dd>
    
    <p>text or number by which software can identify the function of a component within Web

--- a/guidelines/terms/20/same-functionality.html
+++ b/guidelines/terms/20/same-functionality.html
@@ -1,4 +1,4 @@
-<dt><dfn>same functionality</dfn></dt>
+<dt><dfn id="dfn-same-functionality">same functionality</dfn></dt>
 <dd>
    
    <p>same result when used</p>

--- a/guidelines/terms/20/same-relative-order.html
+++ b/guidelines/terms/20/same-relative-order.html
@@ -1,4 +1,4 @@
-<dt><dfn>same relative order</dfn></dt>
+<dt><dfn id="dfn-same-relative-order">same relative order</dfn></dt>
 <dd>
    
    <p>same position relative to other items</p>

--- a/guidelines/terms/20/satisfies-a-success-criterion.html
+++ b/guidelines/terms/20/satisfies-a-success-criterion.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="satisfies">satisfies a success criterion</dfn></dt>
+<dt><dfn id="dfn-satisfies" data-lt="satisfies">satisfies a success criterion</dfn></dt>
 <dd>
    
    <p>the success criterion does not evaluate to 'false' when applied to the page</p>

--- a/guidelines/terms/20/section.html
+++ b/guidelines/terms/20/section.html
@@ -1,4 +1,4 @@
-<dt><dfn>section</dfn></dt>
+<dt><dfn id="dfn-section">section</dfn></dt>
 <dd>
    
    <p>a self-contained portion of written content that deals with one or more related topics

--- a/guidelines/terms/20/set-of-web-pages.html
+++ b/guidelines/terms/20/set-of-web-pages.html
@@ -1,4 +1,4 @@
-<dt><dfn>set of Web pages</dfn></dt>
+<dt><dfn id="dfn-set-of-web-pages">set of Web pages</dfn></dt>
 <dd>
    
    <p>collection of <a>Web pages</a> that share a common purpose and that are created by the same author, group or organization.</p>

--- a/guidelines/terms/20/sign-language-interpretation.html
+++ b/guidelines/terms/20/sign-language-interpretation.html
@@ -1,4 +1,4 @@
-<dt><dfn>sign language interpretation</dfn></dt>
+<dt><dfn id="dfn-sign-language-interpretation">sign language interpretation</dfn></dt>
 <dd>
    
    <p>translation of one language, generally a spoken language, into a <a>sign language</a></p>

--- a/guidelines/terms/20/sign-language.html
+++ b/guidelines/terms/20/sign-language.html
@@ -1,4 +1,4 @@
-<dt><dfn>sign language</dfn></dt>
+<dt><dfn id="dfn-sign-language">sign language</dfn></dt>
 <dd>
    
    <p>a language using combinations of movements of the hands and arms, facial expressions,

--- a/guidelines/terms/20/specific-sensory-experience.html
+++ b/guidelines/terms/20/specific-sensory-experience.html
@@ -1,4 +1,4 @@
-<dt><dfn>specific sensory experience</dfn></dt>
+<dt><dfn id="dfn-specific-sensory-experience">specific sensory experience</dfn></dt>
 <dd>
    
    <p>a sensory experience that is not purely decorative and does not primarily convey important

--- a/guidelines/terms/20/structure.html
+++ b/guidelines/terms/20/structure.html
@@ -1,4 +1,4 @@
-<dt><dfn>structure</dfn></dt>
+<dt><dfn id="dfn-structure">structure</dfn></dt>
 <dd>
    
    <ol>

--- a/guidelines/terms/20/supplemental-content.html
+++ b/guidelines/terms/20/supplemental-content.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="supplementary content">supplemental content</dfn></dt>
+<dt><dfn id="dfn-supplementary-content" data-lt="supplementary content">supplemental content</dfn></dt>
 <dd>
    
    <p>additional <a>content</a> that illustrates or clarifies the primary content

--- a/guidelines/terms/20/synchronized-media.html
+++ b/guidelines/terms/20/synchronized-media.html
@@ -1,4 +1,4 @@
-<dt><dfn>synchronized media</dfn></dt>
+<dt><dfn id="dfn-synchronized-media">synchronized media</dfn></dt>
 <dd>
    
    <p><a>audio</a> or <a>video</a> synchronized with another format for presenting information and/or with time-based

--- a/guidelines/terms/20/technology.html
+++ b/guidelines/terms/20/technology.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="technologies|web technology|web content technology|web content technologies">technology</dfn> (Web content)
+<dt><dfn id="dfn-technologies" data-lt="technologies|web technology|web content technology|web content technologies">technology</dfn> (Web content)
 </dt>
 <dd>
    

--- a/guidelines/terms/20/text-alternative.html
+++ b/guidelines/terms/20/text-alternative.html
@@ -1,4 +1,4 @@
-<dt><dfn>text alternative</dfn></dt>
+<dt><dfn id="dfn-text-alternative">text alternative</dfn></dt>
 <dd>
    
    <p><a>Text</a> that is programmatically associated with <a>non-text content</a> or referred to from text that is programmatically associated with non-text content.

--- a/guidelines/terms/20/text.html
+++ b/guidelines/terms/20/text.html
@@ -1,4 +1,4 @@
-<dt><dfn>text</dfn></dt>
+<dt><dfn id="dfn-text">text</dfn></dt>
 <dd>
    
    <p>sequence of characters that can be <a>programmatically determined</a>, where the sequence is expressing something in <a>human language</a></p>

--- a/guidelines/terms/20/used-in-an-unusual-or-restricted-way.html
+++ b/guidelines/terms/20/used-in-an-unusual-or-restricted-way.html
@@ -1,4 +1,4 @@
-<dt><dfn>used in an unusual or restricted way</dfn></dt>
+<dt><dfn id="dfn-used-in-an-unusual-or-restricted-way">used in an unusual or restricted way</dfn></dt>
 <dd>
    
    <p>words used in such a way that requires users to know exactly which definition to apply

--- a/guidelines/terms/20/user-agent.html
+++ b/guidelines/terms/20/user-agent.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="user agents">user agent</dfn></dt>
+<dt><dfn id="dfn-user-agents" data-lt="user agents">user agent</dfn></dt>
 <dd>
    
    <p>any software that retrieves and presents Web content for users</p>

--- a/guidelines/terms/20/user-controllable.html
+++ b/guidelines/terms/20/user-controllable.html
@@ -1,4 +1,4 @@
-<dt><dfn>user-controllable</dfn></dt>
+<dt><dfn id="dfn-user-controllable">user-controllable</dfn></dt>
 <dd>
    
    <p>data that is intended to be accessed by users</p>

--- a/guidelines/terms/20/user-interface-component.html
+++ b/guidelines/terms/20/user-interface-component.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="user interface components">user interface component</dfn></dt>
+<dt><dfn id="dfn-user-interface-components" data-lt="user interface components">user interface component</dfn></dt>
 <dd>
    
    <p>a part of the content that is perceived by users as a single control for a distinct

--- a/guidelines/terms/20/video-only.html
+++ b/guidelines/terms/20/video-only.html
@@ -1,4 +1,4 @@
-<dt><dfn>video-only</dfn></dt>
+<dt><dfn id="dfn-video-only">video-only</dfn></dt>
 <dd>
    
    <p>a time-based presentation that contains only <a>video</a> (no <a>audio</a> and no interaction)

--- a/guidelines/terms/20/video.html
+++ b/guidelines/terms/20/video.html
@@ -1,4 +1,4 @@
-<dt><dfn>video</dfn></dt>
+<dt><dfn id="dfn-video">video</dfn></dt>
 <dd>
    
    <p>the technology of moving or sequenced pictures or images</p>

--- a/guidelines/terms/20/viewport.html
+++ b/guidelines/terms/20/viewport.html
@@ -1,4 +1,4 @@
-<dt><dfn>viewport</dfn></dt>
+<dt><dfn id="dfn-viewport">viewport</dfn></dt>
 <dd>
    
    <p>object in which the user agent presents content</p>

--- a/guidelines/terms/20/visually-customized.html
+++ b/guidelines/terms/20/visually-customized.html
@@ -1,4 +1,4 @@
-<dt><dfn>visually customized</dfn></dt>
+<dt><dfn id="dfn-visually-customized">visually customized</dfn></dt>
 <dd>
    
    <p>the font, size, color, and background can be set</p>

--- a/guidelines/terms/20/web-page.html
+++ b/guidelines/terms/20/web-page.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="web page(s)|web pages">Web page</dfn></dt>
+<dt><dfn id="dfn-web-page-s" data-lt="web page(s)|web pages">Web page</dfn></dt>
 <dd>
    
    <p>a non-embedded resource obtained from a single URI using HTTP plus any other resources

--- a/guidelines/terms/21/css-pixel.html
+++ b/guidelines/terms/21/css-pixel.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="CSS pixels">CSS pixel</dfn></dt>
+<dt><dfn id="dfn-css-pixels" data-lt="CSS pixels">CSS pixel</dfn></dt>
 <dd>
    					
    <p>visual angle of about 0.0213 degrees</p>

--- a/guidelines/terms/21/down-event.html
+++ b/guidelines/terms/21/down-event.html
@@ -1,4 +1,4 @@
-<dt><dfn>down-event</dfn></dt>
+<dt><dfn id="dfn-down-event">down-event</dfn></dt>
 <dd>
   <p>platform event that occurs  when the trigger stimulus of a pointer is depressed</p>
 	<p>The down-event may have different names on different platforms, such as "touchstart" or "mousedown".</p>

--- a/guidelines/terms/21/keyboard-shortcut.html
+++ b/guidelines/terms/21/keyboard-shortcut.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="keyboard shortcuts">keyboard shortcut</dfn></dt>
+<dt><dfn id="dfn-keyboard-shortcuts" data-lt="keyboard shortcuts">keyboard shortcut</dfn></dt>
 <dd>
    					
    <p>alternative means of triggering an action by the pressing of one or more keys</p>

--- a/guidelines/terms/21/motion-animation.html
+++ b/guidelines/terms/21/motion-animation.html
@@ -1,4 +1,4 @@
-<dt><dfn>motion animation</dfn></dt>
+<dt><dfn id="dfn-motion-animation">motion animation</dfn></dt>
 <dd>
    					
    <p>addition of steps between conditions to create the illusion of movement or to give a sense of a smooth transition</p>

--- a/guidelines/terms/21/pointer-input.html
+++ b/guidelines/terms/21/pointer-input.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="pointer inputs">pointer input</dfn></dt>
+<dt><dfn id="dfn-pointer-inputs" data-lt="pointer inputs">pointer input</dfn></dt>
 <dd>
    					
    <p>input from a device that can target a specific coordinate (or set of coordinates) on a screen,

--- a/guidelines/terms/21/region.html
+++ b/guidelines/terms/21/region.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="regions">region</dfn></dt>
+<dt><dfn id="dfn-regions" data-lt="regions">region</dfn></dt>
 <dd>
   <p>perceivable, programmatically determined section of content</p>
   <p class="note">In HTML, any area designated with a landmark role would be a region.</p>

--- a/guidelines/terms/21/set-of-web-pages.html
+++ b/guidelines/terms/21/set-of-web-pages.html
@@ -1,4 +1,4 @@
-<dt><dfn>set of web pages</dfn></dt>
+<dt><dfn id="dfn-set-of-web-pages">set of web pages</dfn></dt>
 <dd>
    
    <p>collection of <a>web pages</a> that share a common purpose and that are created by the same author, group or organization

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,4 +1,4 @@
-<dt><dfn>single pointer</dfn></dt>
+<dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
    	
    <p>pointer input that operates with one point of contact with the screen, including single taps and clicks, double-taps and clicks, long presses, and path-based gestures</p>

--- a/guidelines/terms/21/state.html
+++ b/guidelines/terms/21/state.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="states">state</dfn></dt>
+<dt><dfn id="dfn-states" data-lt="states">state</dfn></dt>
 <dd>
    					
    <p>dynamic property expressing characteristics of a user interface component that may change in response to user action or automated processes</p>

--- a/guidelines/terms/21/status-message.html
+++ b/guidelines/terms/21/status-message.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="status messages">status message</dfn></dt>
+<dt><dfn id="dfn-status-messages" data-lt="status messages">status message</dfn></dt>
 <dd>
    					
    <p>change in content that is not a <a>change of context</a>, and that provides information to the user on the success or results of an action, on the waiting state of an application, on the progress of a process, or on the existence of errors</p>

--- a/guidelines/terms/21/style-property.html
+++ b/guidelines/terms/21/style-property.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="style properties">style property</dfn></dt>
+<dt><dfn id="dfn-style-properties" data-lt="style properties">style property</dfn></dt>
   <dd>
   <p>property whose value determines the presentation (e.g. font, color, size, location, padding, volume, synthesized speech prosody) of
  content elements as they are rendered (e.g. onscreen, via loudspeaker, via braille display) by user agents</p>

--- a/guidelines/terms/21/target.html
+++ b/guidelines/terms/21/target.html
@@ -1,4 +1,4 @@
-<dt><dfn data-lt="targets">target</dfn></dt>
+<dt><dfn id="dfn-targets" data-lt="targets">target</dfn></dt>
 <dd>
    					
      <p>region of the display that will accept a pointer action, such as the interactive area of a user interface component</p> 

--- a/guidelines/terms/21/up-event.html
+++ b/guidelines/terms/21/up-event.html
@@ -1,4 +1,4 @@
-<dt><dfn>up-event</dfn></dt>
+<dt><dfn id="dfn-up-event">up-event</dfn></dt>
 <dd>
   <p>platform event that occurs  when the trigger stimulus of a pointer is released</p>
 	<p>The up-event may have different names on different platforms, such as "touchend" or "mouseup".</p>

--- a/guidelines/terms/21/user-inactivity.html
+++ b/guidelines/terms/21/user-inactivity.html
@@ -1,4 +1,4 @@
-<dt><dfn>user inactivity</dfn></dt>
+<dt><dfn id="dfn-user-inactivity">user inactivity</dfn></dt>
 <dd>
   <p>any continuous period of time where no user actions occur</p>
 	<p>The method of tracking will be determined by the web site or application.</p>

--- a/guidelines/terms/22/cognitive-function-test.html
+++ b/guidelines/terms/22/cognitive-function-test.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn data-lt="cognitive function test">Cognitive function test</dfn></dt>
+<dt class="new"><dfn id="dfn-cognitive-function-test" data-lt="cognitive function test">Cognitive function test</dfn></dt>
 <dd class="new">
    					
    <p class="change">New</p>

--- a/guidelines/terms/22/dragging-movement.html
+++ b/guidelines/terms/22/dragging-movement.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn data-lt="dragging movements">dragging movement</dfn></dt>
+<dt class="new"><dfn id="dfn-dragging-movements" data-lt="dragging movements">dragging movement</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>
    					

--- a/guidelines/terms/22/encloses.html
+++ b/guidelines/terms/22/encloses.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn data-lt="enclose">encloses</dfn></dt>
+<dt class="new"><dfn id="dfn-enclose" data-lt="enclose">encloses</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>
    					

--- a/guidelines/terms/22/focus-indicator.html
+++ b/guidelines/terms/22/focus-indicator.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn>focus indicator</dfn></dt>
+<dt class="new"><dfn id="dfn-focus-indicator">focus indicator</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>	
 

--- a/guidelines/terms/22/minimum-bounding-box.html
+++ b/guidelines/terms/22/minimum-bounding-box.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn data-lt="bounding boxes|bounding box">minimum bounding box</dfn></dt>
+<dt class="new"><dfn id="dfn-bounding-boxes" data-lt="bounding boxes|bounding box">minimum bounding box</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>	
    <p>the smallest enclosing rectangle aligned to the horizontal axis within which all the points of a shape lie. For components which wrap onto multiple lines as part of a sentence or block of text (such as hypertext links), the bounding box is based on how the component would appear on a single line.</p>

--- a/guidelines/terms/22/perimeter.html
+++ b/guidelines/terms/22/perimeter.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn>perimeter</dfn></dt>
+<dt class="new"><dfn id="dfn-perimeter">perimeter</dfn></dt>
 <dd class="new">
 	<p class="change">New</p>	
    <p>continuous line forming the boundary of a shape not including shared pixels, or the <a>minimum bounding box</a>, whichever is shortest.</p>


### PR DESCRIPTION
### Current Issue:

By default:
- ReSpec uses heading's text content to generate IDs. See https://respec.org/docs/#custom-heading-ids
- Sections are automatically numbered and uniquely id's. See https://respec.org/docs/#sections
- IDs for glossary entries (`dfn` elements) are generated based on description term (or `data-lt` value when existing)

Therefore, when main headings, guidelines headings and definitions terms are translated in another language, IDs also change. 

Issues include:
- That does not work properly for non-latin characters. For example, for Simplified Chinese headings, automatically created IDs are `generatedID`, `generatedID-0`, etc.
- Translations checks are more difficult when IDs differ from the original version.
- Restoring the English IDs after exporting to HTML is very tedious.

### Proposed Solution:

Stable IDs are manually added to main headings, guidelines headings and definition terms, so that they are not overwritten by ReSpec during translation.

In this pull request, I have used the currently generated IDs from the live original version.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/remibetin/wcag/pull/3620.html" title="Last updated on Jan 11, 2024, 1:00 PM UTC (81818c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3620/cf3d2fb...remibetin:81818c5.html" title="Last updated on Jan 11, 2024, 1:00 PM UTC (81818c5)">Diff</a>