### PR TITLE
Move 2.1 requirements into subfolder; fix edDraftURIs

### DIFF
--- a/requirements/21/index.html
+++ b/requirements/21/index.html
@@ -33,7 +33,7 @@
 		license: "document",
 
 		// if there a publicly available Editors Draft, this is the link
-		edDraftURI: "https://w3c.github.io/wcag/requirements/",
+		edDraftURI: "https://w3c.github.io/wcag/wcag21/requirements/",
 
 		// if this is a LCWD, uncomment and set the end of its review period
 		// lcEnd: "2012-02-21",

--- a/requirements/22/index.html
+++ b/requirements/22/index.html
@@ -34,7 +34,7 @@
       license: "document",
 
       // if there a publicly available Editors Draft, this is the link
-      edDraftURI: "https://w3c.github.io/wcag/requirements/",
+      edDraftURI: "https://w3c.github.io/wcag/requirements/22/",
 
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2012-02-21",


### PR DESCRIPTION
This does the following:

- Relocates the HTML file for WCAG 2.1's requirements under a subdirectory, consistent with 2.2's
  - This is not currently referenced by any actively-used build/deploy processes (republishing 2.1 docs is a future task)
  - This would technically fix one of the XSLT build targets, which assumes there's always a version subdirectory; however, that target has not been recently used and is slated for removal in #3985
- Updates `edDraftURI` in both the 2.1 and 2.2 files, as both referenced a nonexistent URL
  - You may notice that the editors' draft locations are inconsistent between 2.1 and 2.2; I am not planning on changing that (on the gh-pages branch) since the current locations are actively linked from each version of the recommendation, and it seems unlikely that the 2.1 rec would be updated, which would necessitate a long-standing redirect page.