### PR TITLE
Update broken link, remove double link in F47

### DIFF
--- a/techniques/failures/F47.html
+++ b/techniques/failures/F47.html
@@ -33,10 +33,7 @@
       
          <ul>
             <li> 
-                  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blink">Mozilla Developer Network: &lt;blink&gt;</a> 
-               </li>
-            <li> 
-                  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blink">Mozilla Developer Network: text-decoration</a> 
+                  <a href="https://en.wikipedia.org/wiki/Blink_element">Wikipedia: Blink element</a> 
                </li>
          </ul>
       


### PR DESCRIPTION
MDN no longer has a page on the blink element, replacing it with a link to Wikipedia for historical reference. 

The second link went to the same place, also removed that as it was redundant.