### PR TITLE
Updated Page Titled for better links

### DIFF
--- a/understanding/20/page-titled.html
+++ b/understanding/20/page-titled.html
@@ -98,12 +98,10 @@
                that it will be displayed in the title bar of the user agent.</dd>
          <dt>A document collection</dt>
          <dd>
-            <p>The title of <a href="./">Understanding WCAG 2.1 </a>
-               is "Understanding WCAG 2.1."</p>
+            <p>The title of <a href="./">Understanding WCAG 2.2</a> is "Understanding WCAG 2.2".</p>
             <ul>
-               <li>The introduction page has the title "Introduction to Understanding WCAG 2.0."</li>
-               <li>Major sections of the document are pages titled "Understanding Guideline X" and "Understanding
-                  Success Criterion X." 
+               <li>The <a href="../Understanding/intro">Introduction to Understanding WCAG</a> page has the title "Introduction to Understanding WCAG".</li>
+               <li>Major sections of the document collection are pages titled "Understanding Guideline X" and "Understanding Success Criterion X." 
                </li>
                <li>Appendix A has the title "Glossary."</li>
                <li>Appendix B has the title "Acknowledgements."</li>

--- a/understanding/20/page-titled.html
+++ b/understanding/20/page-titled.html
@@ -102,7 +102,6 @@
             <ul>
                <li>The <a href="../Understanding/intro">Introduction to Understanding WCAG</a> page has the title "Introduction to Understanding WCAG".</li>
                <li>Major sections of the document collection are pages titled "Understanding Guideline X" and "Understanding Success Criterion X." 
-               </li>
                <li>Appendix A has the title "Glossary."</li>
                <li>Appendix B has the title "Acknowledgements."</li>
                <li>Appendix C has the title "References."</li>

--- a/understanding/20/page-titled.html
+++ b/understanding/20/page-titled.html
@@ -101,7 +101,7 @@
             <p>The title of <a href="./">Understanding WCAG 2.2</a> is "Understanding WCAG 2.2".</p>
             <ul>
                <li>The <a href="../Understanding/intro">Introduction to Understanding WCAG</a> page has the title "Introduction to Understanding WCAG".</li>
-               <li>Major sections of the document collection are pages titled "Understanding Guideline X" and "Understanding Success Criterion X." 
+               <li>Major sections of the document collection are pages titled "Understanding Guideline X" and "Understanding Success Criterion X."</li>
                <li>Appendix A has the title "Glossary."</li>
                <li>Appendix B has the title "Acknowledgements."</li>
                <li>Appendix C has the title "References."</li>


### PR DESCRIPTION
1. updated the "document collection" Understanding link to say WCAG 2.2 instead of 2.1.
2. updated the quoted page title for the Introduction to WCAG page.
3. linked to Introduction to WCAG page.

Note: I don't understand the references to the appendices on the WCAG homepage. What do they have to do with page titles?