### PR TITLE
Fix display of “New in WCAG 22” text

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This is a build file for Apache ant (http://ant.apache.org/). This has been tested with Ant 1.7. -->
 <project name="wcag" basedir="." default="usage">
-	
+
 	<description>Generate WCAG 2.1 and related documents</description>
-	
+
 	<!-- Load overriding properties -->
 	<xmlproperty file="build.properties" keeproot="false" semanticattributes="true"/>
-	
+
 	<!-- The following properties need to be set appropriately before doing a build - they should all be overridden by the above property file, but are kept here to serve as defaults -->
 	<property name="outputdir" location="." description="Directory within which the output folders are created, normally &quot;../YYYY&quot; unless doing TR in which case it is &quot;../../../TR/&lt;YYYY&gt;&quot;"/>
 	<property name="uri.prefix" value="file:///" description="Prefix if any that must be prepended to URIs to make it resolve on the platform"/>
-	<property name="guidelines.version" value="22" description="Which version of WCAG is being built"/>
+	<property name="guidelines.version" value="2.2" description="Which version of WCAG is being built"/>
 	<property name="w3ccvs.location" location="../../../w3ccvs"/>
-	
+
 	<property name="xslt.factory" value="net.sf.saxon.TransformerFactoryImpl" description="Class name of the XSLT transformer factory, which sets which XSLT engine to use; must be an XSLT 2.0 processor"/>
 	<property name="classpath.saxon" value="lib/saxon9he.jar" description="Path to Saxon jar in order to run XSLT 2.0"/>
-	
+
 	<!-- The following properties usually do not need to be adjusted -->
 	<property name="inputdir.guidelines" location="guidelines"/>
 	<property name="inputdir.understanding" location="understanding"/>
 	<property name="inputdir.techniques" location="techniques"/>
-	
+
 	<property name="outputdir.guidelines" location="${outputdir}/guidelines"/>
 	<property name="outputdir.understanding" location="${outputdir}/understanding"/>
 	<property name="outputdir.techniques" location="${outputdir}/techniques"/>
-	
+
 	<taskdef resource="net/sf/antcontrib/antcontrib.properties">
 		<classpath>
 			<pathelement location="lib/ant-contrib-0.6.jar" />
 		</classpath>
 	</taskdef>
-	
+
 	<target name="usage">
 		<echo level="info">Usage: &quot;ant &lt;target&gt;&quot; to execute a build task
 			Enter &quot;ant -projecthelp&quot; to get list of available build tasks</echo>
 	</target>
-	
+
 	<target name="init"></target>
-	
+
 	<target name="clean" description="Clean up any temp files">
 		<delete file="${inputdir.guidelines}/index-flat.html" failonerror="false"/>
 		<delete file="${inputdir.techniques}/index-flat.html" failonerror="false"/>
@@ -55,7 +55,7 @@
 		<delete dir="output" failonerror="false"/>
 		<delete dir="input" failonerror="false"/>
 	</target>
-	
+
 	<target name="flatten" depends="init" description="Build a copy of guidelines with all data-include files incorporated">
 		<makeurl file="${basedir}/guidelines/" property="base.guidelines"/>
 		<xslt in="${inputdir.guidelines}/index.html" out="${inputdir.guidelines}/index-flat.html" style="xslt/flatten-document.xslt">
@@ -64,14 +64,14 @@
 			<param name="base.dir" expression="${base.guidelines}"/>
 		</xslt>
 	</target>
-	
+
 	<target name="guidelines-xml" depends="flatten, guidelines-versions" description="Build an XML representation of the guidelines">
 		<xslt in="${inputdir.guidelines}/index-flat.html" out="${inputdir.guidelines}/wcag.xml" style="xslt/generate-structure-xml.xslt">
 			<classpath path="${classpath.saxon}"/>
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<target name="guidelines-versions" description="Create XML list of which WCAG version introduces which guidelines">
 		<local name="output.file"/>
 		<property name="output.file" value="${inputdir.guidelines}/versions.xml"/>
@@ -100,7 +100,7 @@
 		<echo file="${output.file}" append="yes"><![CDATA[</versions>
 ]]></echo>
 	</target>
-	
+
 	<target name="guidelines" depends="init">
 		<mkdir dir="output/guidelines/${guidelines.version}"/>
 		<copy file="css/base.css" todir="output/guidelines/${guidelines.version}"/>
@@ -115,7 +115,7 @@
 			<arg value="3"/>
 		</exec>
 	</target>
-	
+
 	<!-- Techniques -->
 	<target name="techniques-list" description="Create XML list of all the technique files">
 		<local name="output.file"/>
@@ -160,7 +160,7 @@
 		<echo file="${output.file}" append="yes"><![CDATA[</techniques>
 ]]></echo>
 	</target>
-	
+
 	<target name="techniques-association" depends="flatten, guidelines-xml, guidelines-versions" description="Build an XML structure of all techniques">
 		<makeurl file="${basedir}/techniques" property="techniques.dir"/>
 		<makeurl file="${basedir}/understanding" property="understanding.dir"/>
@@ -171,7 +171,7 @@
 			<param name="understanding.dir" expression="${understanding.dir}"/>
 		</xslt>
 	</target>
-	
+
 	<target name="techniques" depends="techniques-list, techniques-association, techniques-index, techniques-about">
 		<makeurl file="${basedir}/techniques/" property="base.techniques"/>
 		<makeurl file="${basedir}/techniques/technique-associations.xml" property="associations.file"/>
@@ -202,14 +202,14 @@
 			<fileset dir="techniques" includes="**/img/*"/>
 		</copy>
 	</target>
-	
+
 	<target name="techniques-toc" depends="techniques-list" description="Generate the TOC for Techniques">
 		<xslt in="${inputdir.techniques}/techniques.xml" out="techniques/toc.html" style="xslt/generate-techniques-toc.xslt" force="true">
 			<classpath path="${classpath.saxon}"/>
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<target name="techniques-index" depends="techniques-toc" description="Process the techniques index file">
 		<makeurl file="${basedir}/techniques/" property="base.techniques"/>
 		<mkdir dir="${basedir}/output/techniques/"/>
@@ -233,7 +233,7 @@
 			<param name="navigation.current" expression="all"/>
 		</xslt>
 	</target>
-	
+
 	<target name="techniques-about" description="Process the techniques about file">
 		<makeurl file="${basedir}/techniques/" property="base.techniques"/>
 		<mkdir dir="${basedir}/output/techniques/"/>
@@ -258,7 +258,7 @@
 		</xslt>
 		<copy file="css/base.css" todir="output/techniques/"/>
 	</target>
-	
+
 	<!-- Understanding -->
 	<target name="understanding" depends="guidelines-xml, guidelines-versions, techniques-list, understanding-index, understanding-about" description="Generate formatted Understanding docs">
 		<makeurl file="${basedir}/understanding/" property="base.understanding"/>
@@ -288,14 +288,14 @@
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="understanding-toc" depends="guidelines-xml" description="Generate the TOC for Understanding">
 		<xslt in="${inputdir.guidelines}/wcag.xml" out="understanding/toc.html" style="xslt/generate-understanding-toc.xslt" force="true">
 			<classpath path="${classpath.saxon}"/>
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<target name="understanding-index" depends="understanding-toc" description="Process the understanding index file">
 		<makeurl file="${basedir}/understanding/" property="base.understanding"/>
 		<mkdir dir="${basedir}/output/understanding/"/>
@@ -319,7 +319,7 @@
 			<param name="navigation.current" expression="all"/>
 		</xslt>
 	</target>
-	
+
 	<target name="understanding-about" description="Process the understanding about file">
 		<makeurl file="${basedir}/understanding/" property="base.understanding"/>
 		<mkdir dir="${basedir}/output/understanding/"/>
@@ -344,7 +344,7 @@
 		</xslt>
 		<copy file="css/base.css" todir="output/understanding/"/>
 	</target>
-	
+
 	<!-- Requirements -->
 	<target name="requirements" depends="init">
 		<mkdir dir="output/requirements/${guidelines.version}"/>
@@ -357,7 +357,7 @@
 			<arg value="3"/>
 		</exec>
 	</target>
-	
+
 	<!-- Conformance Challenges -->
 	<target name="conformance-challenges" depends="init">
 		<mkdir dir="output/conformance-challenges"/>
@@ -370,7 +370,7 @@
 			<arg value="3"/>
 		</exec>
 	</target>
-	
+
 	<!-- Publish -->
 	<target name="deploy" depends="init, understanding-toc, techniques-toc" description="Generate content ready to deploy to gh-pages">
 		<property name="editors" value="true"/>
@@ -383,7 +383,7 @@
 			<fileset dir="working-examples/"/>
 		</copy>
 	</target>
-	
+
 	<target name="publish-w3c" depends="init, understanding-toc, techniques-toc" description="Publish resources to w3c">
 		<property name="publication" value="true"/>
 		<antcall target="techniques"/>
@@ -412,7 +412,7 @@
 			<fileset dir="working-examples/" excludes="index.html **/index.html"/>
 		</copy>
 	</target>
-	
+
 	<!-- JSON -->
 	<target name="json" depends="init, guidelines-xml, techniques-list, techniques-association">
 		<xslt in="${inputdir.guidelines}/wcag.xml" out="${inputdir.guidelines}/wcag.json" style="xslt/xml-to-json.xslt" force="true">
@@ -420,7 +420,7 @@
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<!-- Generic JSON -->
 	<target name="generic-json" depends="init, guidelines-xml">
 		<xslt in="${inputdir.guidelines}/wcag.xml" out="${inputdir.guidelines}/wcag.json" style="xslt/generic-xml-to-json.xslt" force="true">
@@ -428,7 +428,7 @@
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<!-- Redirects -->
 	<target name="redirects">
 		<xslt in="xslt/ids.xml" out="output/understanding/.htaccess" style="xslt/ids-to-redirects.xslt" force="true">
@@ -436,7 +436,7 @@
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<!-- SQL for CR test tool -->
 	<target name="cr-sql" depends="guidelines-xml, guidelines-versions, techniques-list, techniques-association">
 		<xslt in="${inputdir.guidelines}/wcag.xml" out="${inputdir.guidelines}/test-sql.sql" style="xslt/generate-test-sql.xslt" force="true">
@@ -444,11 +444,11 @@
 			<factory name="${xslt.factory}"/>
 		</xslt>
 	</target>
-	
+
 	<!-- Everything -->
 	<target name="all" depends="init, understanding, techniques" description="Generate entire suite"/>
-	
+
 	<!-- === Sanity check === -->
 	<target name="sanity" depends="init" description="Identifies inconsistencies in documents"></target>
-	
+
 </project>

--- a/understanding/20/focus-visible.html
+++ b/understanding/20/focus-visible.html
@@ -1,166 +1,159 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
-
 <head>
-  <meta charset="UTF-8">
-  </meta>
-  <title>Understanding Focus Visible</title>
-  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove" />
+   <meta charset="UTF-8"></meta>
+   <title>Understanding Focus Visible</title>
+   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
 </head>
-
 <body>
-  <h1>Understanding Focus Visible</h1>
+   <h1>Understanding Focus Visible</h1>
 
-  <section id="brief">
-    <h2>In brief</h2>
-    <dl>
-      <dt>Goal</dt>
-      <dd>Users know which element has keyboard focus.</dd>
-      <dt>What to do</dt>
-      <dd>Ensure each item receiving focus has a visible indicator.</dd>
-      <dt>Why it's important</dt>
-      <dd>Without a focus indicator, sighted keyboard users cannot operate the page.</dd>
-    </dl>
+   <section id="brief">
+		<h2>In brief</h2>
+		<dl>
+         <dt>Goal</dt><dd>Users know which element has keyboard focus.</dd>
+         <dt>What to do</dt><dd>Ensure each item receiving focus has a visible indicator.</dd>
+         <dt>Why it's important</dt><dd>Without a focus indicator, sighted keyboard users cannot operate the page.</dd>
+      </dl>
 
-  </section>
+   </section>
 
-  <section id="intent">
-    <h2>Intent of Focus Visible</h2>
+   <section id="intent">
+      <h2>Intent of Focus Visible</h2>
 
 
-    <p>The purpose of this success criterion is to help a person know which element has the
-      keyboard focus.
-    </p>
+      <p>The purpose of this success criterion is to help a person know which element has the
+         keyboard focus.
+      </p>
 
-    <p>“Mode of operation” accounts for user agents which may not always show a focus indicator, or only show the focus indicator when the keyboard is used. User agents may optimise when the focus indicator is shown, such as only showing it when a keyboard is used. Authors are responsible for providing at least one mode of operation where the focus is visible. In most cases there is only one mode of operation so this success criterion applies. The focus indicator must not be time limited, when the keyboard focus is shown it must remain.</p>
+      <p>“Mode of operation” accounts for user agents which may not always show a focus indicator, or only show the focus indicator when the keyboard is used. User agents may optimise when the focus indicator is shown, such as only showing it when a keyboard is used. Authors are responsible for providing at least one mode of operation where the focus is visible. In most cases there is only one mode of operation so this success criterion applies. The focus indicator must not be time limited, when the keyboard focus is shown it must remain.</p>
 
-    <div class="note">
-      <p>There may be situations where mouse/pointer users could also benefit from having a visible focus indicator, even though they did not set focus to an element using the keyboard. As a best practice, consider still providing an explicit focus indicator for these cases.</p>
-    </div>
+      <div class="note">
+         <p>There may be situations where mouse/pointer users could also benefit from having a visible focus indicator, even though they did not set focus to an element using the keyboard. As a best practice, consider still providing an explicit focus indicator for these cases.</p>
+      </div>
 
-    <p>Note that a keyboard focus indicator can take different forms. <span class="wcag2.2">While Focus Visible does not specify what that form is, <a href="focus-appearance">2.4.13 Focus Appearance (Level AAA)</a> provides guidance on creating a consistent, visible indicator.</span></p>
+   	<p>Note that a keyboard focus indicator can take different forms. <span class="wcag2.2">While Focus Visible does not specify what that form is, <a href="focus-appearance">2.4.13 Focus Appearance (Level AAA)</a> provides guidance on creating a consistent, visible indicator.</span></p>
 
-  </section>
-  <section id="benefits">
-    <h2>Benefits of Focus Visible</h2>
+   </section>
+   <section id="benefits">
+      <h2>Benefits of Focus Visible</h2>
 
-    <ul>
-      <li>This Success Criterion helps anyone who relies on the keyboard to operate the page,
-        by letting them visually determine the component on which keyboard operations will
-        interact at any point in time.
-      </li>
-      <li>People with attention limitations, short term memory limitations, or limitations in
-        executive processes benefit by being able to discover where the focus is located.
-      </li>
-    </ul>
-
-  </section>
-
-  <section id="examples">
-    <h2>Examples of Focus Visible</h2>
-
-    <ul>
-      <li>When text fields receive focus, a vertical bar is displayed in the field, indicating
-        that the user can insert text, OR all of the text is highlighted, indicating that
-        the user can type over the text.
-      </li>
-      <li>When a user interface control receives focus, a visible border is displayed around
-        it.
-      </li>
-    </ul>
-
-  </section>
-
-  <section id="resources">
-    <h2>Resources for Focus Visible</h2>
-
-
-    <ul>
-
-      <li>
-
-        <a href="http://www.456bereastreet.com/archive/200701/styling_form_controls_with_css_revisited/">Styling form controls with CSS, revisited</a>
-
-      </li>
-
-    </ul>
-
-  </section>
-
-  <section id="techniques">
-    <h2>Techniques for Focus Visible</h2>
-
-
-    <section id="sufficient">
-      <h3>Sufficient Techniques for Focus Visible</h3>
       <ul>
-        <li>
-
-
-          <a href="../Techniques/general/G149" class="general">Using user interface components that are highlighted by the user agent when they receive
-            focus
-          </a>
-        </li>
-        <li>
-
-
-          <a href="../Techniques/css/C15" class="css">Using CSS to change the presentation of a user interface component when it receives
-            focus
-          </a>
-        </li>
-        <li>
-
-
-          <a href="../Techniques/general/G165" class="general">G165: Using the default focus indicator for the platform so that high visibility default
-            focus indicators will carry over
-          </a>
-        </li>
-        <li>
-
-
-          <a href="../Techniques/general/G195" class="general">Using an author-supplied, highly visible focus indicator</a>
-
-
-        </li>
-        <li>
-          <a href="../../techniques/css/C40">Creating a two-color focus indicator to ensure sufficient contrast</a>
-        </li>
-        <li>
-          <a href="../../techniques/css/C45">Using CSS :focus-visible to provide keyboard focus indication</a>
-        </li>
-        <li>
-          <a href="../Techniques/client-side-script/SCR31" class="script">Using script to change the background color or border of the element with focus</a>
-
-        </li>
+         <li>This Success Criterion helps anyone who relies on the keyboard to operate the page,
+            by letting them visually determine the component on which keyboard operations will
+            interact at any point in time.
+         </li>
+         <li>People with attention limitations, short term memory limitations, or limitations in
+            executive processes benefit by being able to discover where the focus is located.
+         </li>
       </ul>
-    </section>
 
-    <section id="advisory">
-      <h3>Additional Techniques (Advisory) for Focus Visible</h3>
+   </section>
 
-    </section>
+   <section id="examples">
+      <h2>Examples of Focus Visible</h2>
 
-    <section id="failure">
-      <h3>Failures for Focus Visible</h3>
       <ul>
-        <li>
-
-
-          <a href="../Techniques/failures/F55" class="failure">Failure of Success Criterion 2.1.1, 2.4.7, and 3.2.1 due to using script to remove
-            focus when focus is received
-          </a>
-        </li>
-        <li>
-
-          <a href="../Techniques/failures/F78" class="failure">Failure due to styling element outlines and borders in a way that overrides or renders
-            non-visible the default visual focus indicator
-          </a>
-        </li>
+         <li>When text fields receive focus, a vertical bar is displayed in the field, indicating
+            that the user can insert text, OR all of the text is highlighted, indicating that
+            the user can type over the text.
+         </li>
+         <li>When a user interface control receives focus, a visible border is displayed around
+            it.
+         </li>
       </ul>
-    </section>
 
-  </section>
+   </section>
+
+   <section id="resources">
+      <h2>Resources for Focus Visible</h2>
+
+
+      <ul>
+
+         <li>
+
+            <a href="http://www.456bereastreet.com/archive/200701/styling_form_controls_with_css_revisited/">Styling form controls with CSS, revisited</a>
+
+         </li>
+
+      </ul>
+
+   </section>
+
+   <section id="techniques">
+      <h2>Techniques for Focus Visible</h2>
+
+
+      <section id="sufficient">
+         <h3>Sufficient Techniques for Focus Visible</h3>
+         <ul>
+            <li>
+
+
+               <a href="../Techniques/general/G149" class="general">Using user interface components that are highlighted by the user agent when they receive
+                  focus
+               </a>
+            </li>
+            <li>
+
+
+               <a href="../Techniques/css/C15" class="css">Using CSS to change the presentation of a user interface component when it receives
+                  focus
+               </a>
+            </li>
+            <li>
+
+
+               <a href="../Techniques/general/G165" class="general">G165: Using the default focus indicator for the platform so that high visibility default
+                  focus indicators will carry over
+               </a>
+            </li>
+            <li>
+
+
+               <a href="../Techniques/general/G195" class="general">Using an author-supplied, highly visible focus indicator</a>
+
+
+            </li>
+            <li>
+               <a href="../../techniques/css/C40">Creating a two-color focus indicator to ensure sufficient contrast</a>
+            </li>
+            <li>
+               <a href="../../techniques/css/C45">Using CSS :focus-visible to provide keyboard focus indication</a>
+            </li>
+            <li>
+               <a href="../Techniques/client-side-script/SCR31" class="script">Using script to change the background color or border of the element with focus</a>
+
+            </li>
+         </ul>
+      </section>
+
+      <section id="advisory">
+         <h3>Additional Techniques (Advisory) for Focus Visible</h3>
+
+      </section>
+
+      <section id="failure">
+         <h3>Failures for Focus Visible</h3>
+         <ul>
+            <li>
+
+
+               <a href="../Techniques/failures/F55" class="failure">Failure of Success Criterion 2.1.1, 2.4.7, and 3.2.1 due to using script to remove
+                  focus when focus is received
+               </a>
+            </li>
+            <li>
+
+               <a href="../Techniques/failures/F78" class="failure">Failure due to styling element outlines and borders in a way that overrides or renders
+                  non-visible the default visual focus indicator
+               </a>
+            </li>
+         </ul>
+      </section>
+
+   </section>
 
 </body>
-
 </html>

--- a/understanding/20/focus-visible.html
+++ b/understanding/20/focus-visible.html
@@ -1,159 +1,166 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
 <head>
-   <meta charset="UTF-8"></meta>
-   <title>Understanding Focus Visible</title>
-   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
+  <meta charset="UTF-8">
+  </meta>
+  <title>Understanding Focus Visible</title>
+  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove" />
 </head>
+
 <body>
-   <h1>Understanding Focus Visible</h1>
-   
-   <section id="brief">
-		<h2>In brief</h2>
-		<dl>
-         <dt>Goal</dt><dd>Users know which element has keyboard focus.</dd>
-         <dt>What to do</dt><dd>Ensure each item receiving focus has a visible indicator.</dd>
-         <dt>Why it's important</dt><dd>Without a focus indicator, sighted keyboard users cannot operate the page.</dd> 
-      </dl>
+  <h1>Understanding Focus Visible</h1>
 
-   </section>
-   
-   <section id="intent">
-      <h2>Intent of Focus Visible</h2>
-      
-      
-      <p>The purpose of this success criterion is to help a person know which element has the
-         keyboard focus.
-      </p>
-      
-      <p>“Mode of operation” accounts for user agents which may not always show a focus indicator, or only show the focus indicator when the keyboard is used. User agents may optimise when the focus indicator is shown, such as only showing it when a keyboard is used. Authors are responsible for providing at least one mode of operation where the focus is visible. In most cases there is only one mode of operation so this success criterion applies. The focus indicator must not be time limited, when the keyboard focus is shown it must remain.</p>
+  <section id="brief">
+    <h2>In brief</h2>
+    <dl>
+      <dt>Goal</dt>
+      <dd>Users know which element has keyboard focus.</dd>
+      <dt>What to do</dt>
+      <dd>Ensure each item receiving focus has a visible indicator.</dd>
+      <dt>Why it's important</dt>
+      <dd>Without a focus indicator, sighted keyboard users cannot operate the page.</dd>
+    </dl>
 
-      <div class="note">
-         <p>There may be situations where mouse/pointer users could also benefit from having a visible focus indicator, even though they did not set focus to an element using the keyboard. As a best practice, consider still providing an explicit focus indicator for these cases.</p>
-      </div>
-      
-   	<p>Note that a keyboard focus indicator can take different forms. <span class="wcag22">While Focus Visible does not specify what that form is, <a href="focus-appearance">2.4.13 Focus Appearance (Level AAA)</a> provides guidance on creating a consistent, visible indicator.</span></p>     
-      
-   </section>
-   <section id="benefits">
-      <h2>Benefits of Focus Visible</h2>
-      
+  </section>
+
+  <section id="intent">
+    <h2>Intent of Focus Visible</h2>
+
+
+    <p>The purpose of this success criterion is to help a person know which element has the
+      keyboard focus.
+    </p>
+
+    <p>“Mode of operation” accounts for user agents which may not always show a focus indicator, or only show the focus indicator when the keyboard is used. User agents may optimise when the focus indicator is shown, such as only showing it when a keyboard is used. Authors are responsible for providing at least one mode of operation where the focus is visible. In most cases there is only one mode of operation so this success criterion applies. The focus indicator must not be time limited, when the keyboard focus is shown it must remain.</p>
+
+    <div class="note">
+      <p>There may be situations where mouse/pointer users could also benefit from having a visible focus indicator, even though they did not set focus to an element using the keyboard. As a best practice, consider still providing an explicit focus indicator for these cases.</p>
+    </div>
+
+    <p>Note that a keyboard focus indicator can take different forms. <span class="wcag2.2">While Focus Visible does not specify what that form is, <a href="focus-appearance">2.4.13 Focus Appearance (Level AAA)</a> provides guidance on creating a consistent, visible indicator.</span></p>
+
+  </section>
+  <section id="benefits">
+    <h2>Benefits of Focus Visible</h2>
+
+    <ul>
+      <li>This Success Criterion helps anyone who relies on the keyboard to operate the page,
+        by letting them visually determine the component on which keyboard operations will
+        interact at any point in time.
+      </li>
+      <li>People with attention limitations, short term memory limitations, or limitations in
+        executive processes benefit by being able to discover where the focus is located.
+      </li>
+    </ul>
+
+  </section>
+
+  <section id="examples">
+    <h2>Examples of Focus Visible</h2>
+
+    <ul>
+      <li>When text fields receive focus, a vertical bar is displayed in the field, indicating
+        that the user can insert text, OR all of the text is highlighted, indicating that
+        the user can type over the text.
+      </li>
+      <li>When a user interface control receives focus, a visible border is displayed around
+        it.
+      </li>
+    </ul>
+
+  </section>
+
+  <section id="resources">
+    <h2>Resources for Focus Visible</h2>
+
+
+    <ul>
+
+      <li>
+
+        <a href="http://www.456bereastreet.com/archive/200701/styling_form_controls_with_css_revisited/">Styling form controls with CSS, revisited</a>
+
+      </li>
+
+    </ul>
+
+  </section>
+
+  <section id="techniques">
+    <h2>Techniques for Focus Visible</h2>
+
+
+    <section id="sufficient">
+      <h3>Sufficient Techniques for Focus Visible</h3>
       <ul>
-         <li>This Success Criterion helps anyone who relies on the keyboard to operate the page,
-            by letting them visually determine the component on which keyboard operations will
-            interact at any point in time.
-         </li>
-         <li>People with attention limitations, short term memory limitations, or limitations in
-            executive processes benefit by being able to discover where the focus is located.
-         </li>
-      </ul>
-      
-   </section>
-   
-   <section id="examples">
-      <h2>Examples of Focus Visible</h2>
+        <li>
 
+
+          <a href="../Techniques/general/G149" class="general">Using user interface components that are highlighted by the user agent when they receive
+            focus
+          </a>
+        </li>
+        <li>
+
+
+          <a href="../Techniques/css/C15" class="css">Using CSS to change the presentation of a user interface component when it receives
+            focus
+          </a>
+        </li>
+        <li>
+
+
+          <a href="../Techniques/general/G165" class="general">G165: Using the default focus indicator for the platform so that high visibility default
+            focus indicators will carry over
+          </a>
+        </li>
+        <li>
+
+
+          <a href="../Techniques/general/G195" class="general">Using an author-supplied, highly visible focus indicator</a>
+
+
+        </li>
+        <li>
+          <a href="../../techniques/css/C40">Creating a two-color focus indicator to ensure sufficient contrast</a>
+        </li>
+        <li>
+          <a href="../../techniques/css/C45">Using CSS :focus-visible to provide keyboard focus indication</a>
+        </li>
+        <li>
+          <a href="../Techniques/client-side-script/SCR31" class="script">Using script to change the background color or border of the element with focus</a>
+
+        </li>
+      </ul>
+    </section>
+
+    <section id="advisory">
+      <h3>Additional Techniques (Advisory) for Focus Visible</h3>
+
+    </section>
+
+    <section id="failure">
+      <h3>Failures for Focus Visible</h3>
       <ul>
-         <li>When text fields receive focus, a vertical bar is displayed in the field, indicating
-            that the user can insert text, OR all of the text is highlighted, indicating that
-            the user can type over the text.
-         </li>
-         <li>When a user interface control receives focus, a visible border is displayed around
-            it.
-         </li>
+        <li>
+
+
+          <a href="../Techniques/failures/F55" class="failure">Failure of Success Criterion 2.1.1, 2.4.7, and 3.2.1 due to using script to remove
+            focus when focus is received
+          </a>
+        </li>
+        <li>
+
+          <a href="../Techniques/failures/F78" class="failure">Failure due to styling element outlines and borders in a way that overrides or renders
+            non-visible the default visual focus indicator
+          </a>
+        </li>
       </ul>
-      
-   </section>
-   
-   <section id="resources">
-      <h2>Resources for Focus Visible</h2>
-      
-      
-      <ul>
-         
-         <li>
-            								       
-            <a href="http://www.456bereastreet.com/archive/200701/styling_form_controls_with_css_revisited/">Styling form controls with CSS, revisited</a>
-            							     
-         </li>
-         
-      </ul>
-      
-   </section>
-   
-   <section id="techniques">
-      <h2>Techniques for Focus Visible</h2>
-      
-      
-      <section id="sufficient">
-         <h3>Sufficient Techniques for Focus Visible</h3>
-         <ul>
-            <li>
+    </section>
 
-               									         
-               <a href="../Techniques/general/G149" class="general">Using user interface components that are highlighted by the user agent when they receive
-                  focus
-               </a>
-            </li>
-            <li>
+  </section>
 
-               									         
-               <a href="../Techniques/css/C15" class="css">Using CSS to change the presentation of a user interface component when it receives
-                  focus
-               </a>
-            </li>
-            <li>
-
-               									         
-               <a href="../Techniques/general/G165" class="general">G165: Using the default focus indicator for the platform so that high visibility default
-                  focus indicators will carry over
-               </a>
-            </li>
-            <li>
-
-               									         
-               <a href="../Techniques/general/G195" class="general">Using an author-supplied, highly visible focus indicator</a>
-               								       
-
-            </li>
-            <li>
-               <a href="../../techniques/css/C40">Creating a two-color focus indicator to ensure sufficient contrast</a>
-            </li>
-            <li>
-               <a href="../../techniques/css/C45">Using CSS :focus-visible to provide keyboard focus indication</a>
-            </li>
-            <li>
-               <a href="../Techniques/client-side-script/SCR31" class="script">Using script to change the background color or border of the element with focus</a>
-
-            </li>
-         </ul>
-      </section>
-      
-      <section id="advisory">
-         <h3>Additional Techniques (Advisory) for Focus Visible</h3>
-         
-      </section>
-      
-      <section id="failure">
-         <h3>Failures for Focus Visible</h3>
-         <ul>
-            <li>
-
-               									         
-               <a href="../Techniques/failures/F55" class="failure">Failure of Success Criterion 2.1.1, 2.4.7, and 3.2.1 due to using script to remove
-                  focus when focus is received
-               </a>
-            </li>
-            <li>
-               									         
-               <a href="../Techniques/failures/F78" class="failure">Failure due to styling element outlines and borders in a way that overrides or renders
-                  non-visible the default visual focus indicator
-               </a>
-            </li>
-         </ul>
-      </section>
-      
-   </section>
-   
 </body>
+
 </html>

--- a/understanding/20/parsing.html
+++ b/understanding/20/parsing.html
@@ -1,207 +1,200 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
-
 <head>
-  <meta charset="UTF-8">
-  </meta>
-  <title>Understanding Parsing</title>
-  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove" />
+   <meta charset="UTF-8"></meta>
+   <title>Understanding Parsing</title>
+   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
 </head>
-
 <body>
-  <h1>Understanding Parsing</h1>
+   <h1>Understanding Parsing</h1>
 
-  <section id="brief">
-    <h2>In brief</h2>
-    <dl>
-      <dt>Goal</dt>
-      <dd>Assistive technology can properly present page content.</dd>
-      <dt>What to do</dt>
-      <dd>Create web pages according to specifications.</dd>
-      <dt>Why it's important</dt>
-      <dd>People can browse web content more easily with their assistive technology.</dd>
-    </dl>
+   <section id="brief">
+		<h2>In brief</h2>
+		<dl>
+         <dt>Goal</dt><dd>Assistive technology can properly present page content.</dd>
+         <dt>What to do</dt><dd>Create web pages according to specifications.</dd>
+         <dt>Why it's important</dt><dd>People can browse web content more easily with their assistive technology.</dd>
+      </dl>
 
-  </section>
+   </section>
 
-  <section id="intent">
-    <h2>Intent of Parsing</h2>
+   <section id="intent">
+      <h2>Intent of Parsing</h2>
 
-    <div class="wcag2.2">
-      <p>This criterion has been removed from WCAG 2.2.</p>
+      <div class="wcag2.2">
+         <p>This criterion has been removed from WCAG 2.2.</p>
 
-      <p>The intent of this Success Criterion was to ensure that user-agents, including assistive technologies, can accurately interpret and parse content. Since WCAG 2.0 was published, the specifications (such as HTML) and browsers have improved their handling of parsing errors. It is also the case that assistive technology used to do their own parsing of markup, but now rely on the browser. For that reason this success criterion has been removed. Many issues that would have failed this criterion will fail <a href="info-and-relationships">Info and Relationships</a> or <a href="name-role-value">Name, Role, Value</a>. Other issues are excepted by the "except where the specification allow these features" part of the criterion.</p>
+         <p>The intent of this Success Criterion was to ensure that user-agents, including assistive technologies, can accurately interpret and parse content. Since WCAG 2.0 was published, the specifications (such as HTML) and browsers have improved their handling of parsing errors. It is also the case that assistive technology used to do their own parsing of markup, but now rely on the browser. For that reason this success criterion has been removed. Many issues that would have failed this criterion will fail <a href="info-and-relationships">Info and Relationships</a> or <a href="name-role-value">Name, Role, Value</a>. Other issues are excepted by the "except where the specification allow these features" part of the criterion.</p>
 
-      <p>The following content is left for historical purposes to show the original intent.</p>
+         <p>The following content is left for historical purposes to show the original intent.</p>
 
-      <hr />
+         <hr/>
 
-      <blockquote class="scquote">
-        <p>Success Criterion <a href="https://www.w3.org/TR/WCAG21/#parsing" style="font-weight: bold;">4.1.1 Parsing</a> (Level A): In content implemented using markup languages, elements have complete start and end
-          tags, elements are nested according to their specifications, elements do not contain
-          duplicate attributes, and any IDs are unique, except where the specifications allow
-          these features.
-        </p>
-        <p class="note">Start and end tags that are missing a critical character in their formation, such
-          as a closing angle bracket or a mismatched attribute value quotation mark are not
-          complete.
-        </p>
-      </blockquote>
-    </div>
+         <blockquote class="scquote">
+            <p>Success Criterion <a href="https://www.w3.org/TR/WCAG21/#parsing" style="font-weight: bold;">4.1.1 Parsing</a> (Level A): In content implemented using markup languages, elements have complete start and end
+               tags, elements are nested according to their specifications, elements do not contain
+               duplicate attributes, and any IDs are unique, except where the specifications allow
+               these features.
+               </p>
+            <p class="note">Start and end tags that are missing a critical character in their formation, such
+               as a closing angle bracket or a mismatched attribute value quotation mark are not
+               complete.
+               </p>
+         </blockquote>
+      </div>
 
-    <p>
-      The intent of this Success Criterion is to ensure that user agents, including assistive technologies, can accurately interpret and parse content. If the content cannot be parsed into a data structure, then different user agents may present it differently or be completely unable to parse it. Some user agents use "repair techniques" to render poorly coded content.
-    </p>
-
-    <p>Since repair techniques vary among user agents, authors cannot assume that content
-      will be accurately parsed into a data structure or that it will be rendered correctly
-      by specialized user agents, including assistive technologies, unless the content is
-      created according to the rules defined in the formal grammar for that technology.
-      In markup languages, errors in element and attribute syntax and
-      failure to provide properly nested start/end tags lead to errors that
-      prevent user agents from parsing the content reliably.
-      Therefore, the Success Criterion requires that the content can be parsed using only
-      the rules of the formal grammar.
-
-    </p>
-
-    <div class="note">
-
-      <p>The concept of "well formed" is close to what is required here. However, exact parsing
-        requirements vary amongst markup languages, and most non XML-based languages do not
-        explicitly define requirements for well formedness. Therefore, it was necessary to
-        be more explicit in the Success Criterion in order to be generally applicable to markup
-        languages. Because the term "well formed" is only defined in XML, and (because end
-        tags are sometimes optional) valid HTML does not require well formed code, the term
-        is not used in this Success Criterion.
+      <p>
+         The intent of this Success Criterion is to ensure that user agents, including assistive technologies, can accurately interpret and parse content.  If the content cannot be parsed into a data structure, then different user agents may present it differently or be completely unable to parse it. Some user agents use "repair techniques" to render poorly coded content.
       </p>
 
-      <p>With the exception of one Success Criterion (
-        <a href="resize-text">1.4.4: Resize Text</a>, which specifically mentions that the effect specified by the Success Criterion must
-        be achieved without relying on an assistive technology) authors can meet the Success
-        Criteria with content that assumes use of an assistive technology (or access features
-        in use agents) by the user, where such assistive technologies (or access features
-        in user agents) exist and are available to the user.
+      <p>Since repair techniques vary among user agents, authors cannot assume that content
+         will be accurately parsed into a data structure or that it will be rendered correctly
+         by specialized user agents, including assistive technologies, unless the content is
+         created according to the rules defined in the formal grammar for that technology.
+         In markup languages, errors in element and attribute syntax and
+         failure to provide properly nested start/end tags lead to errors that
+         prevent user agents from parsing the content reliably.
+         Therefore, the Success Criterion requires that the content can be parsed using only
+         the rules of the formal grammar.
+
       </p>
 
-    </div>
+      <div class="note">
+
+         <p>The concept of "well formed" is close to what is required here. However, exact parsing
+            requirements vary amongst markup languages, and most non XML-based languages do not
+            explicitly define requirements for well formedness. Therefore, it was necessary to
+            be more explicit in the Success Criterion in order to be generally applicable to markup
+            languages. Because the term "well formed" is only defined in XML, and (because end
+            tags are sometimes optional) valid HTML does not require well formed code, the term
+            is not used in this Success Criterion.
+         </p>
+
+         <p>With the exception of one Success Criterion (
+            <a href="resize-text">1.4.4: Resize Text</a>, which specifically mentions that the effect specified by the Success Criterion must
+            be achieved without relying on an assistive technology) authors can meet the Success
+            Criteria with content that assumes use of an assistive technology (or access features
+            in use agents) by the user, where such assistive technologies (or access features
+            in user agents) exist and are available to the user.
+         </p>
+
+      </div>
 
 
-  </section>
-  <section id="benefits">
-    <h2>Benefits of Parsing</h2>
-
-
-    <ul>
-
-      <li>Ensuring that Web pages have complete start and end tags and are nested according
-        to specification
-        helps ensure that assistive technologies can parse the content accurately and without
-        crashing.
-      </li>
-
-    </ul>
-
-  </section>
-
-  <section id="examples">
-    <h2>Examples of Parsing</h2>
-
-
-  </section>
-
-  <section id="resources">
-    <h2>Resources for Parsing</h2>
-
-
-  </section>
-
-  <section id="techniques">
-    <h2>Techniques for Parsing</h2>
-
-
-    <section id="sufficient">
-      <h3>Sufficient Techniques for Parsing</h3>
+   </section>
+   <section id="benefits">
+      <h2>Benefits of Parsing</h2>
 
 
       <ul>
 
-        <li>
+         <li>Ensuring that Web pages have complete start and end tags and are nested according
+            to specification
+            helps ensure that assistive technologies can parse the content accurately and without
+            crashing.
+         </li>
 
-          <a href="../Techniques/general/G134" class="general">Validating Web pages</a>
+      </ul>
 
-        </li>
+   </section>
 
-        <li>
+   <section id="examples">
+      <h2>Examples of Parsing</h2>
 
-          <a href="../Techniques/general/G192" class="general">Fully conforming to specifications</a>
 
-        </li>
+   </section>
 
-        <li>
+   <section id="resources">
+      <h2>Resources for Parsing</h2>
 
-          <a href="../Techniques/html/H88" class="html">Using (X)HTML according to spec</a>
 
-        </li>
+   </section>
 
-        <li>
+   <section id="techniques">
+      <h2>Techniques for Parsing</h2>
 
-          <p>Ensuring that Web pages can be parsed by using one of the following techniques:</p>
 
-          <ul>
+      <section id="sufficient">
+         <h3>Sufficient Techniques for Parsing</h3>
+
+
+         <ul>
 
             <li>
 
-              <a href="../Techniques/html/H74" class="html">Ensuring that opening and closing tags are used according to specification</a>
-
-              <strong>AND</strong>
-
-              <a href="../Techniques/html/H93" class="html">Ensuring that id attributes are unique on a Web page</a>
-
-              <strong>AND</strong>
-
-              <a href="../Techniques/html/H94" class="html">Ensuring that elements do not contain duplicate attributes</a>
+               <a href="../Techniques/general/G134" class="general">Validating Web pages</a>
 
             </li>
 
-          </ul>
+            <li>
 
-        </li>
+               <a href="../Techniques/general/G192" class="general">Fully conforming to specifications</a>
 
-      </ul>
+            </li>
 
-    </section>
+            <li>
 
-    <section id="advisory">
-      <h3>Additional Techniques (Advisory) for Parsing</h3>
+               <a href="../Techniques/html/H88" class="html">Using (X)HTML according to spec</a>
+
+            </li>
+
+            <li>
+
+               <p>Ensuring that Web pages can be parsed  by using one of the following techniques:</p>
+
+               <ul>
+
+                  <li>
+
+                     <a href="../Techniques/html/H74" class="html">Ensuring that  opening and closing tags are used according to specification</a>
+
+                     <strong>AND</strong>
+
+                     <a href="../Techniques/html/H93" class="html">Ensuring that id attributes are unique on a Web page</a>
+
+                     <strong>AND</strong>
+
+                     <a href="../Techniques/html/H94" class="html">Ensuring that elements do not contain duplicate attributes</a>
+
+                  </li>
+
+               </ul>
+
+            </li>
+
+         </ul>
+
+      </section>
+
+      <section id="advisory">
+         <h3>Additional Techniques (Advisory) for Parsing</h3>
 
 
-    </section>
+      </section>
 
-    <section id="failure">
-      <h3>Failures for Parsing</h3>
+      <section id="failure">
+         <h3>Failures for Parsing</h3>
 
 
-      <ul>
+         <ul>
 
-        <li>
+            <li>
 
-          <a href="../Techniques/failures/F70" class="failure">Failure of 4.1.1 due to incorrect use of start and end tags or attribute markup</a>
+               <a href="../Techniques/failures/F70" class="failure">Failure of 4.1.1 due to incorrect use of start and end tags or attribute markup</a>
 
-        </li>
+            </li>
 
-        <li>
+            <li>
 
-          <a href="../Techniques/failures/F77" class="failure">Failure of 4.1.1 due to duplicate values of type ID</a>
+               <a href="../Techniques/failures/F77" class="failure">Failure of 4.1.1 due to duplicate values of type ID</a>
 
-        </li>
+            </li>
 
-      </ul>
+         </ul>
 
-    </section>
+      </section>
 
-  </section>
+   </section>
 
 </body>
-
 </html>

--- a/understanding/20/parsing.html
+++ b/understanding/20/parsing.html
@@ -1,200 +1,207 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
 <head>
-   <meta charset="UTF-8"></meta>
-   <title>Understanding Parsing</title>
-   <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
+  <meta charset="UTF-8">
+  </meta>
+  <title>Understanding Parsing</title>
+  <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove" />
 </head>
+
 <body>
-   <h1>Understanding Parsing</h1>
-   
-   <section id="brief">
-		<h2>In brief</h2>
-		<dl>
-         <dt>Goal</dt><dd>Assistive technology can properly present page content.</dd>
-         <dt>What to do</dt><dd>Create web pages according to specifications.</dd>
-         <dt>Why it's important</dt><dd>People can browse web content more easily with their assistive technology.</dd> 
-      </dl>
+  <h1>Understanding Parsing</h1>
 
-   </section>
-   
-   <section id="intent">
-      <h2>Intent of Parsing</h2>
-      
-      <div class="wcag22">
-         <p>This criterion has been removed from WCAG 2.2.</p>
+  <section id="brief">
+    <h2>In brief</h2>
+    <dl>
+      <dt>Goal</dt>
+      <dd>Assistive technology can properly present page content.</dd>
+      <dt>What to do</dt>
+      <dd>Create web pages according to specifications.</dd>
+      <dt>Why it's important</dt>
+      <dd>People can browse web content more easily with their assistive technology.</dd>
+    </dl>
 
-         <p>The intent of this Success Criterion was to ensure that user-agents, including assistive technologies, can accurately interpret and parse content. Since WCAG 2.0 was published, the specifications (such as HTML) and browsers have improved their handling of parsing errors. It is also the case that assistive technology used to do their own parsing of markup, but now rely on the browser. For that reason this success criterion has been removed. Many issues that would have failed this criterion will fail <a href="info-and-relationships">Info and Relationships</a> or <a href="name-role-value">Name, Role, Value</a>. Other issues are excepted by the "except where the specification allow these features" part of the criterion.</p>
+  </section>
 
-         <p>The following content is left for historical purposes to show the original intent.</p>  
-            
-         <hr/>
+  <section id="intent">
+    <h2>Intent of Parsing</h2>
 
-         <blockquote class="scquote">
-            <p>Success Criterion <a href="https://www.w3.org/TR/WCAG21/#parsing" style="font-weight: bold;">4.1.1 Parsing</a> (Level A): In content implemented using markup languages, elements have complete start and end
-               tags, elements are nested according to their specifications, elements do not contain
-               duplicate attributes, and any IDs are unique, except where the specifications allow
-               these features.
-               </p>
-            <p class="note">Start and end tags that are missing a critical character in their formation, such
-               as a closing angle bracket or a mismatched attribute value quotation mark are not
-               complete.
-               </p>
-         </blockquote>
-      </div>
+    <div class="wcag2.2">
+      <p>This criterion has been removed from WCAG 2.2.</p>
 
-      <p>
-         The intent of this Success Criterion is to ensure that user agents, including assistive technologies, can accurately interpret and parse content.  If the content cannot be parsed into a data structure, then different user agents may present it differently or be completely unable to parse it. Some user agents use "repair techniques" to render poorly coded content.
+      <p>The intent of this Success Criterion was to ensure that user-agents, including assistive technologies, can accurately interpret and parse content. Since WCAG 2.0 was published, the specifications (such as HTML) and browsers have improved their handling of parsing errors. It is also the case that assistive technology used to do their own parsing of markup, but now rely on the browser. For that reason this success criterion has been removed. Many issues that would have failed this criterion will fail <a href="info-and-relationships">Info and Relationships</a> or <a href="name-role-value">Name, Role, Value</a>. Other issues are excepted by the "except where the specification allow these features" part of the criterion.</p>
+
+      <p>The following content is left for historical purposes to show the original intent.</p>
+
+      <hr />
+
+      <blockquote class="scquote">
+        <p>Success Criterion <a href="https://www.w3.org/TR/WCAG21/#parsing" style="font-weight: bold;">4.1.1 Parsing</a> (Level A): In content implemented using markup languages, elements have complete start and end
+          tags, elements are nested according to their specifications, elements do not contain
+          duplicate attributes, and any IDs are unique, except where the specifications allow
+          these features.
+        </p>
+        <p class="note">Start and end tags that are missing a critical character in their formation, such
+          as a closing angle bracket or a mismatched attribute value quotation mark are not
+          complete.
+        </p>
+      </blockquote>
+    </div>
+
+    <p>
+      The intent of this Success Criterion is to ensure that user agents, including assistive technologies, can accurately interpret and parse content. If the content cannot be parsed into a data structure, then different user agents may present it differently or be completely unable to parse it. Some user agents use "repair techniques" to render poorly coded content.
+    </p>
+
+    <p>Since repair techniques vary among user agents, authors cannot assume that content
+      will be accurately parsed into a data structure or that it will be rendered correctly
+      by specialized user agents, including assistive technologies, unless the content is
+      created according to the rules defined in the formal grammar for that technology.
+      In markup languages, errors in element and attribute syntax and
+      failure to provide properly nested start/end tags lead to errors that
+      prevent user agents from parsing the content reliably.
+      Therefore, the Success Criterion requires that the content can be parsed using only
+      the rules of the formal grammar.
+
+    </p>
+
+    <div class="note">
+
+      <p>The concept of "well formed" is close to what is required here. However, exact parsing
+        requirements vary amongst markup languages, and most non XML-based languages do not
+        explicitly define requirements for well formedness. Therefore, it was necessary to
+        be more explicit in the Success Criterion in order to be generally applicable to markup
+        languages. Because the term "well formed" is only defined in XML, and (because end
+        tags are sometimes optional) valid HTML does not require well formed code, the term
+        is not used in this Success Criterion.
       </p>
-      
-      <p>Since repair techniques vary among user agents, authors cannot assume that content
-         will be accurately parsed into a data structure or that it will be rendered correctly
-         by specialized user agents, including assistive technologies, unless the content is
-         created according to the rules defined in the formal grammar for that technology.
-         In markup languages, errors in element and attribute syntax and
-         failure to provide properly nested start/end tags lead to errors that
-         prevent user agents from parsing the content reliably.
-         Therefore, the Success Criterion requires that the content can be parsed using only
-         the rules of the formal grammar.
-         
+
+      <p>With the exception of one Success Criterion (
+        <a href="resize-text">1.4.4: Resize Text</a>, which specifically mentions that the effect specified by the Success Criterion must
+        be achieved without relying on an assistive technology) authors can meet the Success
+        Criteria with content that assumes use of an assistive technology (or access features
+        in use agents) by the user, where such assistive technologies (or access features
+        in user agents) exist and are available to the user.
       </p>
-      
-      <div class="note">
-         
-         <p>The concept of "well formed" is close to what is required here. However, exact parsing
-            requirements vary amongst markup languages, and most non XML-based languages do not
-            explicitly define requirements for well formedness. Therefore, it was necessary to
-            be more explicit in the Success Criterion in order to be generally applicable to markup
-            languages. Because the term "well formed" is only defined in XML, and (because end
-            tags are sometimes optional) valid HTML does not require well formed code, the term
-            is not used in this Success Criterion.
-         </p>
-         
-         <p>With the exception of one Success Criterion (
-            <a href="resize-text">1.4.4: Resize Text</a>, which specifically mentions that the effect specified by the Success Criterion must
-            be achieved without relying on an assistive technology) authors can meet the Success
-            Criteria with content that assumes use of an assistive technology (or access features
-            in use agents) by the user, where such assistive technologies (or access features
-            in user agents) exist and are available to the user.
-         </p>
-         
-      </div>
-      
-      
-   </section>
-   <section id="benefits">
-      <h2>Benefits of Parsing</h2>
-      
-      
+
+    </div>
+
+
+  </section>
+  <section id="benefits">
+    <h2>Benefits of Parsing</h2>
+
+
+    <ul>
+
+      <li>Ensuring that Web pages have complete start and end tags and are nested according
+        to specification
+        helps ensure that assistive technologies can parse the content accurately and without
+        crashing.
+      </li>
+
+    </ul>
+
+  </section>
+
+  <section id="examples">
+    <h2>Examples of Parsing</h2>
+
+
+  </section>
+
+  <section id="resources">
+    <h2>Resources for Parsing</h2>
+
+
+  </section>
+
+  <section id="techniques">
+    <h2>Techniques for Parsing</h2>
+
+
+    <section id="sufficient">
+      <h3>Sufficient Techniques for Parsing</h3>
+
+
       <ul>
-         
-         <li>Ensuring that Web pages have complete start and end tags and are nested according
-            to specification
-            helps ensure that assistive technologies can parse the content accurately and without
-            crashing.
-         </li>
-         
+
+        <li>
+
+          <a href="../Techniques/general/G134" class="general">Validating Web pages</a>
+
+        </li>
+
+        <li>
+
+          <a href="../Techniques/general/G192" class="general">Fully conforming to specifications</a>
+
+        </li>
+
+        <li>
+
+          <a href="../Techniques/html/H88" class="html">Using (X)HTML according to spec</a>
+
+        </li>
+
+        <li>
+
+          <p>Ensuring that Web pages can be parsed by using one of the following techniques:</p>
+
+          <ul>
+
+            <li>
+
+              <a href="../Techniques/html/H74" class="html">Ensuring that opening and closing tags are used according to specification</a>
+
+              <strong>AND</strong>
+
+              <a href="../Techniques/html/H93" class="html">Ensuring that id attributes are unique on a Web page</a>
+
+              <strong>AND</strong>
+
+              <a href="../Techniques/html/H94" class="html">Ensuring that elements do not contain duplicate attributes</a>
+
+            </li>
+
+          </ul>
+
+        </li>
+
       </ul>
-      
-   </section>
-   
-   <section id="examples">
-      <h2>Examples of Parsing</h2>
-      
-      
-   </section>
-   
-   <section id="resources">
-      <h2>Resources for Parsing</h2>
-      
-      
-   </section>
-   
-   <section id="techniques">
-      <h2>Techniques for Parsing</h2>
-      
-      
-      <section id="sufficient">
-         <h3>Sufficient Techniques for Parsing</h3>
-         
-         
-         <ul>
-            
-            <li>
-               									         
-               <a href="../Techniques/general/G134" class="general">Validating Web pages</a>
-               								       
-            </li>
-            
-            <li>
-               									         
-               <a href="../Techniques/general/G192" class="general">Fully conforming to specifications</a>
-               								       
-            </li>
-            
-            <li>
-               									         
-               <a href="../Techniques/html/H88" class="html">Using (X)HTML according to spec</a>
-               								       
-            </li>
-            
-            <li>
-               
-               <p>Ensuring that Web pages can be parsed  by using one of the following techniques:</p>
-               
-               <ul>
-                  
-                  <li>
-                     											             
-                     <a href="../Techniques/html/H74" class="html">Ensuring that  opening and closing tags are used according to specification</a>
-                     											             
-                     <strong>AND</strong>
-                     											             
-                     <a href="../Techniques/html/H93" class="html">Ensuring that id attributes are unique on a Web page</a>
-                     											             
-                     <strong>AND</strong>
-                     											             
-                     <a href="../Techniques/html/H94" class="html">Ensuring that elements do not contain duplicate attributes</a>
-                     										           
-                  </li>
-                  
-               </ul>
-               
-            </li>
-            
-         </ul>
-         
-      </section>
-      
-      <section id="advisory">
-         <h3>Additional Techniques (Advisory) for Parsing</h3>
-         
-         
-      </section>
-      
-      <section id="failure">
-         <h3>Failures for Parsing</h3>
-         
-         
-         <ul>
-            
-            <li>
-               									         
-               <a href="../Techniques/failures/F70" class="failure">Failure of 4.1.1 due to incorrect use of start and end tags or attribute markup</a>
-               								       
-            </li>
-            
-            <li>
-               									         
-               <a href="../Techniques/failures/F77" class="failure">Failure of 4.1.1 due to duplicate values of type ID</a>
-               								       
-            </li>
-            
-         </ul>
-         
-      </section>
-      
-   </section>
-   
+
+    </section>
+
+    <section id="advisory">
+      <h3>Additional Techniques (Advisory) for Parsing</h3>
+
+
+    </section>
+
+    <section id="failure">
+      <h3>Failures for Parsing</h3>
+
+
+      <ul>
+
+        <li>
+
+          <a href="../Techniques/failures/F70" class="failure">Failure of 4.1.1 due to incorrect use of start and end tags or attribute markup</a>
+
+        </li>
+
+        <li>
+
+          <a href="../Techniques/failures/F77" class="failure">Failure of 4.1.1 due to duplicate values of type ID</a>
+
+        </li>
+
+      </ul>
+
+    </section>
+
+  </section>
+
 </body>
+
 </html>

--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -1,567 +1,580 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head>
-		<meta charset="UTF-8"/>
-		<title>Understanding Non-text Contrast</title>
-		<link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove"/>
-	</head>
-	<body>
-		<h1>Understanding Non-text Contrast</h1>
 
-		<section id="brief">
-			<h2>In brief</h2>
-			<dl>
-				<dt>Goal</dt><dd>Important visual information meets the same minimum contrast required for larger text.</dd>
-				<dt>What to do</dt><dd>Ensure meaningful visual cues achieve 3:1 against the background.</dd>
-				<dt>Why it's important</dt><dd>Some people cannot see elements with low contrast.</dd>
-			</dl>
+<head>
+  <meta charset="UTF-8" />
+  <title>Understanding Non-text Contrast</title>
+  <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove" />
+</head>
 
-		</section>
-		<section id="intent">
-			<h2>Intent</h2>
+<body>
+  <h1>Understanding Non-text Contrast</h1>
 
+  <section id="brief">
+    <h2>In brief</h2>
+    <dl>
+      <dt>Goal</dt>
+      <dd>Important visual information meets the same minimum contrast required for larger text.</dd>
+      <dt>What to do</dt>
+      <dd>Ensure meaningful visual cues achieve 3:1 against the background.</dd>
+      <dt>Why it's important</dt>
+      <dd>Some people cannot see elements with low contrast.</dd>
+    </dl>
 
-			<p>The intent of this Success Criterion is to ensure that user interface components (i.e., controls) and meaningful graphics are distinguishable by people with moderately low vision. The requirements and rationale are similar to those for large text in <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>. Note that this requirement does not apply to <em>inactive</em> user interface components.</p>
+  </section>
+  <section id="intent">
+    <h2>Intent</h2>
 
-			<p>Low contrast controls are more difficult to perceive, and may be completely missed by people with a visual impairment. Similarly, if a graphic is needed to understand the content or functionality of the webpage then it should be perceivable by people with low vision or other impairments without the need for contrast-enhancing assistive technology.</p>
 
-			<div class="note">
-				<p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed values should not be rounded (e.g. 2.999:1 would not meet the 3:1 threshold).</p>
-			</div>
+    <p>The intent of this Success Criterion is to ensure that user interface components (i.e., controls) and meaningful graphics are distinguishable by people with moderately low vision. The requirements and rationale are similar to those for large text in <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>. Note that this requirement does not apply to <em>inactive</em> user interface components.</p>
 
-			<div class="note">
-				<p>Because authors do not have control over user settings for font smoothing and anti-aliasing, when evaluating this
-					 Success Criterion, refer to the colors obtained from the user agent, or the underlying
-					 markup and stylesheets, rather than the non-text elements as presented on screen.</p>
-				<p>Due to anti-aliasing, particularly thin lines and shapes of non-text elements may be rendered by user agents with
-					 a much fainter color than the actual color defined in the underlying CSS. This can lead to situations where
-					 non-text elements have a contrast ratio that nominally passes the Success Criterion, but have a much lower contrast
-					 in practice. In these cases, best practice would be for authors to avoid particularly thin lines and shapes,
-					 or to use a combination of colors that exceeds the normative requirements of this Success Criterion.
-				</p>
-		 </div>
+    <p>Low contrast controls are more difficult to perceive, and may be completely missed by people with a visual impairment. Similarly, if a graphic is needed to understand the content or functionality of the webpage then it should be perceivable by people with low vision or other impairments without the need for contrast-enhancing assistive technology.</p>
 
-			<section id="user-interface-components">
-				<h3>User Interface Components</h3>
+    <div class="note">
+      <p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed values should not be rounded (e.g. 2.999:1 would not meet the 3:1 threshold).</p>
+    </div>
 
-				<p>Unless the control is <em>inactive</em>, any visual information provided that is necessary for a user to identify that a control is present and how to operate it must have a minimum 3:1 contrast ratio with the adjacent colors. Also, any visual information necessary to indicate state, such as whether a component is selected or focused must also ensure that the information used to identify the control in that state has a minimum 3:1 contrast ratio.</p>
+    <div class="note">
+      <p>Because authors do not have control over user settings for font smoothing and anti-aliasing, when evaluating this
+        Success Criterion, refer to the colors obtained from the user agent, or the underlying
+        markup and stylesheets, rather than the non-text elements as presented on screen.</p>
+      <p>Due to anti-aliasing, particularly thin lines and shapes of non-text elements may be rendered by user agents with
+        a much fainter color than the actual color defined in the underlying CSS. This can lead to situations where
+        non-text elements have a contrast ratio that nominally passes the Success Criterion, but have a much lower contrast
+        in practice. In these cases, best practice would be for authors to avoid particularly thin lines and shapes,
+        or to use a combination of colors that exceeds the normative requirements of this Success Criterion.
+      </p>
+    </div>
 
-				<p>This Success Criterion does not require that changes in color that differentiate between states of an individual component meet the 3:1 contrast ratio when they do not appear next to each other. For example, there is not a new requirement that visited links contrast with the default color, or that mouse hover indicators contrast with the default state. However, the component must not lose contrast with the adjacent colors, and non-text indicators such as the check in a checkbox, or an arrow graphic indicating a menu is selected or open must have sufficient contrast to the adjacent colors.</p>
+    <section id="user-interface-components">
+      <h3>User Interface Components</h3>
 
-				<h4>Boundaries</h4>
+      <p>Unless the control is <em>inactive</em>, any visual information provided that is necessary for a user to identify that a control is present and how to operate it must have a minimum 3:1 contrast ratio with the adjacent colors. Also, any visual information necessary to indicate state, such as whether a component is selected or focused must also ensure that the information used to identify the control in that state has a minimum 3:1 contrast ratio.</p>
 
-				<p>This success criterion does not require that controls have a visual boundary indicating the hit area, but if the visual indicator of the control is the only way to identify the control, then that indicator must have sufficient contrast. If text (or an icon) within a button or placeholder text inside a text input is visible and there is no visual indication of the hit area then the Success Criterion is passed. If a button with text also has a colored border, since the border does not provide the only indication there is no contrast requirement beyond the text contrast (<a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>). Note that for people with cognitive disabilities it is recommended to delineate the boundary of controls to aid in the recognition of controls and therefore the completion of activities.</p>
+      <p>This Success Criterion does not require that changes in color that differentiate between states of an individual component meet the 3:1 contrast ratio when they do not appear next to each other. For example, there is not a new requirement that visited links contrast with the default color, or that mouse hover indicators contrast with the default state. However, the component must not lose contrast with the adjacent colors, and non-text indicators such as the check in a checkbox, or an arrow graphic indicating a menu is selected or open must have sufficient contrast to the adjacent colors.</p>
 
-				<figure id="figure-buttons-no-visual-indicator">
-						<img alt="Two buttons, the first with no visual indicator except text saying 'button'. The second is the same but with an added grey border." src="img/minimal-button.png" /> 
-						<figcaption>A button without a visual boundary, and the same button with a focus indicator that is a defined visual boundary of grey (#949494) adjacent to white.</figcaption>
-				</figure>
+      <h4>Boundaries</h4>
 
-				<h4>Adjacent colors</h4>
-				<p>For user interface components 'adjacent colors' means the colors adjacent to the component. For example, if an input has a white internal background, dark border, and white external background the 'adjacent color' to the component would be the white external background.</p>
-				<figure id="figure-standard-text-adjacent-white">
-					<img src="img/text-input-default.png" alt="Standard text input with a label, white internal and external background with a dark border."/>
-					<figcaption>A standard text input with a grey border (#767676) and white adjacent color outside the component</figcaption>
-				</figure>
+      <p>This success criterion does not require that controls have a visual boundary indicating the hit area, but if the visual indicator of the control is the only way to identify the control, then that indicator must have sufficient contrast. If text (or an icon) within a button or placeholder text inside a text input is visible and there is no visual indication of the hit area then the Success Criterion is passed. If a button with text also has a colored border, since the border does not provide the only indication there is no contrast requirement beyond the text contrast (<a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>). Note that for people with cognitive disabilities it is recommended to delineate the boundary of controls to aid in the recognition of controls and therefore the completion of activities.</p>
 
-				<p>If components use several colors, any color which does not interfere with identifying the component can be ignored for the purpose of measuring contrast ratio. For example, a 3D drop-shadow on an input, or a dark border line between contrasting backgrounds is considered to be subsumed into the color closest in brightness (perceived luminance).</p>
-
-				<p>The following example shows an input that has a light background on the inside and a dark background around it. The input also has a dark grey border which is considered to be subsumed into the dark background. The border does not interfere with identifying the component, so the contrast ratio is taken between the white background and dark blue background.</p>
-
-				<figure id="figure-text-box-dark-bg-light-border">
-					<img alt="A text box with a dark background and light border, with a white background." src="img/text-input-background-border.png"/>
-					<figcaption> The contrast of the input background (white) and color adjacent to the control (dark blue #003366) is sufficient. There is also a border (silver) on the component that is not required to contrast with either.</figcaption>
-				</figure>
-
-				<p>For visual information required to identify a state, such as the check in a checkbox or the thumb of a slider, that part might be within the component so the adjacent color might be another part of the component.</p>
-
-				<figure id="figure-purple-box-light-check">
-					<img alt="A purple box with a light grey check." src="img/checkbox-purple.png"/>
-					<figcaption> A customized checkbox with light grey check (#E5E5E5), which has a contrast ratio of 5.6:1 with the purple box (#6221EA).</figcaption>
-				</figure>
-
-				<p>It is possible to use a flat design where the status indicator fills the component and does not contrast with the component, but does contrast with the colors adjacent to the component.</p>
-
-
-				<figure id="figure-three-radios">
-					<img alt="Four radio buttons, the first is a plain circle labelled 'Not selected'. The second shows the circle filled with a darker color than the border. The third is filled with the same color as the border. The fourth has an inner filled circle with a gap between it and the outer border." src="img/radio-custom.png"/>
-					<figcaption>The first radio button shows the default state with a grey (#949494) circle. The second and third show the radio button selected and filled with a color that contrasts with the color adjacent to the component. The last example shows the state indicator contrasting with the component colors.</figcaption>
-				</figure>
-
-				<h4 id="related-color">Relationship with Use of Color</h4>
-
-				<p>The <a href="use-of-color">Use of Color</a> success criterion addresses changing <strong>only the color</strong> (hue) of an object or text without otherwise altering the object's form. The principle is that contrast ratio (the difference in brightness) can be used to distinguish text or graphics. For example, <a href="../Techniques/general/G183.html">G183</a> is a technique to use a contrast ratio of 3:1 with surrounding text to distinguish links and controls. In that case the Working Group regards a link color that meets the 3:1 contrast ratio relative to the non-linked text color as satisfying the Success Criterion <a href="use-of-color">1.4.1 Use of color</a> since it is relying on contrast ratio as well as color (hue) to convey that the text is a link.</p>
-
-				<p>Non-text information within controls that uses a change of hue alone to convey the value or state of an input, such as a 1-5 star indicator with a black outline for each star filled with either yellow (full) or white (empty) is likely to fail the Use of color criterion rather than this one.</p>
-
-				<figure id="figure-two-star-ratings">
-					<img src="img/star-examples-pass.png" alt="Two star ratings, one uses a black outline (on white) with a black fill to indicate it is checked. The second has a yellow fill and a thicker dark border." width="300"/>
-					<figcaption>
-						Two examples which pass this success criterion, using either a solid fill to indicate a checked-state that has contrast, or a thicker border as well as yellow fill.
-					</figcaption>
-				</figure>
-				<figure id="figure-two-star-ratings-failing">
-					<img src="img/star-examples-fail.png" alt="Two star ratings, the first uses 5 stars with a black outline and a yellow or white fill, where yellow indicates checked. The second uses only pale yellow stars on white." width="300"/>
-					<figcaption>
-						Two examples which fail a success criterion, the first fails the Use of color criterion due to relying on yellow and white hues. The second example fails the Non-text contrast criterion due to the yellow (#FFF000) to white contrast ratio of 1.2:1.
-					</figcaption>
-				</figure>
-
-				<p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../Techniques/general/G195.html" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
-
-
-				<h4 id="related-focus">Relationship with Focus Visible</h4>
-
-				<p>In combination with <a href="focus-visible" class="sc">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
-
-				<p>Most focus indicators appear outside the component - in that case it needs to contrast with the background that the component is on. Other cases include focus indicators which are:</p>
-
-				<ul>
-					<li>only inside the component and need to contrast with the adjacent color(s) within the component.</li>
-					<li>the border of the component (inside the component and adjacent to the outside) and need to contrast with both adjacent colours. </li>
-					<li>partly inside and partly outside, where either part of the focus indicator can contrast with the adjacent colors.</li>
-				</ul>
-
-				<figure id="figure-focus-inner">
-					<img src="img/ntc-focus-inner.png" alt="Three blue buttons, the middle has a thick yellow outline well inside the border of the button." width="400"/>
-					<figcaption>
-						The internal yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
-					</figcaption>
-				</figure>
-
-
-				<figure id="figure-focus-outer-yellow">
-					<img src="img/ntc-focus-outer-yellow.png" alt="Three blue buttons on a white background, the middle has a light yellow outline outside of the botton's non-focused boundary." width="400"/>
-					<figcaption>
-						The external yellow indicator (#FFFF00) does not contrast with the white background (#FFF) which the component is on, <strong>failing</strong> the criterion.
-					</figcaption>
-				</figure>
-
-				<figure id="figure-focus-outer-green">
-					<img src="img/ntc-focus-outer-green.png" alt="Three blue buttons on a white background, the middle has a dark green outline outside of the botton's non-focused boundary." width="400"/>
-					<figcaption>
-						The external green indicator (#008000) does contrast with the white background (#FFF) which the component is on, <strong>passing</strong> the criterion. It does not need to contrast with both the component background and the component, as visually the effect is that the button is noticeably larger, and it's not necessary for a user to be able to discern this extra border in isolation. Although this passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag22">There is a AAA criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance.html">Focus Appearance</a></span>.
-					</figcaption>
-				</figure>
-
-				<p>Although the figure above with a dark outline passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag22">There is a criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance" class="sc">Focus Appearance</a>.</span></p>
-				<p>If an indicator is partly inside and partly outside the component, either part of the indicator could provide contrast.</p>
-
-				<figure id="figure-focus-outer-inner">
-					<img src="img/ntc-focus-inner-outer.png" alt="Three blue buttons on a white background, the middle has the outline of a yellow rectangle that is partly inside the button's boundary, and partly outside on the white background." width="400"/>
-					<figcaption>
-						The focus indicator is partially inside, partially outside the button. The internal part of the yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
-					</figcaption>
-				</figure>
-
-				<p>If the focus indicator changes the border of the component within the visible boundary it must contrast with the component. Typically an outline goes around (outside) the visible boundary of the component, in this case changing the border is just inside the visible edge of the component.</p>
-
-				<figure id="figure-focus-border">
-					<img src="img/ntc-focus-border.png" alt="Three blue buttons on a white background, the center button has a green border exactly on the outer boundary of the button." width="400"/>
-					<figcaption>
-						The border of the control changes from blue (#4189B9) to green (#4B933A). This is within the component and does not contrast with the inside background of the component therefore <strong>fails</strong> non-text contrast.
-					</figcaption>
-				</figure>
-
-				<figure id="figure-focus-inner-green">
-					<img src="img/ntc-focus-inner-border.png" alt="Three blue buttons with a black border on a white background, the center button has a green border inside, adjacent to the inner background and black border." width="400"/>
-					<figcaption>
-						An inner border of dark green (#008000) does contrast with the black border, but does not contrast with the blue component background, therefore <strong>fails</strong> non-text contrast.
-					</figcaption>
-				</figure>
-
-				<figure id="figure-focus-inner-white">
-					<img src="img/ntc-focus-inner-white.png" alt="Three blue buttons with a black border on a white background, the center button has a white border inside, adjacent to the inner background and black border." width="400"/>
-					<figcaption>
-						An inner border of white contrasts with the black border and the blue component background, therefore <strong>passes</strong> non-text contrast.
-					</figcaption>
-				</figure>
-
-		        <p>Note that this Success Criterion does not directly compare the focused and unfocused states of a control - if the focus state relies on a change of color (e.g., changing <em>only</em> the background color of a button), this Success Criterion does not define any requirement for the difference in contrast between the two states.</p>
-
-				<figure id="figure-focus-background">
-					<img src="img/ntc-focus-background.png" alt="Three blue buttons, the center button is a lighter blue than the others." width="400"/>
-					<figcaption>
-						The change of background within the component is not in scope of non-text contrast. However, this would not pass <a href="use-of-color.html">Use of color</a>.
-					</figcaption>
-				</figure>
-
-				<section>
-					<h4>User Interface Component Examples</h4>
-					<p>For designing focus indicators, selection indicators and user interface components that need to be perceived clearly, the following are examples that have sufficient contrast.</p>
-
-					<table class="left-headers">
-						<caption>
-							User Interface Component Examples
-						</caption>
-						<tr>
-						<th>Type</th>
-						<th>Description</th>
-						<th>Examples</th>
-						</tr>
-						<tr>
-							<th>Link Text</th>
-							<td>Default link text is in the scope of <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>, and the underline is sufficient to indicate the link.</td>
-							<td><img src="img/link-text-default.png" alt="A browser-default styled link, blue with an underline."/></td>
-						</tr>
-						<tr>
-							<th>Default focus style</th>
-							<td>Links are required to have a visible focus indicator by <a href="focus-visible.html">2.4.7 Focus Visible</a>. Where the focus style of the user-agent is not adjusted on interactive controls (such as links, form fields or buttons) by the website (author), the default focus style is exempt from contrast requirements (but must still be visible).</td>
-							<td><img src="img/link-text-focus.png" alt="A browser-default styled link, with a black dotted outline around the link."/></td>
-						</tr>
-						<tr>
-							<th>Buttons</th>
-							<td>A button which has a distinguishing indicator such as position, text style, or context does not need a <em>contrasting</em> visual indicator to show that it is a button, although some users are likely to identify a button with an outline that meets contrast requirements more easily.</td>
-							<td><img src="img/button-background.png" alt="Button with a faint blue background." width="100"/></td>
-						</tr>
-						<tr>
-							<th>Text input (minimal)</th>
-							<td>Where a text-input has a visual indicator to show it is an input, such as a bottom border (#767676), that indicator must meet 3:1 contrast ratio.</td>
-							<td>
-								<img src="img/text-input-minimal.png" alt="A label with a text input shown by a bottom border and faint grey background."/>
-							</td>
-						</tr>
-						<tr>
-							<th>Text input</th>
-							<td>Where a text-input has an indicator such as a complete border (#767676), that indicator must meet 3:1 contrast ratio.</td>
-							<td>
-								<img src="img/text-input-default.png" alt="A label with a text input shown by a complete border."/>
-							</td>
-						</tr>
-						<tr>
-							<th>Text input focus style</th>
-							<td>A focus indicator is required. While in this case the additional gray (#CCC) outline has an insufficient contrast of 1.6:1 against the white (#FFF) background, the cursor/caret which is displayed when the input receives focus <em>does</em> provide a sufficiently strong visual indication.</td>
-							<td>
-								<img src="img/text-input-focus.png" alt="A label with a text input with a faint gray outline and a visible cursor/caret."/>
-							</td>
-						</tr>
-						<tr> 
-							<th>Text input using background color</th>
-							<td>Text inputs that have no border and are differentiated only by a background color must have a 3:1 contrast ratio to the adjacent background (#043464).</td>
-							<td>
-								<img src="img/text-input-background.png" alt="A label with a text input shown by a dark blue page background, and white box."/>
-							</td>
-						</tr>
-						<tr>
-							<th>Toggle button</th>
-							<td>The toggle button's internal background (#070CD5) has a good contrast with the external white background. Also, the round toggle within (#7AC2FF) contrasts with the internal background.</td>
-							<td><img src="img/toggle.png" alt="Dark blue oval toggle button with light blue internal indicator." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Dropdown indicator</th>
-							<td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 4.7:1 for the white icon on dark gray (#6E747B).</td>
-							<td><img src="img/dropdown.png" alt="Button with the word Menu, and a down-arrow icon next to it." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Dropdown indicator</th>
-							<td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 21:1 for the black icon on white.</td>
-							<td><img src="img/dropdown2.png" alt="Text with the word Menu, and a down-arrow icon next to it." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Checkbox - empty</th>
-							<td>A black border on a white background indicates the checkbox.</td>
-							<td><img src="img/checkbox-example1.png" alt="Black square border with a text label." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Checkbox - checked</th>
-							<td>A black border on a white background indicates the checkbox, the black tick shape indicates the state of checked.</td>
-							<td><img src="img/checkbox-example2.png" alt="Black square border with a tick inside, and a text label." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Checkbox - Fail</th>
-							<td>The grey border color of the checkbox (#9D9D9D) has a contrast ratio of 2.7:1 with the white background, which is not sufficient for the visual information required to identify the checkbox.</td>
-							<td><img src="img/checkbox-example3.png" alt="Grey box on a white background with a black tick in the middle." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Checkbox - Subtle hover style</th>
-							<td>A black border on a white background indicates the checkbox, when the mouse pointer activates the subtle hover state adds a grey background (#DEDEDE). The black border has a 15:1 contrast ratio with the grey background.</td>
-							<td><img src="img/checkbox-example4.png" alt="Blackbox on a circular grey background next to a text label." width="150"/></td>
-						</tr>
-						<tr>
-							<th>Checkbox - Subtle focus style - fail</th>
-							<td>A focus indicator is required. If the focus indicator is styled by the author, it must meet the 3:1 contrast ratio with adjacent colors. In this case, the gray (#AAA) indicator has an insufficient ratio of 2.3:1 with the white (#FFF) adjacent background.</td>
-							<td>
-								<img src="img/checkbox-example5.png" alt="Unchecked checkbox with a thick gray additional outline as focus indication." width="150"/>
-							</td>
-						</tr>
-					</table>
-
-				</section>
-				<section id="inactive-controls">
-					<h4>Inactive User Interface Components</h4>
-
-					<p>User Interface Components that are not available for user interaction (e.g., a disabled control in HTML) are not required to meet contrast requirements. An inactive user interface component is visible but not currently operable. An example would be a submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed.</p>
-					<figure id="figure-grey-button-and-text">
-						<img src="img/inactive-button.png" alt="Grey button with non-contrasting grey text." width="120"/>
-						<figcaption> An inactive button using default browser styles</figcaption>
-					</figure>
-					<p>Inactive components, such as disabled controls in HTML, are not available for user interaction. The decision to exempt inactive controls from the contrast requirements was based on a number of considerations. Although it would be beneficial to some people to discern inactive controls, a one-size-fits-all solution has been very difficult to establish. A method of varying the presentation of disabled controls, such as adding an icon for disabled controls, based on user preferences is anticipated as an advancement in the future.</p>
-				</section>
-			</section><!-- end user-interface-component section -->
-
-
-			<section id="graphical-objects">
-				<h3>Graphical Objects</h3>
-
-
-				<p>The term &quot;graphical object&quot; applies to stand-alone icons such as a print icon (with no text), and the important parts of a more complex diagram such as each line in a graph. For simple graphics such as single-color icons the entire image is a graphical object. Images made up of multiple lines, colors and shapes will be made of multiple graphical objects, some of which are required for understanding.</p>
-
-				<p>Not every graphical object needs to contrast with its surroundings - only those that are required for a user to understand what the graphic is conveying. <a href="https://en.wikipedia.org/wiki/Gestalt_psychology#Pr.C3.A4gnanz">Gestalt principles</a> such as the &quot;law of continuity&quot; can be used to ignore minor overlaps with other graphical objects or colors.</p>
-
-				<table class="data">
-					<thead>
-						<tr>
-							<th>Image</th>
-							<th>Notes</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td><img src="img/contrast-phone.png" alt="An orange circle with a white telephone icon in the middle." width="40"/></td>
-							<td><p>The phone icon is a simple shape within the orange (#E3660E) circle. The meaning can be understood from that icon alone, the background behind the circle is irrelevant. The orange background and the white icon have a contrast ratio greater than 3:1, which passes.</p>
-							<p>The graphical object is the white phone icon.</p>
-							</td>
-						</tr>
-						<tr>
-							<td><img src="img/contrast-magnet.png" alt="A red magnet with grey tips and a black outline."/></td>
-							<td><p>A magnet can be understood by the "U" shape with lighter colored tips. Therefore to understand this graphic you should be able to discern the overall shape (against the background) and the lighter colored tips (against the rest of the U shape and the background).</p>
-							<p>The graphical objects are the "U" shape (by outline or by the solid red color #D0021B), and each tip of the magnet.</p>
-							</td>
-						</tr>
-						<tr>
-							<td><img src="img/contrast-currency-down.png" alt="A yellow arrow pointing down with a pound sign (currency) in the middle."/></td>
-							<td><p>The symbol to show a currency (the £) going down can be understood with recognition of the shape (down arrow) and the currency symbol (pound icon with the shape which is part of the graphic). To understand this graphic you need to discern the arrow shape against the white background, and the pound icon against the yellow background (#F5A623).</p>
-							<p>The graphical objects are the shape and the currency symbol.</p>
-							</td>
-						</tr>
-						<tr>
-							<td><!-- Sourced from wikipedia under CC sharealike license https://en.wikipedia.org/wiki/File:Simple_line_graph_of_ACE_2012_results_by_candidate_sj01.png -->
-								<a href="img/simple-line-graph.png"><img src="img/simple-line-graph.png" alt="A line chart of votes across a region, with 4 lines of different colors tracking over time." width="200"/></a></td>
-
-							<td><p>In order to understand the graph you need to discern the lines and shapes for each condition. To perceive the values of each line along the chart you need to discern the grey lines marking the graduated 100 value increments.</p>
-							<p>The graphical objects are the lines in the graph, including the background lines for the values, and the colored lines with shapes.</p>
-							<p>The lines should have 3:1 contrast against their background, but as there is little overlap with other lines they do not need to contrast with each other or the graduated lines. (See the testing principles below.)</p>
-						</td>
-
-						</tr>
-						<tr>
-							<td><a href="img/graphics-contrast_pie-chart_pass.png"><img src="img/graphics-contrast_pie-chart_pass.png" alt="A pie chart with small gaps between each slice showing the white background, and a dark outline around light colored slices." width="200"/></a></td>
-							<td><p>To understand the pie chart you have to discern each slice of the pie chart from the others.</p>
-							<p>The graphical objects are the slices of the pie (chart).</p>
-							<p>Note: If the values of the pie chart slices were also presented in a conforming manner (see the Pie Charts example for details), the slices would not be required for understanding.</p>
-						</td>
-						</tr>
-					</tbody>
-				</table>
-
-				<p>Taking the magnet image above as an example, the process for establishing the graphical object(s) is to:</p>
-				<ul>
-					<li>Assess what part of each image is needed to understand what it represents.<br/>
-						The magnet's "U" shape can be conveyed by the outline or by the red background (either is acceptable). The white tips are also important (otherwise it would be a horseshoe), which needs to contrast with the red background.</li>
-					<li>Assume that the user could only see those aspects. Do they contrast with the adjacent colors?<br/>
-						The outline of the magnet contrasts with the surrounding text (black/white), and the red and white between the tips also has sufficient contrast.</li>
-				</ul>
-
-				<p>Due to the strong contrast of the red and white, it would also be possible to only put the outline around the white tips of the magnet and it would still conform.</p>
-
-				<section>
-				<h4>Required for Understanding</h4>
-
-				<p>The term &quot;required for understanding&quot; is used in the Success Criterion as many graphics do not need to meet the contrast requirements. If a person needs to perceive a graphic, or part of a graphic (a graphical object) in order to understand the content it should have sufficient contrast. However, that is not a requirement when:</p>
-				<ul>
-					<li>
-						<p>A graphic with text embedded or overlayed conveys the same information, such as labels <em>and</em> values on a chart.</p>
-						<p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
-					</li>
-					<li> The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
-					<li> The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
-					<li> The graphic is part of a logo or brand name (which is considered &quot;essential&quot; to its presentation).</li>
-				</ul>
-				</section>
-				<section>
-				<h4>Gradients</h4>
-
-				<p>Gradients can reduce the apparent contrast between areas, and make it more difficult to test. The general principles is to identify the graphical object(s) required for understanding, and take the central color of that area. If you remove the adjacent color which does not have sufficient contrast, can you still identify and understand the graphical object?</p>
-				<figure id="figure-blue-circle-i-versions">
-          <img src="img/contrast-gradient.png" alt="Two versions of a blue circle with an 'i' indicating information. The first example has a blue gradient background, the second is missing the upper half of the background which obscures the i." width="300"/>
-				<figcaption>Removing the background which does not have sufficient contrast highlights that the graphical object (the &quot;i&quot;) is not then understandable.</figcaption></figure>
-				</section>
-				<section>
-				<h4>Dynamic Examples</h4>
-
-				<p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, the unfocused default version must already have sufficiently contrasting colors or text. For the area that receives focus, information can then be made available dynamically as pop-up text, or be foregrounded dynamically by increasing the contrast.</p>
-
-				<!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
-				<figure id="figure-pie-slice-hover-data">
-					<img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350"/> 
-					<figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
-				</figure>
-				</section>
-				<section>
-				<h4>Infographics</h4>
-
-				<p>Infographics can mean any graphic conveying data, such as a chart or diagram. On the web it is often used to indicate a large graphic with lots of statements, pictures, charts or other ways of conveying data. In the context of graphics contrast, each item within such an infographic should be treated as a set of graphical objects, regardless of whether it is in one file or separate files.</p>
-
-				<p>Infographics often fail to meet several WCAG level AA criteria including:</p>
-
-				<ul>
-					<li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
-					<li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
-					<li><a href="contrast-minimum" class="sc">1.4.3 (Text) Contrast</a></li>
-					<li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
-				</ul>
-
-				<p>An infographic can use text which meets the other criteria to minimise the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infograph is not relied upon for understanding.</p>
-
-				</section>
-
-				<section>
-					<h4>Symbolic text characters</h4>
-					<p>When text characters are used as symbols – used for their visual appearance, rather than <q>expressing something in human language</q> – they fall under the definition of <a>non-text content</a>.</p>
-					<figure id="figure-text-symbols">
-						<img alt="A button using an uppercase 'X' and a button with a greater-than character" src="img/buttons-text-symbols.png" />
-						<figcaption>Even though the two buttons use text characters — an uppercase <q>X</q>, often used for "Close" buttons, and a <q>&gt;</q> character, to act as a right-pointing arrow — they count as non-text characters/symbols. Their contrast ratio of just above 3:1 passes this Success Criterion.</figcaption>
-					</figure>
-				</section>
-
-				<section>
-					<h4>Essential Exception</h4>
-
-					<p>Graphical objects do not have to meet the contrast requirements when &quot;a particular presentation of graphics is essential to the information being conveyed&quot;. The Essential exception is intended to apply when there is no way of presenting the graphic with sufficient contrast without undermining the meaning. For example:</p>
-					<ul>
-						<li><strong>Logotypes and flags</strong>: The brand logo of an organization or product is the representation of that organization and therefore exempt. Flags may not be identifiable if the colors are changed to have sufficient contrast.</li>
-						<li><strong>Sensory</strong>: There is no requirement to change pictures of real life scenes such as photos of people or scenery.</li>
-						<li><strong>Representing other things</strong>: If you cannot represent the graphic in any other way, it is essential. Examples include: 
-							<ul>
-								<li>Screenshots to demonstrate how a website appeared.</li>
-								<li>Diagrams of medical information that use the colors found in biology (<a href="https://commons.wikimedia.org/wiki/File:Schematic_diagram_of_the_human_eye_it.svg">example medical schematic from Wikipedia</a>).</li>
-								<li>color gradients that represent a measurement, such as heat maps (<a href="https://commons.wikimedia.org/wiki/File:Eyetracking_heat_map_Wikipedia.jpg">example heatmap from Wikipedia</a>).</li>
-							</ul>
-						</li>
-					</ul>
-				</section>
-
-			<section id="testing-principles">
-					<h3>Testing Principles</h3>
-					<p>A summary of the high-level process for finding and assessing non-text graphics on a web page:</p>
-					<ul>
-						<li>Identify each user-interface component (link, button, form control) on the page and:
-							<ul>
-								<li>Identify the visual (non-text) indicators of the component that are required to identify that a control exists, and indicate the current state. In the default (on page load) state, test the contrast ratio against the adjacent colors.</li>
-								<li>Test those contrast indicators in each state.</li>
-							</ul>
-						</li>
-						<li>Identify each graphic on the page that includes information required for understanding the content (i.e. excluding graphics which have visible text for the same information, or are decorative) and:
-							<ul>
-								<li>Check the contrast of the graphical object against its adjacent colors;</li>
-								<li>If there are multiple colors and/or a gradient, choose the least contrasting area to test;</li>
-								<li>If it passes, move to the next graphical object;</li>
-								<li>If the least-contrasting area is less than 3:1, assume that area is invisible, is the graphical object still understandable?</li>
-								<li>If there is enough of the graphical object to understand, it passes, else fail.</li>
-							</ul>
-						</li>
-					</ul>
-					<p>The techniques below each have testing criteria, and the related criteria for <a href="focus-visible">Focus visible (2.4.7)</a>, <a href="use-of-color">Use of color (1.4.1)</a>, and <a href="contrast-minimum">Contrast minimum</a> also have techniques.</p>
-			</section>
-
-			</section>
-			
-		</section><!-- end Intent -->
-
-		<section id="benefits">
-			<h2>Benefits</h2>
-			<p>People with low vision often have difficulty perceiving graphics that have insufficient contrast. This can be exacerbated if the person has a color vision deficiency that lowers the contrast even further. Providing a <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef">relative luminance</a> (lightness difference) of 3:1 or greater can make these items more distinguishable when the person does not see a full range of colors.</p>
-		</section>
-
-		<section id="examples">
-			<h2>Graphical Object Examples</h2>
-			<ul>
-				<li>Status icons on an application's dashboard (without associated text) have a 3:1 minimum contrast ratio.</li>
-				<li>A text input has a dark border around the white editable area.</li>
-				<li>A graph uses a light background and ensures that the colors for each line have a 3:1 contrast ratio against the background.</li>
-			</ul>
-			<section class="example">
-				<h3>Pie Charts</h3>
-				<p>Pie charts make a good case study for the graphical objects part of this success criterion, the following pie charts are intended to convey the proportion of market share each browser has. Please Note: The actual figures are made up, these are not actual market shares. </p>
-				<figure id="figure-failing-pie-chart">
-					<img src="img/graphics-contrast_pie-chart_fail.png" alt="Failing pie chart"/>
-					<figcaption>
-						<p><strong>Fail:</strong> The pie chart has labels for each slice (so passes 1.4.1 Use of Color), but in order to understand the proportions of the slices you must discern the edges of the slices (the graphical objects conveying essential information), and the contrast between the slices is not  3:1 or greater. </p>
-					</figcaption>
-				</figure>
-				<figure id="figure-not-applicable-pie-chart">
-					<img src="img/graphics-contrast_pie-chart_na.png" alt="Not applicable pie chart"/>
-					<figcaption>
-						<p><strong>Not applicable:</strong> The pie chart has visible labels <em>and</em> values that convey equivalent information to the graphical objects (the pie slices). </p>
-					</figcaption>
-				</figure>
-				<figure id="figure-passing-pie-chart">
-					<img src="img/graphics-contrast_pie-chart_pass.png" alt="Passing pie chart"/>
-					<figcaption>
-						<p><strong>Pass:</strong> The pie chart has visible labels, and sufficient contrast around and between the slices of the pie chart (the graphical objects). A darker border has been added around the yellow slice in order to achieve the contrast level.</p>
-					</figcaption>
-				</figure>
-			</section>
-			<section class="example">
-				<h3>Infographics</h3>
-				<figure id="figure-infographic-light-circles">
-					<img src="img/infographic-fail.png" alt="An infographic showing lightly colored circles of various sizes to indicate the size of five different social networks"/>
-					<figcaption>
-						<p><strong>Fail:</strong> Discerning the circles is required to understand the size of network and discerning the icons in each circle is required to identify which network it shows.</p>
-					</figcaption>
-				</figure>
-				<p>The graphical objects are the circles (measured against the background) and the icons in each circle (measured against the circle's background).</p>
-				<figure id="figure-infographic-contrasting-text">
-					<img src="img/infographic-pass.png" alt="The same infographic with contrasting text, dark borders around the circles, and contrasting icons."/>
-					<figcaption>
-						<p><strong>Pass:</strong> The circles have contrasting borders and the icons are a contrasting dark color against the light circle backgrounds.</p>
-					</figcaption>
-				</figure>
-				<p>There are many possible solutions to ensuring contrast, the example shows the use of borders. Other techniques are to use darker colors for the circle backgrounds, or to add text labels &amp; values for each item.</p>
-			</section>
-		</section><!-- end graphic-object-examples -->
-			
-
-		<section id="resources">
-			<h2>Resources </h2>
-			<ul>
-				<li><a href="http://w3c.github.io/low-vision-a11y-tf/requirements.html">Accessibility Requirements for People with Low Vision</a>.</li>
-				<li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017May/0007.html">Smith Kettlewell Eye Research Institute</a> -  &quot;If the text is better understood with the graphics, they should be equally visible as the text&quot;.</li>
-				<li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017Jun/0054.html">Gordon Legge</a> - &quot;Contrast requirements for form controls should be equivalent to contrast requirements for text&quot;.</li>
-			</ul>
-		</section>
-		<section id="techniques">
-			<h2>Techniques</h2>
-			<section id="sufficient">
-				<h3>Sufficient</h3>
-				<section class="situation">
-						<h4>Situation A: Color is used to identify user interface components or used to identify user interface component states</h4>
-						<ul>
-							<li><a href="../Techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
-							<li><a href="../Techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
-						</ul>
-				</section>
-				<section class="situation">
-					<h4>Situation B: Color is required to understand graphical content</h4>
-					<ul>
-						<li><a href="../Techniques/general/G207" class="general">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>
-						<li><a href="../Techniques/general/G209" class="general">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>
-					</ul>
-				</section>
-
-			</section><!--
+      <figure id="figure-buttons-no-visual-indicator">
+        <img alt="Two buttons, the first with no visual indicator except text saying 'button'. The second is the same but with an added grey border." src="img/minimal-button.png" />
+        <figcaption>A button without a visual boundary, and the same button with a focus indicator that is a defined visual boundary of grey (#949494) adjacent to white.</figcaption>
+      </figure>
+
+      <h4>Adjacent colors</h4>
+      <p>For user interface components 'adjacent colors' means the colors adjacent to the component. For example, if an input has a white internal background, dark border, and white external background the 'adjacent color' to the component would be the white external background.</p>
+      <figure id="figure-standard-text-adjacent-white">
+        <img src="img/text-input-default.png" alt="Standard text input with a label, white internal and external background with a dark border." />
+        <figcaption>A standard text input with a grey border (#767676) and white adjacent color outside the component</figcaption>
+      </figure>
+
+      <p>If components use several colors, any color which does not interfere with identifying the component can be ignored for the purpose of measuring contrast ratio. For example, a 3D drop-shadow on an input, or a dark border line between contrasting backgrounds is considered to be subsumed into the color closest in brightness (perceived luminance).</p>
+
+      <p>The following example shows an input that has a light background on the inside and a dark background around it. The input also has a dark grey border which is considered to be subsumed into the dark background. The border does not interfere with identifying the component, so the contrast ratio is taken between the white background and dark blue background.</p>
+
+      <figure id="figure-text-box-dark-bg-light-border">
+        <img alt="A text box with a dark background and light border, with a white background." src="img/text-input-background-border.png" />
+        <figcaption> The contrast of the input background (white) and color adjacent to the control (dark blue #003366) is sufficient. There is also a border (silver) on the component that is not required to contrast with either.</figcaption>
+      </figure>
+
+      <p>For visual information required to identify a state, such as the check in a checkbox or the thumb of a slider, that part might be within the component so the adjacent color might be another part of the component.</p>
+
+      <figure id="figure-purple-box-light-check">
+        <img alt="A purple box with a light grey check." src="img/checkbox-purple.png" />
+        <figcaption> A customized checkbox with light grey check (#E5E5E5), which has a contrast ratio of 5.6:1 with the purple box (#6221EA).</figcaption>
+      </figure>
+
+      <p>It is possible to use a flat design where the status indicator fills the component and does not contrast with the component, but does contrast with the colors adjacent to the component.</p>
+
+
+      <figure id="figure-three-radios">
+        <img alt="Four radio buttons, the first is a plain circle labelled 'Not selected'. The second shows the circle filled with a darker color than the border. The third is filled with the same color as the border. The fourth has an inner filled circle with a gap between it and the outer border." src="img/radio-custom.png" />
+        <figcaption>The first radio button shows the default state with a grey (#949494) circle. The second and third show the radio button selected and filled with a color that contrasts with the color adjacent to the component. The last example shows the state indicator contrasting with the component colors.</figcaption>
+      </figure>
+
+      <h4 id="related-color">Relationship with Use of Color</h4>
+
+      <p>The <a href="use-of-color">Use of Color</a> success criterion addresses changing <strong>only the color</strong> (hue) of an object or text without otherwise altering the object's form. The principle is that contrast ratio (the difference in brightness) can be used to distinguish text or graphics. For example, <a href="../Techniques/general/G183.html">G183</a> is a technique to use a contrast ratio of 3:1 with surrounding text to distinguish links and controls. In that case the Working Group regards a link color that meets the 3:1 contrast ratio relative to the non-linked text color as satisfying the Success Criterion <a href="use-of-color">1.4.1 Use of color</a> since it is relying on contrast ratio as well as color (hue) to convey that the text is a link.</p>
+
+      <p>Non-text information within controls that uses a change of hue alone to convey the value or state of an input, such as a 1-5 star indicator with a black outline for each star filled with either yellow (full) or white (empty) is likely to fail the Use of color criterion rather than this one.</p>
+
+      <figure id="figure-two-star-ratings">
+        <img src="img/star-examples-pass.png" alt="Two star ratings, one uses a black outline (on white) with a black fill to indicate it is checked. The second has a yellow fill and a thicker dark border." width="300" />
+        <figcaption>
+          Two examples which pass this success criterion, using either a solid fill to indicate a checked-state that has contrast, or a thicker border as well as yellow fill.
+        </figcaption>
+      </figure>
+      <figure id="figure-two-star-ratings-failing">
+        <img src="img/star-examples-fail.png" alt="Two star ratings, the first uses 5 stars with a black outline and a yellow or white fill, where yellow indicates checked. The second uses only pale yellow stars on white." width="300" />
+        <figcaption>
+          Two examples which fail a success criterion, the first fails the Use of color criterion due to relying on yellow and white hues. The second example fails the Non-text contrast criterion due to the yellow (#FFF000) to white contrast ratio of 1.2:1.
+        </figcaption>
+      </figure>
+
+      <p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../Techniques/general/G195.html" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
+
+
+      <h4 id="related-focus">Relationship with Focus Visible</h4>
+
+      <p>In combination with <a href="focus-visible" class="sc">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
+
+      <p>Most focus indicators appear outside the component - in that case it needs to contrast with the background that the component is on. Other cases include focus indicators which are:</p>
+
+      <ul>
+        <li>only inside the component and need to contrast with the adjacent color(s) within the component.</li>
+        <li>the border of the component (inside the component and adjacent to the outside) and need to contrast with both adjacent colours. </li>
+        <li>partly inside and partly outside, where either part of the focus indicator can contrast with the adjacent colors.</li>
+      </ul>
+
+      <figure id="figure-focus-inner">
+        <img src="img/ntc-focus-inner.png" alt="Three blue buttons, the middle has a thick yellow outline well inside the border of the button." width="400" />
+        <figcaption>
+          The internal yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
+        </figcaption>
+      </figure>
+
+
+      <figure id="figure-focus-outer-yellow">
+        <img src="img/ntc-focus-outer-yellow.png" alt="Three blue buttons on a white background, the middle has a light yellow outline outside of the botton's non-focused boundary." width="400" />
+        <figcaption>
+          The external yellow indicator (#FFFF00) does not contrast with the white background (#FFF) which the component is on, <strong>failing</strong> the criterion.
+        </figcaption>
+      </figure>
+
+      <figure id="figure-focus-outer-green">
+        <img src="img/ntc-focus-outer-green.png" alt="Three blue buttons on a white background, the middle has a dark green outline outside of the botton's non-focused boundary." width="400" />
+        <figcaption>
+          The external green indicator (#008000) does contrast with the white background (#FFF) which the component is on, <strong>passing</strong> the criterion. It does not need to contrast with both the component background and the component, as visually the effect is that the button is noticeably larger, and it's not necessary for a user to be able to discern this extra border in isolation. Although this passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag2.2">There is a AAA criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance.html">Focus Appearance</a></span>.
+        </figcaption>
+      </figure>
+
+      <p>Although the figure above with a dark outline passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag2.2">There is a criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance" class="sc">Focus Appearance</a>.</span></p>
+      <p>If an indicator is partly inside and partly outside the component, either part of the indicator could provide contrast.</p>
+
+      <figure id="figure-focus-outer-inner">
+        <img src="img/ntc-focus-inner-outer.png" alt="Three blue buttons on a white background, the middle has the outline of a yellow rectangle that is partly inside the button's boundary, and partly outside on the white background." width="400" />
+        <figcaption>
+          The focus indicator is partially inside, partially outside the button. The internal part of the yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
+        </figcaption>
+      </figure>
+
+      <p>If the focus indicator changes the border of the component within the visible boundary it must contrast with the component. Typically an outline goes around (outside) the visible boundary of the component, in this case changing the border is just inside the visible edge of the component.</p>
+
+      <figure id="figure-focus-border">
+        <img src="img/ntc-focus-border.png" alt="Three blue buttons on a white background, the center button has a green border exactly on the outer boundary of the button." width="400" />
+        <figcaption>
+          The border of the control changes from blue (#4189B9) to green (#4B933A). This is within the component and does not contrast with the inside background of the component therefore <strong>fails</strong> non-text contrast.
+        </figcaption>
+      </figure>
+
+      <figure id="figure-focus-inner-green">
+        <img src="img/ntc-focus-inner-border.png" alt="Three blue buttons with a black border on a white background, the center button has a green border inside, adjacent to the inner background and black border." width="400" />
+        <figcaption>
+          An inner border of dark green (#008000) does contrast with the black border, but does not contrast with the blue component background, therefore <strong>fails</strong> non-text contrast.
+        </figcaption>
+      </figure>
+
+      <figure id="figure-focus-inner-white">
+        <img src="img/ntc-focus-inner-white.png" alt="Three blue buttons with a black border on a white background, the center button has a white border inside, adjacent to the inner background and black border." width="400" />
+        <figcaption>
+          An inner border of white contrasts with the black border and the blue component background, therefore <strong>passes</strong> non-text contrast.
+        </figcaption>
+      </figure>
+
+      <p>Note that this Success Criterion does not directly compare the focused and unfocused states of a control - if the focus state relies on a change of color (e.g., changing <em>only</em> the background color of a button), this Success Criterion does not define any requirement for the difference in contrast between the two states.</p>
+
+      <figure id="figure-focus-background">
+        <img src="img/ntc-focus-background.png" alt="Three blue buttons, the center button is a lighter blue than the others." width="400" />
+        <figcaption>
+          The change of background within the component is not in scope of non-text contrast. However, this would not pass <a href="use-of-color.html">Use of color</a>.
+        </figcaption>
+      </figure>
+
+      <section>
+        <h4>User Interface Component Examples</h4>
+        <p>For designing focus indicators, selection indicators and user interface components that need to be perceived clearly, the following are examples that have sufficient contrast.</p>
+
+        <table class="left-headers">
+          <caption>
+            User Interface Component Examples
+          </caption>
+          <tr>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Examples</th>
+          </tr>
+          <tr>
+            <th>Link Text</th>
+            <td>Default link text is in the scope of <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>, and the underline is sufficient to indicate the link.</td>
+            <td><img src="img/link-text-default.png" alt="A browser-default styled link, blue with an underline." /></td>
+          </tr>
+          <tr>
+            <th>Default focus style</th>
+            <td>Links are required to have a visible focus indicator by <a href="focus-visible.html">2.4.7 Focus Visible</a>. Where the focus style of the user-agent is not adjusted on interactive controls (such as links, form fields or buttons) by the website (author), the default focus style is exempt from contrast requirements (but must still be visible).</td>
+            <td><img src="img/link-text-focus.png" alt="A browser-default styled link, with a black dotted outline around the link." /></td>
+          </tr>
+          <tr>
+            <th>Buttons</th>
+            <td>A button which has a distinguishing indicator such as position, text style, or context does not need a <em>contrasting</em> visual indicator to show that it is a button, although some users are likely to identify a button with an outline that meets contrast requirements more easily.</td>
+            <td><img src="img/button-background.png" alt="Button with a faint blue background." width="100" /></td>
+          </tr>
+          <tr>
+            <th>Text input (minimal)</th>
+            <td>Where a text-input has a visual indicator to show it is an input, such as a bottom border (#767676), that indicator must meet 3:1 contrast ratio.</td>
+            <td>
+              <img src="img/text-input-minimal.png" alt="A label with a text input shown by a bottom border and faint grey background." />
+            </td>
+          </tr>
+          <tr>
+            <th>Text input</th>
+            <td>Where a text-input has an indicator such as a complete border (#767676), that indicator must meet 3:1 contrast ratio.</td>
+            <td>
+              <img src="img/text-input-default.png" alt="A label with a text input shown by a complete border." />
+            </td>
+          </tr>
+          <tr>
+            <th>Text input focus style</th>
+            <td>A focus indicator is required. While in this case the additional gray (#CCC) outline has an insufficient contrast of 1.6:1 against the white (#FFF) background, the cursor/caret which is displayed when the input receives focus <em>does</em> provide a sufficiently strong visual indication.</td>
+            <td>
+              <img src="img/text-input-focus.png" alt="A label with a text input with a faint gray outline and a visible cursor/caret." />
+            </td>
+          </tr>
+          <tr>
+            <th>Text input using background color</th>
+            <td>Text inputs that have no border and are differentiated only by a background color must have a 3:1 contrast ratio to the adjacent background (#043464).</td>
+            <td>
+              <img src="img/text-input-background.png" alt="A label with a text input shown by a dark blue page background, and white box." />
+            </td>
+          </tr>
+          <tr>
+            <th>Toggle button</th>
+            <td>The toggle button's internal background (#070CD5) has a good contrast with the external white background. Also, the round toggle within (#7AC2FF) contrasts with the internal background.</td>
+            <td><img src="img/toggle.png" alt="Dark blue oval toggle button with light blue internal indicator." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Dropdown indicator</th>
+            <td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 4.7:1 for the white icon on dark gray (#6E747B).</td>
+            <td><img src="img/dropdown.png" alt="Button with the word Menu, and a down-arrow icon next to it." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Dropdown indicator</th>
+            <td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 21:1 for the black icon on white.</td>
+            <td><img src="img/dropdown2.png" alt="Text with the word Menu, and a down-arrow icon next to it." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Checkbox - empty</th>
+            <td>A black border on a white background indicates the checkbox.</td>
+            <td><img src="img/checkbox-example1.png" alt="Black square border with a text label." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Checkbox - checked</th>
+            <td>A black border on a white background indicates the checkbox, the black tick shape indicates the state of checked.</td>
+            <td><img src="img/checkbox-example2.png" alt="Black square border with a tick inside, and a text label." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Checkbox - Fail</th>
+            <td>The grey border color of the checkbox (#9D9D9D) has a contrast ratio of 2.7:1 with the white background, which is not sufficient for the visual information required to identify the checkbox.</td>
+            <td><img src="img/checkbox-example3.png" alt="Grey box on a white background with a black tick in the middle." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Checkbox - Subtle hover style</th>
+            <td>A black border on a white background indicates the checkbox, when the mouse pointer activates the subtle hover state adds a grey background (#DEDEDE). The black border has a 15:1 contrast ratio with the grey background.</td>
+            <td><img src="img/checkbox-example4.png" alt="Blackbox on a circular grey background next to a text label." width="150" /></td>
+          </tr>
+          <tr>
+            <th>Checkbox - Subtle focus style - fail</th>
+            <td>A focus indicator is required. If the focus indicator is styled by the author, it must meet the 3:1 contrast ratio with adjacent colors. In this case, the gray (#AAA) indicator has an insufficient ratio of 2.3:1 with the white (#FFF) adjacent background.</td>
+            <td>
+              <img src="img/checkbox-example5.png" alt="Unchecked checkbox with a thick gray additional outline as focus indication." width="150" />
+            </td>
+          </tr>
+        </table>
+
+      </section>
+      <section id="inactive-controls">
+        <h4>Inactive User Interface Components</h4>
+
+        <p>User Interface Components that are not available for user interaction (e.g., a disabled control in HTML) are not required to meet contrast requirements. An inactive user interface component is visible but not currently operable. An example would be a submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed.</p>
+        <figure id="figure-grey-button-and-text">
+          <img src="img/inactive-button.png" alt="Grey button with non-contrasting grey text." width="120" />
+          <figcaption> An inactive button using default browser styles</figcaption>
+        </figure>
+        <p>Inactive components, such as disabled controls in HTML, are not available for user interaction. The decision to exempt inactive controls from the contrast requirements was based on a number of considerations. Although it would be beneficial to some people to discern inactive controls, a one-size-fits-all solution has been very difficult to establish. A method of varying the presentation of disabled controls, such as adding an icon for disabled controls, based on user preferences is anticipated as an advancement in the future.</p>
+      </section>
+    </section><!-- end user-interface-component section -->
+
+
+    <section id="graphical-objects">
+      <h3>Graphical Objects</h3>
+
+
+      <p>The term &quot;graphical object&quot; applies to stand-alone icons such as a print icon (with no text), and the important parts of a more complex diagram such as each line in a graph. For simple graphics such as single-color icons the entire image is a graphical object. Images made up of multiple lines, colors and shapes will be made of multiple graphical objects, some of which are required for understanding.</p>
+
+      <p>Not every graphical object needs to contrast with its surroundings - only those that are required for a user to understand what the graphic is conveying. <a href="https://en.wikipedia.org/wiki/Gestalt_psychology#Pr.C3.A4gnanz">Gestalt principles</a> such as the &quot;law of continuity&quot; can be used to ignore minor overlaps with other graphical objects or colors.</p>
+
+      <table class="data">
+        <thead>
+          <tr>
+            <th>Image</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><img src="img/contrast-phone.png" alt="An orange circle with a white telephone icon in the middle." width="40" /></td>
+            <td>
+              <p>The phone icon is a simple shape within the orange (#E3660E) circle. The meaning can be understood from that icon alone, the background behind the circle is irrelevant. The orange background and the white icon have a contrast ratio greater than 3:1, which passes.</p>
+              <p>The graphical object is the white phone icon.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><img src="img/contrast-magnet.png" alt="A red magnet with grey tips and a black outline." /></td>
+            <td>
+              <p>A magnet can be understood by the "U" shape with lighter colored tips. Therefore to understand this graphic you should be able to discern the overall shape (against the background) and the lighter colored tips (against the rest of the U shape and the background).</p>
+              <p>The graphical objects are the "U" shape (by outline or by the solid red color #D0021B), and each tip of the magnet.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><img src="img/contrast-currency-down.png" alt="A yellow arrow pointing down with a pound sign (currency) in the middle." /></td>
+            <td>
+              <p>The symbol to show a currency (the £) going down can be understood with recognition of the shape (down arrow) and the currency symbol (pound icon with the shape which is part of the graphic). To understand this graphic you need to discern the arrow shape against the white background, and the pound icon against the yellow background (#F5A623).</p>
+              <p>The graphical objects are the shape and the currency symbol.</p>
+            </td>
+          </tr>
+          <tr>
+            <td><!-- Sourced from wikipedia under CC sharealike license https://en.wikipedia.org/wiki/File:Simple_line_graph_of_ACE_2012_results_by_candidate_sj01.png -->
+              <a href="img/simple-line-graph.png"><img src="img/simple-line-graph.png" alt="A line chart of votes across a region, with 4 lines of different colors tracking over time." width="200" /></a>
+            </td>
+
+            <td>
+              <p>In order to understand the graph you need to discern the lines and shapes for each condition. To perceive the values of each line along the chart you need to discern the grey lines marking the graduated 100 value increments.</p>
+              <p>The graphical objects are the lines in the graph, including the background lines for the values, and the colored lines with shapes.</p>
+              <p>The lines should have 3:1 contrast against their background, but as there is little overlap with other lines they do not need to contrast with each other or the graduated lines. (See the testing principles below.)</p>
+            </td>
+
+          </tr>
+          <tr>
+            <td><a href="img/graphics-contrast_pie-chart_pass.png"><img src="img/graphics-contrast_pie-chart_pass.png" alt="A pie chart with small gaps between each slice showing the white background, and a dark outline around light colored slices." width="200" /></a></td>
+            <td>
+              <p>To understand the pie chart you have to discern each slice of the pie chart from the others.</p>
+              <p>The graphical objects are the slices of the pie (chart).</p>
+              <p>Note: If the values of the pie chart slices were also presented in a conforming manner (see the Pie Charts example for details), the slices would not be required for understanding.</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Taking the magnet image above as an example, the process for establishing the graphical object(s) is to:</p>
+      <ul>
+        <li>Assess what part of each image is needed to understand what it represents.<br />
+          The magnet's "U" shape can be conveyed by the outline or by the red background (either is acceptable). The white tips are also important (otherwise it would be a horseshoe), which needs to contrast with the red background.</li>
+        <li>Assume that the user could only see those aspects. Do they contrast with the adjacent colors?<br />
+          The outline of the magnet contrasts with the surrounding text (black/white), and the red and white between the tips also has sufficient contrast.</li>
+      </ul>
+
+      <p>Due to the strong contrast of the red and white, it would also be possible to only put the outline around the white tips of the magnet and it would still conform.</p>
+
+      <section>
+        <h4>Required for Understanding</h4>
+
+        <p>The term &quot;required for understanding&quot; is used in the Success Criterion as many graphics do not need to meet the contrast requirements. If a person needs to perceive a graphic, or part of a graphic (a graphical object) in order to understand the content it should have sufficient contrast. However, that is not a requirement when:</p>
+        <ul>
+          <li>
+            <p>A graphic with text embedded or overlayed conveys the same information, such as labels <em>and</em> values on a chart.</p>
+            <p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
+          </li>
+          <li> The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
+          <li> The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
+          <li> The graphic is part of a logo or brand name (which is considered &quot;essential&quot; to its presentation).</li>
+        </ul>
+      </section>
+      <section>
+        <h4>Gradients</h4>
+
+        <p>Gradients can reduce the apparent contrast between areas, and make it more difficult to test. The general principles is to identify the graphical object(s) required for understanding, and take the central color of that area. If you remove the adjacent color which does not have sufficient contrast, can you still identify and understand the graphical object?</p>
+        <figure id="figure-blue-circle-i-versions">
+          <img src="img/contrast-gradient.png" alt="Two versions of a blue circle with an 'i' indicating information. The first example has a blue gradient background, the second is missing the upper half of the background which obscures the i." width="300" />
+          <figcaption>Removing the background which does not have sufficient contrast highlights that the graphical object (the &quot;i&quot;) is not then understandable.</figcaption>
+        </figure>
+      </section>
+      <section>
+        <h4>Dynamic Examples</h4>
+
+        <p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, the unfocused default version must already have sufficiently contrasting colors or text. For the area that receives focus, information can then be made available dynamically as pop-up text, or be foregrounded dynamically by increasing the contrast.</p>
+
+        <!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
+        <figure id="figure-pie-slice-hover-data">
+          <img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350" />
+          <figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
+        </figure>
+      </section>
+      <section>
+        <h4>Infographics</h4>
+
+        <p>Infographics can mean any graphic conveying data, such as a chart or diagram. On the web it is often used to indicate a large graphic with lots of statements, pictures, charts or other ways of conveying data. In the context of graphics contrast, each item within such an infographic should be treated as a set of graphical objects, regardless of whether it is in one file or separate files.</p>
+
+        <p>Infographics often fail to meet several WCAG level AA criteria including:</p>
+
+        <ul>
+          <li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
+          <li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
+          <li><a href="contrast-minimum" class="sc">1.4.3 (Text) Contrast</a></li>
+          <li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
+        </ul>
+
+        <p>An infographic can use text which meets the other criteria to minimise the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infograph is not relied upon for understanding.</p>
+
+      </section>
+
+      <section>
+        <h4>Symbolic text characters</h4>
+        <p>When text characters are used as symbols – used for their visual appearance, rather than <q>expressing something in human language</q> – they fall under the definition of <a>non-text content</a>.</p>
+        <figure id="figure-text-symbols">
+          <img alt="A button using an uppercase 'X' and a button with a greater-than character" src="img/buttons-text-symbols.png" />
+          <figcaption>Even though the two buttons use text characters — an uppercase <q>X</q>, often used for "Close" buttons, and a <q>&gt;</q> character, to act as a right-pointing arrow — they count as non-text characters/symbols. Their contrast ratio of just above 3:1 passes this Success Criterion.</figcaption>
+        </figure>
+      </section>
+
+      <section>
+        <h4>Essential Exception</h4>
+
+        <p>Graphical objects do not have to meet the contrast requirements when &quot;a particular presentation of graphics is essential to the information being conveyed&quot;. The Essential exception is intended to apply when there is no way of presenting the graphic with sufficient contrast without undermining the meaning. For example:</p>
+        <ul>
+          <li><strong>Logotypes and flags</strong>: The brand logo of an organization or product is the representation of that organization and therefore exempt. Flags may not be identifiable if the colors are changed to have sufficient contrast.</li>
+          <li><strong>Sensory</strong>: There is no requirement to change pictures of real life scenes such as photos of people or scenery.</li>
+          <li><strong>Representing other things</strong>: If you cannot represent the graphic in any other way, it is essential. Examples include:
+            <ul>
+              <li>Screenshots to demonstrate how a website appeared.</li>
+              <li>Diagrams of medical information that use the colors found in biology (<a href="https://commons.wikimedia.org/wiki/File:Schematic_diagram_of_the_human_eye_it.svg">example medical schematic from Wikipedia</a>).</li>
+              <li>color gradients that represent a measurement, such as heat maps (<a href="https://commons.wikimedia.org/wiki/File:Eyetracking_heat_map_Wikipedia.jpg">example heatmap from Wikipedia</a>).</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+
+      <section id="testing-principles">
+        <h3>Testing Principles</h3>
+        <p>A summary of the high-level process for finding and assessing non-text graphics on a web page:</p>
+        <ul>
+          <li>Identify each user-interface component (link, button, form control) on the page and:
+            <ul>
+              <li>Identify the visual (non-text) indicators of the component that are required to identify that a control exists, and indicate the current state. In the default (on page load) state, test the contrast ratio against the adjacent colors.</li>
+              <li>Test those contrast indicators in each state.</li>
+            </ul>
+          </li>
+          <li>Identify each graphic on the page that includes information required for understanding the content (i.e. excluding graphics which have visible text for the same information, or are decorative) and:
+            <ul>
+              <li>Check the contrast of the graphical object against its adjacent colors;</li>
+              <li>If there are multiple colors and/or a gradient, choose the least contrasting area to test;</li>
+              <li>If it passes, move to the next graphical object;</li>
+              <li>If the least-contrasting area is less than 3:1, assume that area is invisible, is the graphical object still understandable?</li>
+              <li>If there is enough of the graphical object to understand, it passes, else fail.</li>
+            </ul>
+          </li>
+        </ul>
+        <p>The techniques below each have testing criteria, and the related criteria for <a href="focus-visible">Focus visible (2.4.7)</a>, <a href="use-of-color">Use of color (1.4.1)</a>, and <a href="contrast-minimum">Contrast minimum</a> also have techniques.</p>
+      </section>
+
+    </section>
+
+  </section><!-- end Intent -->
+
+  <section id="benefits">
+    <h2>Benefits</h2>
+    <p>People with low vision often have difficulty perceiving graphics that have insufficient contrast. This can be exacerbated if the person has a color vision deficiency that lowers the contrast even further. Providing a <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef">relative luminance</a> (lightness difference) of 3:1 or greater can make these items more distinguishable when the person does not see a full range of colors.</p>
+  </section>
+
+  <section id="examples">
+    <h2>Graphical Object Examples</h2>
+    <ul>
+      <li>Status icons on an application's dashboard (without associated text) have a 3:1 minimum contrast ratio.</li>
+      <li>A text input has a dark border around the white editable area.</li>
+      <li>A graph uses a light background and ensures that the colors for each line have a 3:1 contrast ratio against the background.</li>
+    </ul>
+    <section class="example">
+      <h3>Pie Charts</h3>
+      <p>Pie charts make a good case study for the graphical objects part of this success criterion, the following pie charts are intended to convey the proportion of market share each browser has. Please Note: The actual figures are made up, these are not actual market shares. </p>
+      <figure id="figure-failing-pie-chart">
+        <img src="img/graphics-contrast_pie-chart_fail.png" alt="Failing pie chart" />
+        <figcaption>
+          <p><strong>Fail:</strong> The pie chart has labels for each slice (so passes 1.4.1 Use of Color), but in order to understand the proportions of the slices you must discern the edges of the slices (the graphical objects conveying essential information), and the contrast between the slices is not 3:1 or greater. </p>
+        </figcaption>
+      </figure>
+      <figure id="figure-not-applicable-pie-chart">
+        <img src="img/graphics-contrast_pie-chart_na.png" alt="Not applicable pie chart" />
+        <figcaption>
+          <p><strong>Not applicable:</strong> The pie chart has visible labels <em>and</em> values that convey equivalent information to the graphical objects (the pie slices). </p>
+        </figcaption>
+      </figure>
+      <figure id="figure-passing-pie-chart">
+        <img src="img/graphics-contrast_pie-chart_pass.png" alt="Passing pie chart" />
+        <figcaption>
+          <p><strong>Pass:</strong> The pie chart has visible labels, and sufficient contrast around and between the slices of the pie chart (the graphical objects). A darker border has been added around the yellow slice in order to achieve the contrast level.</p>
+        </figcaption>
+      </figure>
+    </section>
+    <section class="example">
+      <h3>Infographics</h3>
+      <figure id="figure-infographic-light-circles">
+        <img src="img/infographic-fail.png" alt="An infographic showing lightly colored circles of various sizes to indicate the size of five different social networks" />
+        <figcaption>
+          <p><strong>Fail:</strong> Discerning the circles is required to understand the size of network and discerning the icons in each circle is required to identify which network it shows.</p>
+        </figcaption>
+      </figure>
+      <p>The graphical objects are the circles (measured against the background) and the icons in each circle (measured against the circle's background).</p>
+      <figure id="figure-infographic-contrasting-text">
+        <img src="img/infographic-pass.png" alt="The same infographic with contrasting text, dark borders around the circles, and contrasting icons." />
+        <figcaption>
+          <p><strong>Pass:</strong> The circles have contrasting borders and the icons are a contrasting dark color against the light circle backgrounds.</p>
+        </figcaption>
+      </figure>
+      <p>There are many possible solutions to ensuring contrast, the example shows the use of borders. Other techniques are to use darker colors for the circle backgrounds, or to add text labels &amp; values for each item.</p>
+    </section>
+  </section><!-- end graphic-object-examples -->
+
+
+  <section id="resources">
+    <h2>Resources </h2>
+    <ul>
+      <li><a href="http://w3c.github.io/low-vision-a11y-tf/requirements.html">Accessibility Requirements for People with Low Vision</a>.</li>
+      <li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017May/0007.html">Smith Kettlewell Eye Research Institute</a> - &quot;If the text is better understood with the graphics, they should be equally visible as the text&quot;.</li>
+      <li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017Jun/0054.html">Gordon Legge</a> - &quot;Contrast requirements for form controls should be equivalent to contrast requirements for text&quot;.</li>
+    </ul>
+  </section>
+  <section id="techniques">
+    <h2>Techniques</h2>
+    <section id="sufficient">
+      <h3>Sufficient</h3>
+      <section class="situation">
+        <h4>Situation A: Color is used to identify user interface components or used to identify user interface component states</h4>
+        <ul>
+          <li><a href="../Techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
+          <li><a href="../Techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
+        </ul>
+      </section>
+      <section class="situation">
+        <h4>Situation B: Color is required to understand graphical content</h4>
+        <ul>
+          <li><a href="../Techniques/general/G207" class="general">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>
+          <li><a href="../Techniques/general/G209" class="general">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>
+        </ul>
+      </section>
+
+    </section><!--
 			<section id="advisory">
 				<h3>Advisory</h3>
 				<ul>
 					<li></li>
 				</ul>
 			</section>-->
-			<section id="failure">
-				<h3>Failures</h3>
-				<ul>
-					<li><a href="../Techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
-				</ul>
-			</section>
-		</section>
-	</body>
+    <section id="failure">
+      <h3>Failures</h3>
+      <ul>
+        <li><a href="../Techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
+      </ul>
+    </section>
+  </section>
+</body>
+
 </html>

--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -1,580 +1,567 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+	<head>
+		<meta charset="UTF-8"/>
+		<title>Understanding Non-text Contrast</title>
+		<link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove"/>
+	</head>
+	<body>
+		<h1>Understanding Non-text Contrast</h1>
 
-<head>
-  <meta charset="UTF-8" />
-  <title>Understanding Non-text Contrast</title>
-  <link rel="stylesheet" type="text/css" href="../../css/editors.css" class="remove" />
-</head>
+		<section id="brief">
+			<h2>In brief</h2>
+			<dl>
+				<dt>Goal</dt><dd>Important visual information meets the same minimum contrast required for larger text.</dd>
+				<dt>What to do</dt><dd>Ensure meaningful visual cues achieve 3:1 against the background.</dd>
+				<dt>Why it's important</dt><dd>Some people cannot see elements with low contrast.</dd>
+			</dl>
 
-<body>
-  <h1>Understanding Non-text Contrast</h1>
+		</section>
+		<section id="intent">
+			<h2>Intent</h2>
 
-  <section id="brief">
-    <h2>In brief</h2>
-    <dl>
-      <dt>Goal</dt>
-      <dd>Important visual information meets the same minimum contrast required for larger text.</dd>
-      <dt>What to do</dt>
-      <dd>Ensure meaningful visual cues achieve 3:1 against the background.</dd>
-      <dt>Why it's important</dt>
-      <dd>Some people cannot see elements with low contrast.</dd>
-    </dl>
 
-  </section>
-  <section id="intent">
-    <h2>Intent</h2>
+			<p>The intent of this Success Criterion is to ensure that user interface components (i.e., controls) and meaningful graphics are distinguishable by people with moderately low vision. The requirements and rationale are similar to those for large text in <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>. Note that this requirement does not apply to <em>inactive</em> user interface components.</p>
 
+			<p>Low contrast controls are more difficult to perceive, and may be completely missed by people with a visual impairment. Similarly, if a graphic is needed to understand the content or functionality of the webpage then it should be perceivable by people with low vision or other impairments without the need for contrast-enhancing assistive technology.</p>
 
-    <p>The intent of this Success Criterion is to ensure that user interface components (i.e., controls) and meaningful graphics are distinguishable by people with moderately low vision. The requirements and rationale are similar to those for large text in <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>. Note that this requirement does not apply to <em>inactive</em> user interface components.</p>
+			<div class="note">
+				<p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed values should not be rounded (e.g. 2.999:1 would not meet the 3:1 threshold).</p>
+			</div>
 
-    <p>Low contrast controls are more difficult to perceive, and may be completely missed by people with a visual impairment. Similarly, if a graphic is needed to understand the content or functionality of the webpage then it should be perceivable by people with low vision or other impairments without the need for contrast-enhancing assistive technology.</p>
+			<div class="note">
+				<p>Because authors do not have control over user settings for font smoothing and anti-aliasing, when evaluating this
+					 Success Criterion, refer to the colors obtained from the user agent, or the underlying
+					 markup and stylesheets, rather than the non-text elements as presented on screen.</p>
+				<p>Due to anti-aliasing, particularly thin lines and shapes of non-text elements may be rendered by user agents with
+					 a much fainter color than the actual color defined in the underlying CSS. This can lead to situations where
+					 non-text elements have a contrast ratio that nominally passes the Success Criterion, but have a much lower contrast
+					 in practice. In these cases, best practice would be for authors to avoid particularly thin lines and shapes,
+					 or to use a combination of colors that exceeds the normative requirements of this Success Criterion.
+				</p>
+		 </div>
 
-    <div class="note">
-      <p>The 3:1 contrast ratios referenced in this Success Criterion is intended to be treated as threshold values. When comparing the computed contrast ratio to the Success Criterion ratio, the computed values should not be rounded (e.g. 2.999:1 would not meet the 3:1 threshold).</p>
-    </div>
+			<section id="user-interface-components">
+				<h3>User Interface Components</h3>
 
-    <div class="note">
-      <p>Because authors do not have control over user settings for font smoothing and anti-aliasing, when evaluating this
-        Success Criterion, refer to the colors obtained from the user agent, or the underlying
-        markup and stylesheets, rather than the non-text elements as presented on screen.</p>
-      <p>Due to anti-aliasing, particularly thin lines and shapes of non-text elements may be rendered by user agents with
-        a much fainter color than the actual color defined in the underlying CSS. This can lead to situations where
-        non-text elements have a contrast ratio that nominally passes the Success Criterion, but have a much lower contrast
-        in practice. In these cases, best practice would be for authors to avoid particularly thin lines and shapes,
-        or to use a combination of colors that exceeds the normative requirements of this Success Criterion.
-      </p>
-    </div>
+				<p>Unless the control is <em>inactive</em>, any visual information provided that is necessary for a user to identify that a control is present and how to operate it must have a minimum 3:1 contrast ratio with the adjacent colors. Also, any visual information necessary to indicate state, such as whether a component is selected or focused must also ensure that the information used to identify the control in that state has a minimum 3:1 contrast ratio.</p>
 
-    <section id="user-interface-components">
-      <h3>User Interface Components</h3>
+				<p>This Success Criterion does not require that changes in color that differentiate between states of an individual component meet the 3:1 contrast ratio when they do not appear next to each other. For example, there is not a new requirement that visited links contrast with the default color, or that mouse hover indicators contrast with the default state. However, the component must not lose contrast with the adjacent colors, and non-text indicators such as the check in a checkbox, or an arrow graphic indicating a menu is selected or open must have sufficient contrast to the adjacent colors.</p>
 
-      <p>Unless the control is <em>inactive</em>, any visual information provided that is necessary for a user to identify that a control is present and how to operate it must have a minimum 3:1 contrast ratio with the adjacent colors. Also, any visual information necessary to indicate state, such as whether a component is selected or focused must also ensure that the information used to identify the control in that state has a minimum 3:1 contrast ratio.</p>
+				<h4>Boundaries</h4>
 
-      <p>This Success Criterion does not require that changes in color that differentiate between states of an individual component meet the 3:1 contrast ratio when they do not appear next to each other. For example, there is not a new requirement that visited links contrast with the default color, or that mouse hover indicators contrast with the default state. However, the component must not lose contrast with the adjacent colors, and non-text indicators such as the check in a checkbox, or an arrow graphic indicating a menu is selected or open must have sufficient contrast to the adjacent colors.</p>
+				<p>This success criterion does not require that controls have a visual boundary indicating the hit area, but if the visual indicator of the control is the only way to identify the control, then that indicator must have sufficient contrast. If text (or an icon) within a button or placeholder text inside a text input is visible and there is no visual indication of the hit area then the Success Criterion is passed. If a button with text also has a colored border, since the border does not provide the only indication there is no contrast requirement beyond the text contrast (<a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>). Note that for people with cognitive disabilities it is recommended to delineate the boundary of controls to aid in the recognition of controls and therefore the completion of activities.</p>
 
-      <h4>Boundaries</h4>
+				<figure id="figure-buttons-no-visual-indicator">
+						<img alt="Two buttons, the first with no visual indicator except text saying 'button'. The second is the same but with an added grey border." src="img/minimal-button.png" />
+						<figcaption>A button without a visual boundary, and the same button with a focus indicator that is a defined visual boundary of grey (#949494) adjacent to white.</figcaption>
+				</figure>
 
-      <p>This success criterion does not require that controls have a visual boundary indicating the hit area, but if the visual indicator of the control is the only way to identify the control, then that indicator must have sufficient contrast. If text (or an icon) within a button or placeholder text inside a text input is visible and there is no visual indication of the hit area then the Success Criterion is passed. If a button with text also has a colored border, since the border does not provide the only indication there is no contrast requirement beyond the text contrast (<a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>). Note that for people with cognitive disabilities it is recommended to delineate the boundary of controls to aid in the recognition of controls and therefore the completion of activities.</p>
+				<h4>Adjacent colors</h4>
+				<p>For user interface components 'adjacent colors' means the colors adjacent to the component. For example, if an input has a white internal background, dark border, and white external background the 'adjacent color' to the component would be the white external background.</p>
+				<figure id="figure-standard-text-adjacent-white">
+					<img src="img/text-input-default.png" alt="Standard text input with a label, white internal and external background with a dark border."/>
+					<figcaption>A standard text input with a grey border (#767676) and white adjacent color outside the component</figcaption>
+				</figure>
 
-      <figure id="figure-buttons-no-visual-indicator">
-        <img alt="Two buttons, the first with no visual indicator except text saying 'button'. The second is the same but with an added grey border." src="img/minimal-button.png" />
-        <figcaption>A button without a visual boundary, and the same button with a focus indicator that is a defined visual boundary of grey (#949494) adjacent to white.</figcaption>
-      </figure>
-
-      <h4>Adjacent colors</h4>
-      <p>For user interface components 'adjacent colors' means the colors adjacent to the component. For example, if an input has a white internal background, dark border, and white external background the 'adjacent color' to the component would be the white external background.</p>
-      <figure id="figure-standard-text-adjacent-white">
-        <img src="img/text-input-default.png" alt="Standard text input with a label, white internal and external background with a dark border." />
-        <figcaption>A standard text input with a grey border (#767676) and white adjacent color outside the component</figcaption>
-      </figure>
-
-      <p>If components use several colors, any color which does not interfere with identifying the component can be ignored for the purpose of measuring contrast ratio. For example, a 3D drop-shadow on an input, or a dark border line between contrasting backgrounds is considered to be subsumed into the color closest in brightness (perceived luminance).</p>
-
-      <p>The following example shows an input that has a light background on the inside and a dark background around it. The input also has a dark grey border which is considered to be subsumed into the dark background. The border does not interfere with identifying the component, so the contrast ratio is taken between the white background and dark blue background.</p>
-
-      <figure id="figure-text-box-dark-bg-light-border">
-        <img alt="A text box with a dark background and light border, with a white background." src="img/text-input-background-border.png" />
-        <figcaption> The contrast of the input background (white) and color adjacent to the control (dark blue #003366) is sufficient. There is also a border (silver) on the component that is not required to contrast with either.</figcaption>
-      </figure>
-
-      <p>For visual information required to identify a state, such as the check in a checkbox or the thumb of a slider, that part might be within the component so the adjacent color might be another part of the component.</p>
-
-      <figure id="figure-purple-box-light-check">
-        <img alt="A purple box with a light grey check." src="img/checkbox-purple.png" />
-        <figcaption> A customized checkbox with light grey check (#E5E5E5), which has a contrast ratio of 5.6:1 with the purple box (#6221EA).</figcaption>
-      </figure>
-
-      <p>It is possible to use a flat design where the status indicator fills the component and does not contrast with the component, but does contrast with the colors adjacent to the component.</p>
-
-
-      <figure id="figure-three-radios">
-        <img alt="Four radio buttons, the first is a plain circle labelled 'Not selected'. The second shows the circle filled with a darker color than the border. The third is filled with the same color as the border. The fourth has an inner filled circle with a gap between it and the outer border." src="img/radio-custom.png" />
-        <figcaption>The first radio button shows the default state with a grey (#949494) circle. The second and third show the radio button selected and filled with a color that contrasts with the color adjacent to the component. The last example shows the state indicator contrasting with the component colors.</figcaption>
-      </figure>
-
-      <h4 id="related-color">Relationship with Use of Color</h4>
-
-      <p>The <a href="use-of-color">Use of Color</a> success criterion addresses changing <strong>only the color</strong> (hue) of an object or text without otherwise altering the object's form. The principle is that contrast ratio (the difference in brightness) can be used to distinguish text or graphics. For example, <a href="../Techniques/general/G183.html">G183</a> is a technique to use a contrast ratio of 3:1 with surrounding text to distinguish links and controls. In that case the Working Group regards a link color that meets the 3:1 contrast ratio relative to the non-linked text color as satisfying the Success Criterion <a href="use-of-color">1.4.1 Use of color</a> since it is relying on contrast ratio as well as color (hue) to convey that the text is a link.</p>
-
-      <p>Non-text information within controls that uses a change of hue alone to convey the value or state of an input, such as a 1-5 star indicator with a black outline for each star filled with either yellow (full) or white (empty) is likely to fail the Use of color criterion rather than this one.</p>
-
-      <figure id="figure-two-star-ratings">
-        <img src="img/star-examples-pass.png" alt="Two star ratings, one uses a black outline (on white) with a black fill to indicate it is checked. The second has a yellow fill and a thicker dark border." width="300" />
-        <figcaption>
-          Two examples which pass this success criterion, using either a solid fill to indicate a checked-state that has contrast, or a thicker border as well as yellow fill.
-        </figcaption>
-      </figure>
-      <figure id="figure-two-star-ratings-failing">
-        <img src="img/star-examples-fail.png" alt="Two star ratings, the first uses 5 stars with a black outline and a yellow or white fill, where yellow indicates checked. The second uses only pale yellow stars on white." width="300" />
-        <figcaption>
-          Two examples which fail a success criterion, the first fails the Use of color criterion due to relying on yellow and white hues. The second example fails the Non-text contrast criterion due to the yellow (#FFF000) to white contrast ratio of 1.2:1.
-        </figcaption>
-      </figure>
-
-      <p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../Techniques/general/G195.html" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
-
-
-      <h4 id="related-focus">Relationship with Focus Visible</h4>
-
-      <p>In combination with <a href="focus-visible" class="sc">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
-
-      <p>Most focus indicators appear outside the component - in that case it needs to contrast with the background that the component is on. Other cases include focus indicators which are:</p>
-
-      <ul>
-        <li>only inside the component and need to contrast with the adjacent color(s) within the component.</li>
-        <li>the border of the component (inside the component and adjacent to the outside) and need to contrast with both adjacent colours. </li>
-        <li>partly inside and partly outside, where either part of the focus indicator can contrast with the adjacent colors.</li>
-      </ul>
-
-      <figure id="figure-focus-inner">
-        <img src="img/ntc-focus-inner.png" alt="Three blue buttons, the middle has a thick yellow outline well inside the border of the button." width="400" />
-        <figcaption>
-          The internal yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
-        </figcaption>
-      </figure>
-
-
-      <figure id="figure-focus-outer-yellow">
-        <img src="img/ntc-focus-outer-yellow.png" alt="Three blue buttons on a white background, the middle has a light yellow outline outside of the botton's non-focused boundary." width="400" />
-        <figcaption>
-          The external yellow indicator (#FFFF00) does not contrast with the white background (#FFF) which the component is on, <strong>failing</strong> the criterion.
-        </figcaption>
-      </figure>
-
-      <figure id="figure-focus-outer-green">
-        <img src="img/ntc-focus-outer-green.png" alt="Three blue buttons on a white background, the middle has a dark green outline outside of the botton's non-focused boundary." width="400" />
-        <figcaption>
-          The external green indicator (#008000) does contrast with the white background (#FFF) which the component is on, <strong>passing</strong> the criterion. It does not need to contrast with both the component background and the component, as visually the effect is that the button is noticeably larger, and it's not necessary for a user to be able to discern this extra border in isolation. Although this passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag2.2">There is a AAA criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance.html">Focus Appearance</a></span>.
-        </figcaption>
-      </figure>
-
-      <p>Although the figure above with a dark outline passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag2.2">There is a criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance" class="sc">Focus Appearance</a>.</span></p>
-      <p>If an indicator is partly inside and partly outside the component, either part of the indicator could provide contrast.</p>
-
-      <figure id="figure-focus-outer-inner">
-        <img src="img/ntc-focus-inner-outer.png" alt="Three blue buttons on a white background, the middle has the outline of a yellow rectangle that is partly inside the button's boundary, and partly outside on the white background." width="400" />
-        <figcaption>
-          The focus indicator is partially inside, partially outside the button. The internal part of the yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
-        </figcaption>
-      </figure>
-
-      <p>If the focus indicator changes the border of the component within the visible boundary it must contrast with the component. Typically an outline goes around (outside) the visible boundary of the component, in this case changing the border is just inside the visible edge of the component.</p>
-
-      <figure id="figure-focus-border">
-        <img src="img/ntc-focus-border.png" alt="Three blue buttons on a white background, the center button has a green border exactly on the outer boundary of the button." width="400" />
-        <figcaption>
-          The border of the control changes from blue (#4189B9) to green (#4B933A). This is within the component and does not contrast with the inside background of the component therefore <strong>fails</strong> non-text contrast.
-        </figcaption>
-      </figure>
-
-      <figure id="figure-focus-inner-green">
-        <img src="img/ntc-focus-inner-border.png" alt="Three blue buttons with a black border on a white background, the center button has a green border inside, adjacent to the inner background and black border." width="400" />
-        <figcaption>
-          An inner border of dark green (#008000) does contrast with the black border, but does not contrast with the blue component background, therefore <strong>fails</strong> non-text contrast.
-        </figcaption>
-      </figure>
-
-      <figure id="figure-focus-inner-white">
-        <img src="img/ntc-focus-inner-white.png" alt="Three blue buttons with a black border on a white background, the center button has a white border inside, adjacent to the inner background and black border." width="400" />
-        <figcaption>
-          An inner border of white contrasts with the black border and the blue component background, therefore <strong>passes</strong> non-text contrast.
-        </figcaption>
-      </figure>
-
-      <p>Note that this Success Criterion does not directly compare the focused and unfocused states of a control - if the focus state relies on a change of color (e.g., changing <em>only</em> the background color of a button), this Success Criterion does not define any requirement for the difference in contrast between the two states.</p>
-
-      <figure id="figure-focus-background">
-        <img src="img/ntc-focus-background.png" alt="Three blue buttons, the center button is a lighter blue than the others." width="400" />
-        <figcaption>
-          The change of background within the component is not in scope of non-text contrast. However, this would not pass <a href="use-of-color.html">Use of color</a>.
-        </figcaption>
-      </figure>
-
-      <section>
-        <h4>User Interface Component Examples</h4>
-        <p>For designing focus indicators, selection indicators and user interface components that need to be perceived clearly, the following are examples that have sufficient contrast.</p>
-
-        <table class="left-headers">
-          <caption>
-            User Interface Component Examples
-          </caption>
-          <tr>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Examples</th>
-          </tr>
-          <tr>
-            <th>Link Text</th>
-            <td>Default link text is in the scope of <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>, and the underline is sufficient to indicate the link.</td>
-            <td><img src="img/link-text-default.png" alt="A browser-default styled link, blue with an underline." /></td>
-          </tr>
-          <tr>
-            <th>Default focus style</th>
-            <td>Links are required to have a visible focus indicator by <a href="focus-visible.html">2.4.7 Focus Visible</a>. Where the focus style of the user-agent is not adjusted on interactive controls (such as links, form fields or buttons) by the website (author), the default focus style is exempt from contrast requirements (but must still be visible).</td>
-            <td><img src="img/link-text-focus.png" alt="A browser-default styled link, with a black dotted outline around the link." /></td>
-          </tr>
-          <tr>
-            <th>Buttons</th>
-            <td>A button which has a distinguishing indicator such as position, text style, or context does not need a <em>contrasting</em> visual indicator to show that it is a button, although some users are likely to identify a button with an outline that meets contrast requirements more easily.</td>
-            <td><img src="img/button-background.png" alt="Button with a faint blue background." width="100" /></td>
-          </tr>
-          <tr>
-            <th>Text input (minimal)</th>
-            <td>Where a text-input has a visual indicator to show it is an input, such as a bottom border (#767676), that indicator must meet 3:1 contrast ratio.</td>
-            <td>
-              <img src="img/text-input-minimal.png" alt="A label with a text input shown by a bottom border and faint grey background." />
-            </td>
-          </tr>
-          <tr>
-            <th>Text input</th>
-            <td>Where a text-input has an indicator such as a complete border (#767676), that indicator must meet 3:1 contrast ratio.</td>
-            <td>
-              <img src="img/text-input-default.png" alt="A label with a text input shown by a complete border." />
-            </td>
-          </tr>
-          <tr>
-            <th>Text input focus style</th>
-            <td>A focus indicator is required. While in this case the additional gray (#CCC) outline has an insufficient contrast of 1.6:1 against the white (#FFF) background, the cursor/caret which is displayed when the input receives focus <em>does</em> provide a sufficiently strong visual indication.</td>
-            <td>
-              <img src="img/text-input-focus.png" alt="A label with a text input with a faint gray outline and a visible cursor/caret." />
-            </td>
-          </tr>
-          <tr>
-            <th>Text input using background color</th>
-            <td>Text inputs that have no border and are differentiated only by a background color must have a 3:1 contrast ratio to the adjacent background (#043464).</td>
-            <td>
-              <img src="img/text-input-background.png" alt="A label with a text input shown by a dark blue page background, and white box." />
-            </td>
-          </tr>
-          <tr>
-            <th>Toggle button</th>
-            <td>The toggle button's internal background (#070CD5) has a good contrast with the external white background. Also, the round toggle within (#7AC2FF) contrasts with the internal background.</td>
-            <td><img src="img/toggle.png" alt="Dark blue oval toggle button with light blue internal indicator." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Dropdown indicator</th>
-            <td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 4.7:1 for the white icon on dark gray (#6E747B).</td>
-            <td><img src="img/dropdown.png" alt="Button with the word Menu, and a down-arrow icon next to it." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Dropdown indicator</th>
-            <td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 21:1 for the black icon on white.</td>
-            <td><img src="img/dropdown2.png" alt="Text with the word Menu, and a down-arrow icon next to it." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Checkbox - empty</th>
-            <td>A black border on a white background indicates the checkbox.</td>
-            <td><img src="img/checkbox-example1.png" alt="Black square border with a text label." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Checkbox - checked</th>
-            <td>A black border on a white background indicates the checkbox, the black tick shape indicates the state of checked.</td>
-            <td><img src="img/checkbox-example2.png" alt="Black square border with a tick inside, and a text label." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Checkbox - Fail</th>
-            <td>The grey border color of the checkbox (#9D9D9D) has a contrast ratio of 2.7:1 with the white background, which is not sufficient for the visual information required to identify the checkbox.</td>
-            <td><img src="img/checkbox-example3.png" alt="Grey box on a white background with a black tick in the middle." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Checkbox - Subtle hover style</th>
-            <td>A black border on a white background indicates the checkbox, when the mouse pointer activates the subtle hover state adds a grey background (#DEDEDE). The black border has a 15:1 contrast ratio with the grey background.</td>
-            <td><img src="img/checkbox-example4.png" alt="Blackbox on a circular grey background next to a text label." width="150" /></td>
-          </tr>
-          <tr>
-            <th>Checkbox - Subtle focus style - fail</th>
-            <td>A focus indicator is required. If the focus indicator is styled by the author, it must meet the 3:1 contrast ratio with adjacent colors. In this case, the gray (#AAA) indicator has an insufficient ratio of 2.3:1 with the white (#FFF) adjacent background.</td>
-            <td>
-              <img src="img/checkbox-example5.png" alt="Unchecked checkbox with a thick gray additional outline as focus indication." width="150" />
-            </td>
-          </tr>
-        </table>
-
-      </section>
-      <section id="inactive-controls">
-        <h4>Inactive User Interface Components</h4>
-
-        <p>User Interface Components that are not available for user interaction (e.g., a disabled control in HTML) are not required to meet contrast requirements. An inactive user interface component is visible but not currently operable. An example would be a submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed.</p>
-        <figure id="figure-grey-button-and-text">
-          <img src="img/inactive-button.png" alt="Grey button with non-contrasting grey text." width="120" />
-          <figcaption> An inactive button using default browser styles</figcaption>
-        </figure>
-        <p>Inactive components, such as disabled controls in HTML, are not available for user interaction. The decision to exempt inactive controls from the contrast requirements was based on a number of considerations. Although it would be beneficial to some people to discern inactive controls, a one-size-fits-all solution has been very difficult to establish. A method of varying the presentation of disabled controls, such as adding an icon for disabled controls, based on user preferences is anticipated as an advancement in the future.</p>
-      </section>
-    </section><!-- end user-interface-component section -->
-
-
-    <section id="graphical-objects">
-      <h3>Graphical Objects</h3>
-
-
-      <p>The term &quot;graphical object&quot; applies to stand-alone icons such as a print icon (with no text), and the important parts of a more complex diagram such as each line in a graph. For simple graphics such as single-color icons the entire image is a graphical object. Images made up of multiple lines, colors and shapes will be made of multiple graphical objects, some of which are required for understanding.</p>
-
-      <p>Not every graphical object needs to contrast with its surroundings - only those that are required for a user to understand what the graphic is conveying. <a href="https://en.wikipedia.org/wiki/Gestalt_psychology#Pr.C3.A4gnanz">Gestalt principles</a> such as the &quot;law of continuity&quot; can be used to ignore minor overlaps with other graphical objects or colors.</p>
-
-      <table class="data">
-        <thead>
-          <tr>
-            <th>Image</th>
-            <th>Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><img src="img/contrast-phone.png" alt="An orange circle with a white telephone icon in the middle." width="40" /></td>
-            <td>
-              <p>The phone icon is a simple shape within the orange (#E3660E) circle. The meaning can be understood from that icon alone, the background behind the circle is irrelevant. The orange background and the white icon have a contrast ratio greater than 3:1, which passes.</p>
-              <p>The graphical object is the white phone icon.</p>
-            </td>
-          </tr>
-          <tr>
-            <td><img src="img/contrast-magnet.png" alt="A red magnet with grey tips and a black outline." /></td>
-            <td>
-              <p>A magnet can be understood by the "U" shape with lighter colored tips. Therefore to understand this graphic you should be able to discern the overall shape (against the background) and the lighter colored tips (against the rest of the U shape and the background).</p>
-              <p>The graphical objects are the "U" shape (by outline or by the solid red color #D0021B), and each tip of the magnet.</p>
-            </td>
-          </tr>
-          <tr>
-            <td><img src="img/contrast-currency-down.png" alt="A yellow arrow pointing down with a pound sign (currency) in the middle." /></td>
-            <td>
-              <p>The symbol to show a currency (the £) going down can be understood with recognition of the shape (down arrow) and the currency symbol (pound icon with the shape which is part of the graphic). To understand this graphic you need to discern the arrow shape against the white background, and the pound icon against the yellow background (#F5A623).</p>
-              <p>The graphical objects are the shape and the currency symbol.</p>
-            </td>
-          </tr>
-          <tr>
-            <td><!-- Sourced from wikipedia under CC sharealike license https://en.wikipedia.org/wiki/File:Simple_line_graph_of_ACE_2012_results_by_candidate_sj01.png -->
-              <a href="img/simple-line-graph.png"><img src="img/simple-line-graph.png" alt="A line chart of votes across a region, with 4 lines of different colors tracking over time." width="200" /></a>
-            </td>
-
-            <td>
-              <p>In order to understand the graph you need to discern the lines and shapes for each condition. To perceive the values of each line along the chart you need to discern the grey lines marking the graduated 100 value increments.</p>
-              <p>The graphical objects are the lines in the graph, including the background lines for the values, and the colored lines with shapes.</p>
-              <p>The lines should have 3:1 contrast against their background, but as there is little overlap with other lines they do not need to contrast with each other or the graduated lines. (See the testing principles below.)</p>
-            </td>
-
-          </tr>
-          <tr>
-            <td><a href="img/graphics-contrast_pie-chart_pass.png"><img src="img/graphics-contrast_pie-chart_pass.png" alt="A pie chart with small gaps between each slice showing the white background, and a dark outline around light colored slices." width="200" /></a></td>
-            <td>
-              <p>To understand the pie chart you have to discern each slice of the pie chart from the others.</p>
-              <p>The graphical objects are the slices of the pie (chart).</p>
-              <p>Note: If the values of the pie chart slices were also presented in a conforming manner (see the Pie Charts example for details), the slices would not be required for understanding.</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>Taking the magnet image above as an example, the process for establishing the graphical object(s) is to:</p>
-      <ul>
-        <li>Assess what part of each image is needed to understand what it represents.<br />
-          The magnet's "U" shape can be conveyed by the outline or by the red background (either is acceptable). The white tips are also important (otherwise it would be a horseshoe), which needs to contrast with the red background.</li>
-        <li>Assume that the user could only see those aspects. Do they contrast with the adjacent colors?<br />
-          The outline of the magnet contrasts with the surrounding text (black/white), and the red and white between the tips also has sufficient contrast.</li>
-      </ul>
-
-      <p>Due to the strong contrast of the red and white, it would also be possible to only put the outline around the white tips of the magnet and it would still conform.</p>
-
-      <section>
-        <h4>Required for Understanding</h4>
-
-        <p>The term &quot;required for understanding&quot; is used in the Success Criterion as many graphics do not need to meet the contrast requirements. If a person needs to perceive a graphic, or part of a graphic (a graphical object) in order to understand the content it should have sufficient contrast. However, that is not a requirement when:</p>
-        <ul>
-          <li>
-            <p>A graphic with text embedded or overlayed conveys the same information, such as labels <em>and</em> values on a chart.</p>
-            <p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
-          </li>
-          <li> The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
-          <li> The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
-          <li> The graphic is part of a logo or brand name (which is considered &quot;essential&quot; to its presentation).</li>
-        </ul>
-      </section>
-      <section>
-        <h4>Gradients</h4>
-
-        <p>Gradients can reduce the apparent contrast between areas, and make it more difficult to test. The general principles is to identify the graphical object(s) required for understanding, and take the central color of that area. If you remove the adjacent color which does not have sufficient contrast, can you still identify and understand the graphical object?</p>
-        <figure id="figure-blue-circle-i-versions">
-          <img src="img/contrast-gradient.png" alt="Two versions of a blue circle with an 'i' indicating information. The first example has a blue gradient background, the second is missing the upper half of the background which obscures the i." width="300" />
-          <figcaption>Removing the background which does not have sufficient contrast highlights that the graphical object (the &quot;i&quot;) is not then understandable.</figcaption>
-        </figure>
-      </section>
-      <section>
-        <h4>Dynamic Examples</h4>
-
-        <p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, the unfocused default version must already have sufficiently contrasting colors or text. For the area that receives focus, information can then be made available dynamically as pop-up text, or be foregrounded dynamically by increasing the contrast.</p>
-
-        <!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
-        <figure id="figure-pie-slice-hover-data">
-          <img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350" />
-          <figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
-        </figure>
-      </section>
-      <section>
-        <h4>Infographics</h4>
-
-        <p>Infographics can mean any graphic conveying data, such as a chart or diagram. On the web it is often used to indicate a large graphic with lots of statements, pictures, charts or other ways of conveying data. In the context of graphics contrast, each item within such an infographic should be treated as a set of graphical objects, regardless of whether it is in one file or separate files.</p>
-
-        <p>Infographics often fail to meet several WCAG level AA criteria including:</p>
-
-        <ul>
-          <li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
-          <li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
-          <li><a href="contrast-minimum" class="sc">1.4.3 (Text) Contrast</a></li>
-          <li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
-        </ul>
-
-        <p>An infographic can use text which meets the other criteria to minimise the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infograph is not relied upon for understanding.</p>
-
-      </section>
-
-      <section>
-        <h4>Symbolic text characters</h4>
-        <p>When text characters are used as symbols – used for their visual appearance, rather than <q>expressing something in human language</q> – they fall under the definition of <a>non-text content</a>.</p>
-        <figure id="figure-text-symbols">
-          <img alt="A button using an uppercase 'X' and a button with a greater-than character" src="img/buttons-text-symbols.png" />
-          <figcaption>Even though the two buttons use text characters — an uppercase <q>X</q>, often used for "Close" buttons, and a <q>&gt;</q> character, to act as a right-pointing arrow — they count as non-text characters/symbols. Their contrast ratio of just above 3:1 passes this Success Criterion.</figcaption>
-        </figure>
-      </section>
-
-      <section>
-        <h4>Essential Exception</h4>
-
-        <p>Graphical objects do not have to meet the contrast requirements when &quot;a particular presentation of graphics is essential to the information being conveyed&quot;. The Essential exception is intended to apply when there is no way of presenting the graphic with sufficient contrast without undermining the meaning. For example:</p>
-        <ul>
-          <li><strong>Logotypes and flags</strong>: The brand logo of an organization or product is the representation of that organization and therefore exempt. Flags may not be identifiable if the colors are changed to have sufficient contrast.</li>
-          <li><strong>Sensory</strong>: There is no requirement to change pictures of real life scenes such as photos of people or scenery.</li>
-          <li><strong>Representing other things</strong>: If you cannot represent the graphic in any other way, it is essential. Examples include:
-            <ul>
-              <li>Screenshots to demonstrate how a website appeared.</li>
-              <li>Diagrams of medical information that use the colors found in biology (<a href="https://commons.wikimedia.org/wiki/File:Schematic_diagram_of_the_human_eye_it.svg">example medical schematic from Wikipedia</a>).</li>
-              <li>color gradients that represent a measurement, such as heat maps (<a href="https://commons.wikimedia.org/wiki/File:Eyetracking_heat_map_Wikipedia.jpg">example heatmap from Wikipedia</a>).</li>
-            </ul>
-          </li>
-        </ul>
-      </section>
-
-      <section id="testing-principles">
-        <h3>Testing Principles</h3>
-        <p>A summary of the high-level process for finding and assessing non-text graphics on a web page:</p>
-        <ul>
-          <li>Identify each user-interface component (link, button, form control) on the page and:
-            <ul>
-              <li>Identify the visual (non-text) indicators of the component that are required to identify that a control exists, and indicate the current state. In the default (on page load) state, test the contrast ratio against the adjacent colors.</li>
-              <li>Test those contrast indicators in each state.</li>
-            </ul>
-          </li>
-          <li>Identify each graphic on the page that includes information required for understanding the content (i.e. excluding graphics which have visible text for the same information, or are decorative) and:
-            <ul>
-              <li>Check the contrast of the graphical object against its adjacent colors;</li>
-              <li>If there are multiple colors and/or a gradient, choose the least contrasting area to test;</li>
-              <li>If it passes, move to the next graphical object;</li>
-              <li>If the least-contrasting area is less than 3:1, assume that area is invisible, is the graphical object still understandable?</li>
-              <li>If there is enough of the graphical object to understand, it passes, else fail.</li>
-            </ul>
-          </li>
-        </ul>
-        <p>The techniques below each have testing criteria, and the related criteria for <a href="focus-visible">Focus visible (2.4.7)</a>, <a href="use-of-color">Use of color (1.4.1)</a>, and <a href="contrast-minimum">Contrast minimum</a> also have techniques.</p>
-      </section>
-
-    </section>
-
-  </section><!-- end Intent -->
-
-  <section id="benefits">
-    <h2>Benefits</h2>
-    <p>People with low vision often have difficulty perceiving graphics that have insufficient contrast. This can be exacerbated if the person has a color vision deficiency that lowers the contrast even further. Providing a <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef">relative luminance</a> (lightness difference) of 3:1 or greater can make these items more distinguishable when the person does not see a full range of colors.</p>
-  </section>
-
-  <section id="examples">
-    <h2>Graphical Object Examples</h2>
-    <ul>
-      <li>Status icons on an application's dashboard (without associated text) have a 3:1 minimum contrast ratio.</li>
-      <li>A text input has a dark border around the white editable area.</li>
-      <li>A graph uses a light background and ensures that the colors for each line have a 3:1 contrast ratio against the background.</li>
-    </ul>
-    <section class="example">
-      <h3>Pie Charts</h3>
-      <p>Pie charts make a good case study for the graphical objects part of this success criterion, the following pie charts are intended to convey the proportion of market share each browser has. Please Note: The actual figures are made up, these are not actual market shares. </p>
-      <figure id="figure-failing-pie-chart">
-        <img src="img/graphics-contrast_pie-chart_fail.png" alt="Failing pie chart" />
-        <figcaption>
-          <p><strong>Fail:</strong> The pie chart has labels for each slice (so passes 1.4.1 Use of Color), but in order to understand the proportions of the slices you must discern the edges of the slices (the graphical objects conveying essential information), and the contrast between the slices is not 3:1 or greater. </p>
-        </figcaption>
-      </figure>
-      <figure id="figure-not-applicable-pie-chart">
-        <img src="img/graphics-contrast_pie-chart_na.png" alt="Not applicable pie chart" />
-        <figcaption>
-          <p><strong>Not applicable:</strong> The pie chart has visible labels <em>and</em> values that convey equivalent information to the graphical objects (the pie slices). </p>
-        </figcaption>
-      </figure>
-      <figure id="figure-passing-pie-chart">
-        <img src="img/graphics-contrast_pie-chart_pass.png" alt="Passing pie chart" />
-        <figcaption>
-          <p><strong>Pass:</strong> The pie chart has visible labels, and sufficient contrast around and between the slices of the pie chart (the graphical objects). A darker border has been added around the yellow slice in order to achieve the contrast level.</p>
-        </figcaption>
-      </figure>
-    </section>
-    <section class="example">
-      <h3>Infographics</h3>
-      <figure id="figure-infographic-light-circles">
-        <img src="img/infographic-fail.png" alt="An infographic showing lightly colored circles of various sizes to indicate the size of five different social networks" />
-        <figcaption>
-          <p><strong>Fail:</strong> Discerning the circles is required to understand the size of network and discerning the icons in each circle is required to identify which network it shows.</p>
-        </figcaption>
-      </figure>
-      <p>The graphical objects are the circles (measured against the background) and the icons in each circle (measured against the circle's background).</p>
-      <figure id="figure-infographic-contrasting-text">
-        <img src="img/infographic-pass.png" alt="The same infographic with contrasting text, dark borders around the circles, and contrasting icons." />
-        <figcaption>
-          <p><strong>Pass:</strong> The circles have contrasting borders and the icons are a contrasting dark color against the light circle backgrounds.</p>
-        </figcaption>
-      </figure>
-      <p>There are many possible solutions to ensuring contrast, the example shows the use of borders. Other techniques are to use darker colors for the circle backgrounds, or to add text labels &amp; values for each item.</p>
-    </section>
-  </section><!-- end graphic-object-examples -->
-
-
-  <section id="resources">
-    <h2>Resources </h2>
-    <ul>
-      <li><a href="http://w3c.github.io/low-vision-a11y-tf/requirements.html">Accessibility Requirements for People with Low Vision</a>.</li>
-      <li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017May/0007.html">Smith Kettlewell Eye Research Institute</a> - &quot;If the text is better understood with the graphics, they should be equally visible as the text&quot;.</li>
-      <li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017Jun/0054.html">Gordon Legge</a> - &quot;Contrast requirements for form controls should be equivalent to contrast requirements for text&quot;.</li>
-    </ul>
-  </section>
-  <section id="techniques">
-    <h2>Techniques</h2>
-    <section id="sufficient">
-      <h3>Sufficient</h3>
-      <section class="situation">
-        <h4>Situation A: Color is used to identify user interface components or used to identify user interface component states</h4>
-        <ul>
-          <li><a href="../Techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
-          <li><a href="../Techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
-        </ul>
-      </section>
-      <section class="situation">
-        <h4>Situation B: Color is required to understand graphical content</h4>
-        <ul>
-          <li><a href="../Techniques/general/G207" class="general">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>
-          <li><a href="../Techniques/general/G209" class="general">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>
-        </ul>
-      </section>
-
-    </section><!--
+				<p>If components use several colors, any color which does not interfere with identifying the component can be ignored for the purpose of measuring contrast ratio. For example, a 3D drop-shadow on an input, or a dark border line between contrasting backgrounds is considered to be subsumed into the color closest in brightness (perceived luminance).</p>
+
+				<p>The following example shows an input that has a light background on the inside and a dark background around it. The input also has a dark grey border which is considered to be subsumed into the dark background. The border does not interfere with identifying the component, so the contrast ratio is taken between the white background and dark blue background.</p>
+
+				<figure id="figure-text-box-dark-bg-light-border">
+					<img alt="A text box with a dark background and light border, with a white background." src="img/text-input-background-border.png"/>
+					<figcaption> The contrast of the input background (white) and color adjacent to the control (dark blue #003366) is sufficient. There is also a border (silver) on the component that is not required to contrast with either.</figcaption>
+				</figure>
+
+				<p>For visual information required to identify a state, such as the check in a checkbox or the thumb of a slider, that part might be within the component so the adjacent color might be another part of the component.</p>
+
+				<figure id="figure-purple-box-light-check">
+					<img alt="A purple box with a light grey check." src="img/checkbox-purple.png"/>
+					<figcaption> A customized checkbox with light grey check (#E5E5E5), which has a contrast ratio of 5.6:1 with the purple box (#6221EA).</figcaption>
+				</figure>
+
+				<p>It is possible to use a flat design where the status indicator fills the component and does not contrast with the component, but does contrast with the colors adjacent to the component.</p>
+
+
+				<figure id="figure-three-radios">
+					<img alt="Four radio buttons, the first is a plain circle labelled 'Not selected'. The second shows the circle filled with a darker color than the border. The third is filled with the same color as the border. The fourth has an inner filled circle with a gap between it and the outer border." src="img/radio-custom.png"/>
+					<figcaption>The first radio button shows the default state with a grey (#949494) circle. The second and third show the radio button selected and filled with a color that contrasts with the color adjacent to the component. The last example shows the state indicator contrasting with the component colors.</figcaption>
+				</figure>
+
+				<h4 id="related-color">Relationship with Use of Color</h4>
+
+				<p>The <a href="use-of-color">Use of Color</a> success criterion addresses changing <strong>only the color</strong> (hue) of an object or text without otherwise altering the object's form. The principle is that contrast ratio (the difference in brightness) can be used to distinguish text or graphics. For example, <a href="../Techniques/general/G183.html">G183</a> is a technique to use a contrast ratio of 3:1 with surrounding text to distinguish links and controls. In that case the Working Group regards a link color that meets the 3:1 contrast ratio relative to the non-linked text color as satisfying the Success Criterion <a href="use-of-color">1.4.1 Use of color</a> since it is relying on contrast ratio as well as color (hue) to convey that the text is a link.</p>
+
+				<p>Non-text information within controls that uses a change of hue alone to convey the value or state of an input, such as a 1-5 star indicator with a black outline for each star filled with either yellow (full) or white (empty) is likely to fail the Use of color criterion rather than this one.</p>
+
+				<figure id="figure-two-star-ratings">
+					<img src="img/star-examples-pass.png" alt="Two star ratings, one uses a black outline (on white) with a black fill to indicate it is checked. The second has a yellow fill and a thicker dark border." width="300"/>
+					<figcaption>
+						Two examples which pass this success criterion, using either a solid fill to indicate a checked-state that has contrast, or a thicker border as well as yellow fill.
+					</figcaption>
+				</figure>
+				<figure id="figure-two-star-ratings-failing">
+					<img src="img/star-examples-fail.png" alt="Two star ratings, the first uses 5 stars with a black outline and a yellow or white fill, where yellow indicates checked. The second uses only pale yellow stars on white." width="300"/>
+					<figcaption>
+						Two examples which fail a success criterion, the first fails the Use of color criterion due to relying on yellow and white hues. The second example fails the Non-text contrast criterion due to the yellow (#FFF000) to white contrast ratio of 1.2:1.
+					</figcaption>
+				</figure>
+
+				<p>Using a change of contrast for focus and other states is a technique to differentiate the states. This is the basis for <a href="../Techniques/general/G195.html" class="general">G195: Using an author-supplied, highly visible focus indicator</a>, and more techniques are being added.</p>
+
+
+				<h4 id="related-focus">Relationship with Focus Visible</h4>
+
+				<p>In combination with <a href="focus-visible" class="sc">2.4.7 Focus Visible</a>, the visual focus indicator for a component <em>must</em> have sufficient contrast against the adjacent background when the component is focused, except where the appearance of the component is determined by the user agent and not modified by the author.</p>
+
+				<p>Most focus indicators appear outside the component - in that case it needs to contrast with the background that the component is on. Other cases include focus indicators which are:</p>
+
+				<ul>
+					<li>only inside the component and need to contrast with the adjacent color(s) within the component.</li>
+					<li>the border of the component (inside the component and adjacent to the outside) and need to contrast with both adjacent colours. </li>
+					<li>partly inside and partly outside, where either part of the focus indicator can contrast with the adjacent colors.</li>
+				</ul>
+
+				<figure id="figure-focus-inner">
+					<img src="img/ntc-focus-inner.png" alt="Three blue buttons, the middle has a thick yellow outline well inside the border of the button." width="400"/>
+					<figcaption>
+						The internal yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
+					</figcaption>
+				</figure>
+
+
+				<figure id="figure-focus-outer-yellow">
+					<img src="img/ntc-focus-outer-yellow.png" alt="Three blue buttons on a white background, the middle has a light yellow outline outside of the botton's non-focused boundary." width="400"/>
+					<figcaption>
+						The external yellow indicator (#FFFF00) does not contrast with the white background (#FFF) which the component is on, <strong>failing</strong> the criterion.
+					</figcaption>
+				</figure>
+
+				<figure id="figure-focus-outer-green">
+					<img src="img/ntc-focus-outer-green.png" alt="Three blue buttons on a white background, the middle has a dark green outline outside of the botton's non-focused boundary." width="400"/>
+					<figcaption>
+						The external green indicator (#008000) does contrast with the white background (#FFF) which the component is on, <strong>passing</strong> the criterion. It does not need to contrast with both the component background and the component, as visually the effect is that the button is noticeably larger, and it's not necessary for a user to be able to discern this extra border in isolation. Although this passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag2.2">There is a AAA criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance.html">Focus Appearance</a></span>.
+					</figcaption>
+				</figure>
+
+				<p>Although the figure above with a dark outline passes non-text contrast, it is not a good indicator unless it is very thick. <span class="wcag2.2">There is a criterion in WCAG 2.2 that addresses this aspect, <a href="focus-appearance" class="sc">Focus Appearance</a>.</span></p>
+				<p>If an indicator is partly inside and partly outside the component, either part of the indicator could provide contrast.</p>
+
+				<figure id="figure-focus-outer-inner">
+					<img src="img/ntc-focus-inner-outer.png" alt="Three blue buttons on a white background, the middle has the outline of a yellow rectangle that is partly inside the button's boundary, and partly outside on the white background." width="400"/>
+					<figcaption>
+						The focus indicator is partially inside, partially outside the button. The internal part of the yellow indicator (#FFFF00) contrasts with the blue button background (#4189B9), <strong>passing</strong> the criterion.
+					</figcaption>
+				</figure>
+
+				<p>If the focus indicator changes the border of the component within the visible boundary it must contrast with the component. Typically an outline goes around (outside) the visible boundary of the component, in this case changing the border is just inside the visible edge of the component.</p>
+
+				<figure id="figure-focus-border">
+					<img src="img/ntc-focus-border.png" alt="Three blue buttons on a white background, the center button has a green border exactly on the outer boundary of the button." width="400"/>
+					<figcaption>
+						The border of the control changes from blue (#4189B9) to green (#4B933A). This is within the component and does not contrast with the inside background of the component therefore <strong>fails</strong> non-text contrast.
+					</figcaption>
+				</figure>
+
+				<figure id="figure-focus-inner-green">
+					<img src="img/ntc-focus-inner-border.png" alt="Three blue buttons with a black border on a white background, the center button has a green border inside, adjacent to the inner background and black border." width="400"/>
+					<figcaption>
+						An inner border of dark green (#008000) does contrast with the black border, but does not contrast with the blue component background, therefore <strong>fails</strong> non-text contrast.
+					</figcaption>
+				</figure>
+
+				<figure id="figure-focus-inner-white">
+					<img src="img/ntc-focus-inner-white.png" alt="Three blue buttons with a black border on a white background, the center button has a white border inside, adjacent to the inner background and black border." width="400"/>
+					<figcaption>
+						An inner border of white contrasts with the black border and the blue component background, therefore <strong>passes</strong> non-text contrast.
+					</figcaption>
+				</figure>
+
+		        <p>Note that this Success Criterion does not directly compare the focused and unfocused states of a control - if the focus state relies on a change of color (e.g., changing <em>only</em> the background color of a button), this Success Criterion does not define any requirement for the difference in contrast between the two states.</p>
+
+				<figure id="figure-focus-background">
+					<img src="img/ntc-focus-background.png" alt="Three blue buttons, the center button is a lighter blue than the others." width="400"/>
+					<figcaption>
+						The change of background within the component is not in scope of non-text contrast. However, this would not pass <a href="use-of-color.html">Use of color</a>.
+					</figcaption>
+				</figure>
+
+				<section>
+					<h4>User Interface Component Examples</h4>
+					<p>For designing focus indicators, selection indicators and user interface components that need to be perceived clearly, the following are examples that have sufficient contrast.</p>
+
+					<table class="left-headers">
+						<caption>
+							User Interface Component Examples
+						</caption>
+						<tr>
+						<th>Type</th>
+						<th>Description</th>
+						<th>Examples</th>
+						</tr>
+						<tr>
+							<th>Link Text</th>
+							<td>Default link text is in the scope of <a href="contrast-minimum">1.4.3 Contrast (Minimum)</a>, and the underline is sufficient to indicate the link.</td>
+							<td><img src="img/link-text-default.png" alt="A browser-default styled link, blue with an underline."/></td>
+						</tr>
+						<tr>
+							<th>Default focus style</th>
+							<td>Links are required to have a visible focus indicator by <a href="focus-visible.html">2.4.7 Focus Visible</a>. Where the focus style of the user-agent is not adjusted on interactive controls (such as links, form fields or buttons) by the website (author), the default focus style is exempt from contrast requirements (but must still be visible).</td>
+							<td><img src="img/link-text-focus.png" alt="A browser-default styled link, with a black dotted outline around the link."/></td>
+						</tr>
+						<tr>
+							<th>Buttons</th>
+							<td>A button which has a distinguishing indicator such as position, text style, or context does not need a <em>contrasting</em> visual indicator to show that it is a button, although some users are likely to identify a button with an outline that meets contrast requirements more easily.</td>
+							<td><img src="img/button-background.png" alt="Button with a faint blue background." width="100"/></td>
+						</tr>
+						<tr>
+							<th>Text input (minimal)</th>
+							<td>Where a text-input has a visual indicator to show it is an input, such as a bottom border (#767676), that indicator must meet 3:1 contrast ratio.</td>
+							<td>
+								<img src="img/text-input-minimal.png" alt="A label with a text input shown by a bottom border and faint grey background."/>
+							</td>
+						</tr>
+						<tr>
+							<th>Text input</th>
+							<td>Where a text-input has an indicator such as a complete border (#767676), that indicator must meet 3:1 contrast ratio.</td>
+							<td>
+								<img src="img/text-input-default.png" alt="A label with a text input shown by a complete border."/>
+							</td>
+						</tr>
+						<tr>
+							<th>Text input focus style</th>
+							<td>A focus indicator is required. While in this case the additional gray (#CCC) outline has an insufficient contrast of 1.6:1 against the white (#FFF) background, the cursor/caret which is displayed when the input receives focus <em>does</em> provide a sufficiently strong visual indication.</td>
+							<td>
+								<img src="img/text-input-focus.png" alt="A label with a text input with a faint gray outline and a visible cursor/caret."/>
+							</td>
+						</tr>
+						<tr>
+							<th>Text input using background color</th>
+							<td>Text inputs that have no border and are differentiated only by a background color must have a 3:1 contrast ratio to the adjacent background (#043464).</td>
+							<td>
+								<img src="img/text-input-background.png" alt="A label with a text input shown by a dark blue page background, and white box."/>
+							</td>
+						</tr>
+						<tr>
+							<th>Toggle button</th>
+							<td>The toggle button's internal background (#070CD5) has a good contrast with the external white background. Also, the round toggle within (#7AC2FF) contrasts with the internal background.</td>
+							<td><img src="img/toggle.png" alt="Dark blue oval toggle button with light blue internal indicator." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Dropdown indicator</th>
+							<td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 4.7:1 for the white icon on dark gray (#6E747B).</td>
+							<td><img src="img/dropdown.png" alt="Button with the word Menu, and a down-arrow icon next to it." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Dropdown indicator</th>
+							<td>The down-arrow is required to understand that there is drop-down functionality, it has a contrast of 21:1 for the black icon on white.</td>
+							<td><img src="img/dropdown2.png" alt="Text with the word Menu, and a down-arrow icon next to it." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Checkbox - empty</th>
+							<td>A black border on a white background indicates the checkbox.</td>
+							<td><img src="img/checkbox-example1.png" alt="Black square border with a text label." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Checkbox - checked</th>
+							<td>A black border on a white background indicates the checkbox, the black tick shape indicates the state of checked.</td>
+							<td><img src="img/checkbox-example2.png" alt="Black square border with a tick inside, and a text label." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Checkbox - Fail</th>
+							<td>The grey border color of the checkbox (#9D9D9D) has a contrast ratio of 2.7:1 with the white background, which is not sufficient for the visual information required to identify the checkbox.</td>
+							<td><img src="img/checkbox-example3.png" alt="Grey box on a white background with a black tick in the middle." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Checkbox - Subtle hover style</th>
+							<td>A black border on a white background indicates the checkbox, when the mouse pointer activates the subtle hover state adds a grey background (#DEDEDE). The black border has a 15:1 contrast ratio with the grey background.</td>
+							<td><img src="img/checkbox-example4.png" alt="Blackbox on a circular grey background next to a text label." width="150"/></td>
+						</tr>
+						<tr>
+							<th>Checkbox - Subtle focus style - fail</th>
+							<td>A focus indicator is required. If the focus indicator is styled by the author, it must meet the 3:1 contrast ratio with adjacent colors. In this case, the gray (#AAA) indicator has an insufficient ratio of 2.3:1 with the white (#FFF) adjacent background.</td>
+							<td>
+								<img src="img/checkbox-example5.png" alt="Unchecked checkbox with a thick gray additional outline as focus indication." width="150"/>
+							</td>
+						</tr>
+					</table>
+
+				</section>
+				<section id="inactive-controls">
+					<h4>Inactive User Interface Components</h4>
+
+					<p>User Interface Components that are not available for user interaction (e.g., a disabled control in HTML) are not required to meet contrast requirements. An inactive user interface component is visible but not currently operable. An example would be a submit button at the bottom of a form that is visible but cannot be activated until all the required fields in the form are completed.</p>
+					<figure id="figure-grey-button-and-text">
+						<img src="img/inactive-button.png" alt="Grey button with non-contrasting grey text." width="120"/>
+						<figcaption> An inactive button using default browser styles</figcaption>
+					</figure>
+					<p>Inactive components, such as disabled controls in HTML, are not available for user interaction. The decision to exempt inactive controls from the contrast requirements was based on a number of considerations. Although it would be beneficial to some people to discern inactive controls, a one-size-fits-all solution has been very difficult to establish. A method of varying the presentation of disabled controls, such as adding an icon for disabled controls, based on user preferences is anticipated as an advancement in the future.</p>
+				</section>
+			</section><!-- end user-interface-component section -->
+
+
+			<section id="graphical-objects">
+				<h3>Graphical Objects</h3>
+
+
+				<p>The term &quot;graphical object&quot; applies to stand-alone icons such as a print icon (with no text), and the important parts of a more complex diagram such as each line in a graph. For simple graphics such as single-color icons the entire image is a graphical object. Images made up of multiple lines, colors and shapes will be made of multiple graphical objects, some of which are required for understanding.</p>
+
+				<p>Not every graphical object needs to contrast with its surroundings - only those that are required for a user to understand what the graphic is conveying. <a href="https://en.wikipedia.org/wiki/Gestalt_psychology#Pr.C3.A4gnanz">Gestalt principles</a> such as the &quot;law of continuity&quot; can be used to ignore minor overlaps with other graphical objects or colors.</p>
+
+				<table class="data">
+					<thead>
+						<tr>
+							<th>Image</th>
+							<th>Notes</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><img src="img/contrast-phone.png" alt="An orange circle with a white telephone icon in the middle." width="40"/></td>
+							<td><p>The phone icon is a simple shape within the orange (#E3660E) circle. The meaning can be understood from that icon alone, the background behind the circle is irrelevant. The orange background and the white icon have a contrast ratio greater than 3:1, which passes.</p>
+							<p>The graphical object is the white phone icon.</p>
+							</td>
+						</tr>
+						<tr>
+							<td><img src="img/contrast-magnet.png" alt="A red magnet with grey tips and a black outline."/></td>
+							<td><p>A magnet can be understood by the "U" shape with lighter colored tips. Therefore to understand this graphic you should be able to discern the overall shape (against the background) and the lighter colored tips (against the rest of the U shape and the background).</p>
+							<p>The graphical objects are the "U" shape (by outline or by the solid red color #D0021B), and each tip of the magnet.</p>
+							</td>
+						</tr>
+						<tr>
+							<td><img src="img/contrast-currency-down.png" alt="A yellow arrow pointing down with a pound sign (currency) in the middle."/></td>
+							<td><p>The symbol to show a currency (the £) going down can be understood with recognition of the shape (down arrow) and the currency symbol (pound icon with the shape which is part of the graphic). To understand this graphic you need to discern the arrow shape against the white background, and the pound icon against the yellow background (#F5A623).</p>
+							<p>The graphical objects are the shape and the currency symbol.</p>
+							</td>
+						</tr>
+						<tr>
+							<td><!-- Sourced from wikipedia under CC sharealike license https://en.wikipedia.org/wiki/File:Simple_line_graph_of_ACE_2012_results_by_candidate_sj01.png -->
+								<a href="img/simple-line-graph.png"><img src="img/simple-line-graph.png" alt="A line chart of votes across a region, with 4 lines of different colors tracking over time." width="200"/></a></td>
+
+							<td><p>In order to understand the graph you need to discern the lines and shapes for each condition. To perceive the values of each line along the chart you need to discern the grey lines marking the graduated 100 value increments.</p>
+							<p>The graphical objects are the lines in the graph, including the background lines for the values, and the colored lines with shapes.</p>
+							<p>The lines should have 3:1 contrast against their background, but as there is little overlap with other lines they do not need to contrast with each other or the graduated lines. (See the testing principles below.)</p>
+						</td>
+
+						</tr>
+						<tr>
+							<td><a href="img/graphics-contrast_pie-chart_pass.png"><img src="img/graphics-contrast_pie-chart_pass.png" alt="A pie chart with small gaps between each slice showing the white background, and a dark outline around light colored slices." width="200"/></a></td>
+							<td><p>To understand the pie chart you have to discern each slice of the pie chart from the others.</p>
+							<p>The graphical objects are the slices of the pie (chart).</p>
+							<p>Note: If the values of the pie chart slices were also presented in a conforming manner (see the Pie Charts example for details), the slices would not be required for understanding.</p>
+						</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p>Taking the magnet image above as an example, the process for establishing the graphical object(s) is to:</p>
+				<ul>
+					<li>Assess what part of each image is needed to understand what it represents.<br/>
+						The magnet's "U" shape can be conveyed by the outline or by the red background (either is acceptable). The white tips are also important (otherwise it would be a horseshoe), which needs to contrast with the red background.</li>
+					<li>Assume that the user could only see those aspects. Do they contrast with the adjacent colors?<br/>
+						The outline of the magnet contrasts with the surrounding text (black/white), and the red and white between the tips also has sufficient contrast.</li>
+				</ul>
+
+				<p>Due to the strong contrast of the red and white, it would also be possible to only put the outline around the white tips of the magnet and it would still conform.</p>
+
+				<section>
+				<h4>Required for Understanding</h4>
+
+				<p>The term &quot;required for understanding&quot; is used in the Success Criterion as many graphics do not need to meet the contrast requirements. If a person needs to perceive a graphic, or part of a graphic (a graphical object) in order to understand the content it should have sufficient contrast. However, that is not a requirement when:</p>
+				<ul>
+					<li>
+						<p>A graphic with text embedded or overlayed conveys the same information, such as labels <em>and</em> values on a chart.</p>
+						<p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
+					</li>
+					<li> The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
+					<li> The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
+					<li> The graphic is part of a logo or brand name (which is considered &quot;essential&quot; to its presentation).</li>
+				</ul>
+				</section>
+				<section>
+				<h4>Gradients</h4>
+
+				<p>Gradients can reduce the apparent contrast between areas, and make it more difficult to test. The general principles is to identify the graphical object(s) required for understanding, and take the central color of that area. If you remove the adjacent color which does not have sufficient contrast, can you still identify and understand the graphical object?</p>
+				<figure id="figure-blue-circle-i-versions">
+          <img src="img/contrast-gradient.png" alt="Two versions of a blue circle with an 'i' indicating information. The first example has a blue gradient background, the second is missing the upper half of the background which obscures the i." width="300"/>
+				<figcaption>Removing the background which does not have sufficient contrast highlights that the graphical object (the &quot;i&quot;) is not then understandable.</figcaption></figure>
+				</section>
+				<section>
+				<h4>Dynamic Examples</h4>
+
+				<p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, the unfocused default version must already have sufficiently contrasting colors or text. For the area that receives focus, information can then be made available dynamically as pop-up text, or be foregrounded dynamically by increasing the contrast.</p>
+
+				<!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
+				<figure id="figure-pie-slice-hover-data">
+					<img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350"/>
+					<figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
+				</figure>
+				</section>
+				<section>
+				<h4>Infographics</h4>
+
+				<p>Infographics can mean any graphic conveying data, such as a chart or diagram. On the web it is often used to indicate a large graphic with lots of statements, pictures, charts or other ways of conveying data. In the context of graphics contrast, each item within such an infographic should be treated as a set of graphical objects, regardless of whether it is in one file or separate files.</p>
+
+				<p>Infographics often fail to meet several WCAG level AA criteria including:</p>
+
+				<ul>
+					<li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
+					<li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
+					<li><a href="contrast-minimum" class="sc">1.4.3 (Text) Contrast</a></li>
+					<li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
+				</ul>
+
+				<p>An infographic can use text which meets the other criteria to minimise the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infograph is not relied upon for understanding.</p>
+
+				</section>
+
+				<section>
+					<h4>Symbolic text characters</h4>
+					<p>When text characters are used as symbols – used for their visual appearance, rather than <q>expressing something in human language</q> – they fall under the definition of <a>non-text content</a>.</p>
+					<figure id="figure-text-symbols">
+						<img alt="A button using an uppercase 'X' and a button with a greater-than character" src="img/buttons-text-symbols.png" />
+						<figcaption>Even though the two buttons use text characters — an uppercase <q>X</q>, often used for "Close" buttons, and a <q>&gt;</q> character, to act as a right-pointing arrow — they count as non-text characters/symbols. Their contrast ratio of just above 3:1 passes this Success Criterion.</figcaption>
+					</figure>
+				</section>
+
+				<section>
+					<h4>Essential Exception</h4>
+
+					<p>Graphical objects do not have to meet the contrast requirements when &quot;a particular presentation of graphics is essential to the information being conveyed&quot;. The Essential exception is intended to apply when there is no way of presenting the graphic with sufficient contrast without undermining the meaning. For example:</p>
+					<ul>
+						<li><strong>Logotypes and flags</strong>: The brand logo of an organization or product is the representation of that organization and therefore exempt. Flags may not be identifiable if the colors are changed to have sufficient contrast.</li>
+						<li><strong>Sensory</strong>: There is no requirement to change pictures of real life scenes such as photos of people or scenery.</li>
+						<li><strong>Representing other things</strong>: If you cannot represent the graphic in any other way, it is essential. Examples include:
+							<ul>
+								<li>Screenshots to demonstrate how a website appeared.</li>
+								<li>Diagrams of medical information that use the colors found in biology (<a href="https://commons.wikimedia.org/wiki/File:Schematic_diagram_of_the_human_eye_it.svg">example medical schematic from Wikipedia</a>).</li>
+								<li>color gradients that represent a measurement, such as heat maps (<a href="https://commons.wikimedia.org/wiki/File:Eyetracking_heat_map_Wikipedia.jpg">example heatmap from Wikipedia</a>).</li>
+							</ul>
+						</li>
+					</ul>
+				</section>
+
+			<section id="testing-principles">
+					<h3>Testing Principles</h3>
+					<p>A summary of the high-level process for finding and assessing non-text graphics on a web page:</p>
+					<ul>
+						<li>Identify each user-interface component (link, button, form control) on the page and:
+							<ul>
+								<li>Identify the visual (non-text) indicators of the component that are required to identify that a control exists, and indicate the current state. In the default (on page load) state, test the contrast ratio against the adjacent colors.</li>
+								<li>Test those contrast indicators in each state.</li>
+							</ul>
+						</li>
+						<li>Identify each graphic on the page that includes information required for understanding the content (i.e. excluding graphics which have visible text for the same information, or are decorative) and:
+							<ul>
+								<li>Check the contrast of the graphical object against its adjacent colors;</li>
+								<li>If there are multiple colors and/or a gradient, choose the least contrasting area to test;</li>
+								<li>If it passes, move to the next graphical object;</li>
+								<li>If the least-contrasting area is less than 3:1, assume that area is invisible, is the graphical object still understandable?</li>
+								<li>If there is enough of the graphical object to understand, it passes, else fail.</li>
+							</ul>
+						</li>
+					</ul>
+					<p>The techniques below each have testing criteria, and the related criteria for <a href="focus-visible">Focus visible (2.4.7)</a>, <a href="use-of-color">Use of color (1.4.1)</a>, and <a href="contrast-minimum">Contrast minimum</a> also have techniques.</p>
+			</section>
+
+			</section>
+
+		</section><!-- end Intent -->
+
+		<section id="benefits">
+			<h2>Benefits</h2>
+			<p>People with low vision often have difficulty perceiving graphics that have insufficient contrast. This can be exacerbated if the person has a color vision deficiency that lowers the contrast even further. Providing a <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef">relative luminance</a> (lightness difference) of 3:1 or greater can make these items more distinguishable when the person does not see a full range of colors.</p>
+		</section>
+
+		<section id="examples">
+			<h2>Graphical Object Examples</h2>
+			<ul>
+				<li>Status icons on an application's dashboard (without associated text) have a 3:1 minimum contrast ratio.</li>
+				<li>A text input has a dark border around the white editable area.</li>
+				<li>A graph uses a light background and ensures that the colors for each line have a 3:1 contrast ratio against the background.</li>
+			</ul>
+			<section class="example">
+				<h3>Pie Charts</h3>
+				<p>Pie charts make a good case study for the graphical objects part of this success criterion, the following pie charts are intended to convey the proportion of market share each browser has. Please Note: The actual figures are made up, these are not actual market shares. </p>
+				<figure id="figure-failing-pie-chart">
+					<img src="img/graphics-contrast_pie-chart_fail.png" alt="Failing pie chart"/>
+					<figcaption>
+						<p><strong>Fail:</strong> The pie chart has labels for each slice (so passes 1.4.1 Use of Color), but in order to understand the proportions of the slices you must discern the edges of the slices (the graphical objects conveying essential information), and the contrast between the slices is not  3:1 or greater. </p>
+					</figcaption>
+				</figure>
+				<figure id="figure-not-applicable-pie-chart">
+					<img src="img/graphics-contrast_pie-chart_na.png" alt="Not applicable pie chart"/>
+					<figcaption>
+						<p><strong>Not applicable:</strong> The pie chart has visible labels <em>and</em> values that convey equivalent information to the graphical objects (the pie slices). </p>
+					</figcaption>
+				</figure>
+				<figure id="figure-passing-pie-chart">
+					<img src="img/graphics-contrast_pie-chart_pass.png" alt="Passing pie chart"/>
+					<figcaption>
+						<p><strong>Pass:</strong> The pie chart has visible labels, and sufficient contrast around and between the slices of the pie chart (the graphical objects). A darker border has been added around the yellow slice in order to achieve the contrast level.</p>
+					</figcaption>
+				</figure>
+			</section>
+			<section class="example">
+				<h3>Infographics</h3>
+				<figure id="figure-infographic-light-circles">
+					<img src="img/infographic-fail.png" alt="An infographic showing lightly colored circles of various sizes to indicate the size of five different social networks"/>
+					<figcaption>
+						<p><strong>Fail:</strong> Discerning the circles is required to understand the size of network and discerning the icons in each circle is required to identify which network it shows.</p>
+					</figcaption>
+				</figure>
+				<p>The graphical objects are the circles (measured against the background) and the icons in each circle (measured against the circle's background).</p>
+				<figure id="figure-infographic-contrasting-text">
+					<img src="img/infographic-pass.png" alt="The same infographic with contrasting text, dark borders around the circles, and contrasting icons."/>
+					<figcaption>
+						<p><strong>Pass:</strong> The circles have contrasting borders and the icons are a contrasting dark color against the light circle backgrounds.</p>
+					</figcaption>
+				</figure>
+				<p>There are many possible solutions to ensuring contrast, the example shows the use of borders. Other techniques are to use darker colors for the circle backgrounds, or to add text labels &amp; values for each item.</p>
+			</section>
+		</section><!-- end graphic-object-examples -->
+
+
+		<section id="resources">
+			<h2>Resources </h2>
+			<ul>
+				<li><a href="http://w3c.github.io/low-vision-a11y-tf/requirements.html">Accessibility Requirements for People with Low Vision</a>.</li>
+				<li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017May/0007.html">Smith Kettlewell Eye Research Institute</a> -  &quot;If the text is better understood with the graphics, they should be equally visible as the text&quot;.</li>
+				<li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017Jun/0054.html">Gordon Legge</a> - &quot;Contrast requirements for form controls should be equivalent to contrast requirements for text&quot;.</li>
+			</ul>
+		</section>
+		<section id="techniques">
+			<h2>Techniques</h2>
+			<section id="sufficient">
+				<h3>Sufficient</h3>
+				<section class="situation">
+						<h4>Situation A: Color is used to identify user interface components or used to identify user interface component states</h4>
+						<ul>
+							<li><a href="../Techniques/general/G195" class="general">G195: Using an author-supplied, highly visible focus indicator</a></li>
+							<li><a href="../Techniques/general/G174" class="general">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>
+						</ul>
+				</section>
+				<section class="situation">
+					<h4>Situation B: Color is required to understand graphical content</h4>
+					<ul>
+						<li><a href="../Techniques/general/G207" class="general">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>
+						<li><a href="../Techniques/general/G209" class="general">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>
+					</ul>
+				</section>
+
+			</section><!--
 			<section id="advisory">
 				<h3>Advisory</h3>
 				<ul>
 					<li></li>
 				</ul>
 			</section>-->
-    <section id="failure">
-      <h3>Failures</h3>
-      <ul>
-        <li><a href="../Techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
-      </ul>
-    </section>
-  </section>
-</body>
-
+			<section id="failure">
+				<h3>Failures</h3>
+				<ul>
+					<li><a href="../Techniques/failures/F78" class="general">F78: Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>
+				</ul>
+			</section>
+		</section>
+	</body>
 </html>


### PR DESCRIPTION
Changing the class from wcag22 to wcag2.2 should fix the mentions of non-existing WCAG version 22 throughout the WCAG Understanding Documents.

Example: https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html

The text says: 

> Note that a keyboard focus indicator can take different forms. New in WCAG 22: While Focus Visible does not specify what that form is, 2.4.13 Focus Appearance (Level AAA) provides guidance on creating a consistent, visible indicator.

This fix should change it to “New in WCAG 2.2”.