### PR TITLE
Update labels-or-instructions.html

### DIFF
--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -92,7 +92,7 @@
             correct abbreviation.
          </li>
          
-         <li>A field for entering a date contains initial text which indicates the correct format
+         <li>A field for entering a date is provided text instructions to indicate the correct format
             for the date.
          </li>
          

--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -92,7 +92,7 @@
             correct abbreviation.
          </li>
          
-         <li>A field for entering a date is provided text instructions to indicate the correct format
+         <li>A field for entering a date has text instructions to indicate the correct format
             for the date.
          </li>
          


### PR DESCRIPTION
closes #3887

clarifies that wcag is not recommending use of placeholder text, and instead recommends accompanying text to provide the information (which could then be part of label or description - but those details are not applicable to this SC so not specified in the update)

This helps better match [technique g89](https://www.w3.org/WAI/WCAG22/Techniques/general/G89.html) which includes the date format expectation as part of the label text