### PR TITLE
Fixed url typo for see also audio-only live

### DIFF
--- a/understanding/20/audio-only-and-video-only-prerecorded.html
+++ b/understanding/20/audio-only-and-video-only-prerecorded.html
@@ -50,7 +50,7 @@
       </div>
       
       <p>See also 
-         <a href="audio-only-live">1.2.4: Audio-only (Live)</a>
+         <a href="audio-only-live">1.2.9: Audio-only (Live)</a>
          
       </p>
       


### PR DESCRIPTION
Closes #3323

Changed 1.2.4 to 1.2.9, did not need to change see also urls under SC1.2.3 as it is updated aready for WCAG22 webpage.