### PR TITLE
Change "video description" to "audio description" in 1.2.1 understanding

### DIFF
--- a/understanding/20/audio-only-and-video-only-prerecorded.html
+++ b/understanding/20/audio-only-and-video-only-prerecorded.html
@@ -43,7 +43,7 @@
       <div class="note">
          
          <p>A text equivalent is not required for audio that is provided as an equivalent for
-            video with no audio information.  For example, it is not required to caption video
+            video with no audio information.  For example, it is not required to caption audio
             description that is provided as an alternative to a silent movie.
          </p>
          


### PR DESCRIPTION
for consistency/to avoid confusion

Closes https://github.com/w3c/wcag/issues/3621