### PR TITLE
Expand video fix to `#examples video`

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -375,6 +375,8 @@ margin-left:.8em;
 margin-right:.8em;
 }
 
-.example video {
+.example video,
+#examples video
+{
     max-width: 100%;
 }


### PR DESCRIPTION
Follow-up to https://github.com/w3c/wcag/pull/3115

Closes https://github.com/w3c/wcag/issues/3793 (and all the previous issues about this, the fix in #3115 seems to have been partial/incorrect)