### PR TITLE
Editorial changes to Target Size Enhanced

### DIFF
--- a/understanding/21/target-size-enhanced.html
+++ b/understanding/21/target-size-enhanced.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8"/>
 		<title>Understanding Target Size (Enhanced)</title>
-		<link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
+		<link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove"/>
 	</head>
 	<body>
 		<h1>Understanding SC 2.5.5 Target Size (Enhanced)</h1>
@@ -31,11 +31,9 @@
       <p><strong>Equivalent targets:</strong> If there is more than one target on a screen that performs the same action, only one of the targets need to meet the target size of 44 by 44 CSS pixels.</p>
       <p><strong>Inline:</strong> Content displayed can often be reflowed based on the screen width available. This is known as responsive design and makes it easier to read since you do not need to scroll both horizontally and vertically. In reflowed content, the targets can appear anywhere on a line and can change position based on the width of the available screen. Since targets can appear anywhere on the line, the size cannot be larger than the available text and spacing between the sentences or paragraphs, otherwise the targets could overlap. It is for this reason targets which are contained within one or more sentences are excluded from the target size requirements.</p>
       <div class="note">
-        <div role="heading" class="note-title marker" aria-level="3">Note</div>
         <p>If the target is the full sentence and the sentence is not in a block of text, then the target needs to be at least 44 by 44 CSS pixels.</p>
       </div>
       <div class="note">
-        <div role="heading" class="note-title marker" aria-level="3">Note</div>
         <p>A footnote or an icon within or at the end of a sentence is considered to be part of a sentence and therefore are excluded from the minimum target size.</p>
       </div>
       <p><strong>User Agent Control:</strong> If the size of the target is not modified by the author through CSS or other size properties, then the target does not need to meet the target size of 44 by 44 CSS pixels.</p>
@@ -55,16 +53,23 @@
     </section>
   	<section id="examples">
   	  <h2>Examples</h2>
-      <ul>      
-        <li><strong>Example 1: Buttons</strong><br/> Three buttons are on-screen and the touch target area of each button is 44 by 44 CSS pixels.</li>
-        <li><strong>Example 2: Equivalent target</strong><br/> Multiple targets are provided on the page that perform the same function. One of the targets is 44 by 44 CSS pixels. The other targets do not have a minimum touch target of 44 by 44 CSS pixels.</li>
-        <li><strong>Example 3: Anchor Link</strong><br/> The target is an in-page link and the target is less than 44 by 44 CSS pixels.</li>
-        <li><strong>Example 4: Text Link in a paragraph</strong><br/> Links within a paragraph of text have varying touch target dimensions. Links within
-           paragraphs of text do no need to meet the 44 by 44 CSS pixels requirements.</li>
-        <li><strong>Example 5: Text Link in a sentence</strong><br/> A text link that is in a sentence is excluded and does not need to meet the 44 by 44 CSS pixel requirement. If the text link is the full sentence, then the text link target touch area does need to meet the 44 by 44 CSS pixels.</li>
-        <li><strong>Example 6: Footnote</strong><br/> A footnote link at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The footnote at the end of the sentence is considered to be part of the sentence.</li>
-        <li><strong>Example 7: Help icon</strong><br/> A help icon within or at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The icon at the end of the sentence is considered to be part of the sentence.</li>
-      </ul>
+      <dl>      
+        <dt>Example 1: Buttons</dt>
+        <dd>Three buttons are on-screen and the touch target area of each button is 44 by 44 CSS pixels.</dd>
+        <dt>Example 2: Equivalent target</dt>
+        <dd>Multiple targets are provided on the page that perform the same function. One of the targets is 44 by 44 CSS pixels. The other targets do not have a minimum touch target of 44 by 44 CSS pixels.</dd>
+        <dt>Example 3: Anchor Link</dt>
+        <dd>The target is an in-page link and the target is less than 44 by 44 CSS pixels.</dd>
+        <dt>Example 4: Text Link in a paragraph</dt>
+        <dd>Links within a paragraph of text have varying touch target dimensions. Links within
+           paragraphs of text do no need to meet the 44 by 44 CSS pixels requirements.</dd>
+        <dt>Example 5: Text Link in a sentence</dt>
+        <dd>A text link that is in a sentence is excluded and does not need to meet the 44 by 44 CSS pixel requirement. If the text link is the full sentence, then the text link target touch area does need to meet the 44 by 44 CSS pixels.</dd>
+        <dt>Example 6: Footnote</dt>
+        <dd>A footnote link at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The footnote at the end of the sentence is considered to be part of the sentence.</dd>
+        <dt>Example 7: Help icon</dt>
+        <dd>A help icon within or at the end of a sentence does not need to meet the 44 by 44 CSS pixels requirements. The icon at the end of the sentence is considered to be part of the sentence.</dd>
+      </dl>
     </section> 
     <section id="resources">
       <h2>Resources</h2>


### PR DESCRIPTION
1. Remove two `note-title-marker` elements that were adding extra “Note” headings to notes.
2. Change `ul` element to `dl`