### PR TITLE
Remove an unavailable Firefox add-on link

### DIFF
--- a/techniques/general/G145.html
+++ b/techniques/general/G145.html
@@ -157,9 +157,6 @@
                   <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
                 </li>
             <li>
-                  <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
-                </li>
-            <li>
                   <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>

--- a/techniques/general/G148.html
+++ b/techniques/general/G148.html
@@ -44,9 +44,6 @@
                   <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
                 </li>
             <li>
-                  <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
-                </li>
-            <li>
                   <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>

--- a/techniques/general/G17.html
+++ b/techniques/general/G17.html
@@ -161,9 +161,6 @@
                   <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
                 </li>
             <li>
-                  <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
-                </li>
-            <li>
                   <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>

--- a/techniques/general/G18.html
+++ b/techniques/general/G18.html
@@ -163,9 +163,6 @@
                   <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
                 </li>
             <li>
-                  <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
-                </li>
-            <li>
                   <a href="https://web.archive.org/web/20160814160227/http://trace.wisc.edu/contrast-ratio-examples">Color Contrast Samples</a>
                 </li>
             <li>

--- a/techniques/general/G183.html
+++ b/techniques/general/G183.html
@@ -57,9 +57,6 @@
             <li>
                   <a href="http://juicystudio.com/services/luminositycontrastratio.php">Contrast Ratio Analyser - online service</a>
                 </li>
-            <li>
-                  <a href="http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php">Colour Contrast Analyser - Firefox Extension</a>
-                </li>
          </ul>
       
    </section></body></html>


### PR DESCRIPTION
Some techniques refer to the page [Colour Contrast Analyser - Firefox Extension](http://juicystudio.com/article/colour-contrast-analyser-firefox-extension.php). This page still exists, but the extension it links to is no longer available.

It also doesn't appear in [search results](https://addons.mozilla.org/en-US/firefox/search/?q=Colour%20Contrast%20Analyser), so this PR will remove the link.