### PR TITLE
Tweak F55 to fix broken/partial link text

### DIFF
--- a/techniques/failures/F55.html
+++ b/techniques/failures/F55.html
@@ -2,17 +2,12 @@
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
-   <title>
-      Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is
-      received</title>
-   <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove">
-   </link>
+   <title>Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received</title>
+   <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove"/>
 </head>
 
 <body>
-   <h1>
-      Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is
-      received</h1>
+   <h1>Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received</h1>
    <section class="meta">
       <p class="id">ID: F55</p>
       <p class="technology">Technology: failures</p>


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/3866

(need to actually test that it does, but the fix here is the only reason I can think of why the link is shown as just "received" at the moment)