### PR TITLE
Anti-aliasing notes for 1.4.3, 1.4.6, 1.4.11 understanding docs (more strict proposal)

### DIFF
--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -86,7 +86,7 @@
             Criterion, but the text as-rendered has a much lower contrast in practice and fails the Success Criterion.
          </p>
          <p>In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
-            or to aim for a foreground/background color combination that exceeds the normative requirements
+            or to aim for a foreground and background color combination that exceeds the normative requirements
             of this Success Criterion.
          </p>
       </div>

--- a/understanding/20/contrast-enhanced.html
+++ b/understanding/20/contrast-enhanced.html
@@ -73,13 +73,19 @@
       </div>
 
       <div class="note">
-         <p>Because authors do not have control over user settings for font smoothing/anti-aliasing, when evaluating this
-            Success Criterion, refer to the foreground and background colors obtained from the user agent, or the underlying
-            markup and stylesheets, rather than the text as presented on screen.</p>
-         <p>Due to anti-aliasing, particularly thin or unusual fonts may be rendered by user agents with a much fainter
-            color than the actual text color defined in the underlying CSS. This can lead to situations where text has
-            a contrast ratio that nominally passes the Success Criterion, but has a much lower contrast in practice.
-            In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
+         <p>User agents which render text will often apply anti-aliasing, font smoothing, and other techniques
+            which can cause some pixels of text to render in fainter colors than those specified by authors.
+            When evaluating this Success Criterion, this is usually not relevant; as long as the applied font,
+            size, and weight ensure that some pixel of each character reaches the author-specified color, evaluators
+            may refer to the foreground and background colors obtained from the user agent, or the underlying
+            markup and stylesheets, rather than evaluating individual pixels within the text as presented on screen.
+         </p>
+         <p>However, particularly thin, small, or unusual fonts may be rendered by user agents with a much fainter
+            color than the actual text color defined in the underlying markup and stylesheets. This can lead to
+            situations where a user agent reports that text has a contrast ratio that nominally passes the Success
+            Criterion, but the text as-rendered has a much lower contrast in practice and fails the Success Criterion.
+         </p>
+         <p>In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
             or to aim for a foreground/background color combination that exceeds the normative requirements
             of this Success Criterion.
          </p>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -80,9 +80,9 @@
             markup and stylesheets, rather than evaluating individual pixels within the text as presented on screen.
          </p>
          <p>However, particularly thin, small, or unusual fonts may be rendered by user agents with a much fainter
-            color than the actual text color defined in the underlying CSS. This can lead to situations where a
-            user agent reports that text has a contrast ratio that nominally passes the Success Criterion, but
-            the text as-rendered has a much lower contrast in practice and fails the Success Criterion.
+            color than the actual text color defined in the underlying markup and stylesheets. This can lead to
+            situations where a user agent reports that text has a contrast ratio that nominally passes the Success
+            Criterion, but the text as-rendered has a much lower contrast in practice and fails the Success Criterion.
          </p>
          <p>In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
             or to aim for a foreground/background color combination that exceeds the normative requirements

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -72,13 +72,19 @@
       </div>
       
       <div class="note">
-         <p>Because authors do not have control over user settings for font smoothing/anti-aliasing, when evaluating this
-            Success Criterion, refer to the foreground and background colors obtained from the user agent, or the underlying
-            markup and stylesheets, rather than the text as presented on screen.</p>
-         <p>Due to anti-aliasing, particularly thin or unusual fonts may be rendered by user agents with a much fainter
-            color than the actual text color defined in the underlying CSS. This can lead to situations where text has
-            a contrast ratio that nominally passes the Success Criterion, but has a much lower contrast in practice.
-            In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
+         <p>User agents which render text will often apply anti-aliasing, font smoothing, and other techniques
+            which can cause some pixels of text to render in fainter colors than those specified by authors.
+            When evaluating this Success Criterion, this is usually not relevant; as long as the applied font,
+            size, and weight ensure that some pixel of each character reaches the author-specified color, evaluators
+            may refer to the foreground and background colors obtained from the user agent, or the underlying
+            markup and stylesheets, rather than evaluating individual pixels within the text as presented on screen.
+         </p>
+         <p>However, particularly thin, small, or unusual fonts may be rendered by user agents with a much fainter
+            color than the actual text color defined in the underlying CSS. This can lead to situations where a
+            user agent reports that text has a contrast ratio that nominally passes the Success Criterion, but
+            the text as-rendered has a much lower contrast in practice and fails the Success Criterion.
+         </p>
+         <p>In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
             or to aim for a foreground/background color combination that exceeds the normative requirements
             of this Success Criterion.
          </p>

--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -84,7 +84,7 @@
             situations where a user agent reports that text has a contrast ratio that nominally passes the Success
             Criterion, but the text as-rendered has a much lower contrast in practice and fails the Success Criterion.
          </p>
-         <p>In these cases, best practice would be for authors to choose a font with stronger/thicker lines,
+         <p>In these cases, best practice would be for authors to choose a font with stronger or thicker lines,
             or to aim for a foreground/background color combination that exceeds the normative requirements
             of this Success Criterion.
          </p>

--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -29,6 +29,16 @@
 				<p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed values should not be rounded (e.g. 2.999:1 would not meet the 3:1 threshold).</p>
 			</div>
 
+			<div class="note">
+				<p>User agents which render non-text content may apply anti-aliasing, shadow blending, and other techniques which can cause some pixels of the content to render in fainter colors than those specified by authors. When an author uses markup or stylesheets to specify that a particular bit of content should be a specific color, as long as the some area of the content reaches the author-specified color, evaluators may refer to the foreground and background colors obtained from the user agent, or the underlying markup and stylesheets, rather than evaluating individual pixels within the text as presented on screen.</p>
+
+				<p>For example, if an author uses CSS to specify that a circular button's border should be a specific shade of blue, evaluators may refer to the markup-specified color even though most user agents will apply anti-aliasing when rendering a circular button, as long as some area of the border is actually rendered at that specific color.</p>
+
+				<p>However, some authoring techniques can result in components or graphics which user agents will render using much fainter colors than the colors defined in underlying markup and stylesheets. This can lead to situations where a user agent reports that content has a contrast ratio that nominally passes the Success Criterion, but the content as-rendered has a much lower contrast in practice and fails the Success Criterion.</p>
+
+				<p>In these cases, best practice would be for authors to choose an technique which guarantees that the user agent will render the content with a contrast ratio that meets the Success Criterion. For example, an author seeking to use a line drawn around a button to meet this Success Criterion might choose to use a CSS <code>border</code> or <code>outline</code> property, rather than a CSS <code>box-shadow</code> property; most user agents will attempt to render fractional pixels of a shadow using fainter colors, but will not use this technique to render fractional pixels of a border or outline.</p>
+		 </div>
+
 			<section id="user-interface-components">
 				<h3>User Interface Components</h3>
 


### PR DESCRIPTION
Followup from today's TF discussion (see https://github.com/w3c/wcag/pull/3560#issuecomment-1924263718)

This is a more strict variation of the notes added in #3020 and #3560. I think this addresses @WilcoFiers 's [concerns in this comment](https://github.com/w3c/wcag/pull/3560#pullrequestreview-1856237319).

I think this version is more consistent with [this ACT rule that AGWG approved](https://www.w3.org/WAI/standards-guidelines/act/rules/afw4f7/), but maybe concerning that it seems more strict than what "NOTE 2" in the [contrast ratio definition](https://www.w3.org/TR/WCAG22/#dfn-contrast-ratio) suggests.