### PR TITLE
Remove stray quotation mark

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -480,7 +480,7 @@
                     <p>Conformance claims are <strong>not required</strong>. Authors can conform to WCAG 2.2 without making a claim. However, if a conformance claim is made, then the conformance claim <strong>must</strong> include the following information:</p>
                     <ol>
                         <li><strong>Date</strong> of the claim</li>
-                        <li><strong>Guidelines title, version and URI </strong> "Web Content Accessibility Guidelines 2.2 at <a href="https://www.w3.org/TR/WCAG22/">https://www.w3.org/TR/WCAG22/</a>"</li>
+                        <li><strong>Guidelines title, version and URI </strong> "Web Content Accessibility Guidelines 2.2 at <a href="https://www.w3.org/TR/WCAG22/">https://www.w3.org/TR/WCAG22/</a></li>
                         <li><strong>Conformance level</strong> satisfied: (Level A, AA or AAA)</li>
                         <li>
                             <p><strong>A concise description of the Web pages</strong>, such as a list of URIs for which the claim is made, including whether subdomains are included in the claim.</p>


### PR DESCRIPTION
Closes #1340

Removes stray " after WCAG 2.2 URL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3760.html" title="Last updated on Mar 26, 2024, 5:41 PM UTC (05e0a3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3760/bf44269...05e0a3c.html" title="Last updated on Mar 26, 2024, 5:41 PM UTC (05e0a3c)">Diff</a>