### PR TITLE
Add clarification regarding specific pages within a set of web pages that lack a help mechanism

### DIFF
--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -34,6 +34,8 @@
 
          <p>Without help, some users may abandon the task. They may also fail to correctly complete a task, or they may require assistance from people who do not necessarily keep private information secure.</p>
 
+         <p>While it is ideal and recommended to consistently implement a help mechanism across a set of web pages, the Success Criterion 3.2.6 specifically pertains to pages that do include such a mechanism. Therefore, the absence of a help mechanism on certain pages within a set does not constitute a violation of 3.2.6.</p>
+
          <section id="limitations">
             <h3>Limitations and Exceptions</h3>
 

--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -34,7 +34,7 @@
 
          <p>Without help, some users may abandon the task. They may also fail to correctly complete a task, or they may require assistance from people who do not necessarily keep private information secure.</p>
 
-         <p>While it is ideal and recommended to consistently implement a help mechanism across a set of web pages, the success criterion 3.2.6 specifically pertains to pages that do include such a mechanism. Therefore, the absence of a help mechanism on certain pages within a set does not constitute a violation of 3.2.6.</p>
+         <p>While it is recommended to consistently implement a help mechanism across a set of web pages, this criterion specifically pertains to pages that do include such a mechanism. Therefore, the absence of a help mechanism on certain pages within a set does not constitute a violation.</p>
 
          <section id="limitations">
             <h3>Limitations and Exceptions</h3>

--- a/understanding/22/consistent-help.html
+++ b/understanding/22/consistent-help.html
@@ -34,7 +34,7 @@
 
          <p>Without help, some users may abandon the task. They may also fail to correctly complete a task, or they may require assistance from people who do not necessarily keep private information secure.</p>
 
-         <p>While it is ideal and recommended to consistently implement a help mechanism across a set of web pages, the Success Criterion 3.2.6 specifically pertains to pages that do include such a mechanism. Therefore, the absence of a help mechanism on certain pages within a set does not constitute a violation of 3.2.6.</p>
+         <p>While it is ideal and recommended to consistently implement a help mechanism across a set of web pages, the success criterion 3.2.6 specifically pertains to pages that do include such a mechanism. Therefore, the absence of a help mechanism on certain pages within a set does not constitute a violation of 3.2.6.</p>
 
          <section id="limitations">
             <h3>Limitations and Exceptions</h3>


### PR DESCRIPTION
Closes: #3683

This PR clarifies that if certain pages within a set of web pages featuring a help mechanism lack said mechanism, it does not constitute a violation of guideline 3.2.6, as this criterion specifically pertains to pages that do include a help mechanism.