### PR TITLE
Update usability glossary deep link

### DIFF
--- a/techniques/general/G63.html
+++ b/techniques/general/G63.html
@@ -52,7 +52,7 @@
       
          <ul>
             <li>
-                  <a href="http://www.usabilityfirst.com/glossary/?function=display_term&amp;term_id=193">Usability Glossary: sitemap</a>
+                  <a href="https://www.usabilityfirst.com/glossary/sitemap/">Usability Glossary: sitemap</a>
                 </li>
          </ul>
       


### PR DESCRIPTION
Closes #3127

Link was leading to a glossary page but not the specific term.