### PR TITLE
Don't force term names to lowercase in definition lists

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -393,7 +393,7 @@ export class CustomLiquid extends Liquid {
       // where we have access to global data and the about box's HTML
       const $termLinks = $(termLinkSelector);
       const extractTermName = ($el: Cheerio<Element>) => {
-        const name = $el.text().trim().toLowerCase();
+        const name = $el.text().toLowerCase().trim().replace(/\s*\n+\s*/, " ");
         const term = termsMap[name];
         if (!term) {
           console.warn(`${scope.page.inputPath}: Term not found: ${name}`);
@@ -433,7 +433,11 @@ export class CustomLiquid extends Liquid {
           }
 
           // Iterate over sorted names to populate alphabetized Key Terms definition list
-          termNames.sort();
+          termNames.sort((a, b) => {
+            if (a.toLowerCase() < b.toLowerCase()) return -1;
+            if (a.toLowerCase() > b.toLowerCase()) return 1;
+            return 0;
+          });
           for (const name of termNames) {
             const term = termsMap[name]; // Already verified existence in the earlier loop
             $termsList.append(

--- a/11ty/guidelines.ts
+++ b/11ty/guidelines.ts
@@ -208,11 +208,15 @@ export async function getTermsMap() {
       // but the XSLT process generates id from the element's text which is not always the same
       id: `dfn-${generateId($el.text())}`,
       definition: getContentHtml($el.parent().next()),
-      name: $el.text().toLowerCase(),
+      name: $el.text(),
       trId: el.attribs.id,
     };
 
-    const names = [term.name].concat((el.attribs["data-lt"] || "").toLowerCase().split("|"));
+    // Include both original and all-lowercase version to simplify lookups
+    // (since most synonyms are lowercase) while preserving case in name
+    const names = [term.name, term.name.toLowerCase()].concat(
+      (el.attribs["data-lt"] || "").toLowerCase().split("|")
+    );
     for (const name of names) terms[name] = term;
   });
 

--- a/guidelines/terms/22/cognitive-function-test.html
+++ b/guidelines/terms/22/cognitive-function-test.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn id="dfn-cognitive-function-test" data-lt="cognitive function test">Cognitive function test</dfn></dt>
+<dt class="new"><dfn id="dfn-cognitive-function-test" data-lt="cognitive function test">cognitive function test</dfn></dt>
 <dd class="new">
    					
    <p class="change">New</p>

--- a/guidelines/terms/22/cognitive-function-test.html
+++ b/guidelines/terms/22/cognitive-function-test.html
@@ -1,4 +1,4 @@
-<dt class="new"><dfn id="dfn-cognitive-function-test" data-lt="cognitive function test">cognitive function test</dfn></dt>
+<dt class="new"><dfn id="dfn-cognitive-function-test" data-lt="cognitive function test">Cognitive function test</dfn></dt>
 <dd class="new">
    					
    <p class="change">New</p>


### PR DESCRIPTION
This fixes a couple of issues in the build system that I noticed while reviewing #3038:

- A few term names (e.g. ASCII art) have uppercase letters, which the build was forcing to lowercase (this was apparently also true of the XSLT build, judging by e.g. https://www.w3.org/WAI/WCAG21/Understanding/non-text-content#dfn-ascii-art)
- Any linked terms containing newlines would not be recognized (none of these currently exist, but #3038 added one, which I worked around in that PR so it's not blocked on this)

I also noticed that the term "cognitive function test" includes a capital C, but doesn't seem to warrant one (typically the only term capitalization is for acronyms or proper nouns).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/3978.html" title="Last updated on Jul 19, 2024, 5:53 PM UTC (acec01c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/3978/0440c75...acec01c.html" title="Last updated on Jul 19, 2024, 5:53 PM UTC (acec01c)">Diff</a>