### PR TITLE
Fix token for Eleventy deploy workflow

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -5,7 +5,7 @@ name: CI
 # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
 on:
   push:
-    branches: [main]
+    branches: [main, kgf-11ty-deploy-fix]
 
 jobs:
   main:
@@ -19,6 +19,7 @@ jobs:
         with:
           ref: gh-pages
           path: _site
+          token: ${{ secrets.W3CGRUNTBOT_TOKEN }}
       - name: Install Node.js and dependencies
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -5,7 +5,7 @@ name: CI
 # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
 on:
   push:
-    branches: [main, kgf-11ty-deploy-fix]
+    branches: [main]
 
 jobs:
   main:


### PR DESCRIPTION
This fixes a token issue in #3955 which I was not able to verify from my fork in initial testing.

I created this branch on the main repo itself so that I could test it immediately against this branch, then subsequently removed this branch from the workflow.

Failed deploy from #3955: https://github.com/w3c/wcag/actions/runs/9978687846/job/27576112975
Successful deploy from this PR: https://github.com/w3c/wcag/actions/runs/9978853821/job/27576643580