### PR TITLE
Add workflow for Netlify PR deploys for custom PR comment

### DIFF
--- a/.github/workflows/netlify-preview.yaml
+++ b/.github/workflows/netlify-preview.yaml
@@ -1,0 +1,42 @@
+name: netlify-preview
+
+on:
+  pull_request:
+    branches:
+      - main
+      - kgf-preview-workflow
+permissions:
+  pull-requests: write
+
+jobs:
+  netlify:
+    name: Deploy Netlify Preview
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Netlify Branch Deploy
+        id: deploy
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        # The shell below gets a TTY, enabling use of tee to stream to stdout while storing variable
+        # (see https://github.com/actions/runner/issues/241#issuecomment-2019042651)
+        shell: 'script --return --quiet --log-out /dev/null --command "bash -e {0}"'
+        run: |
+          npm i
+          npm run build
+          OUTPUT=$(netlify deploy \
+            --alias pr-${{ github.event.pull_request.number }} \
+            --dir _site \
+            --message 'PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}' \
+            | tee /dev/tty)
+          echo preview_url=$(echo "$OUTPUT" | egrep -o 'https://\S+\.netlify\.app') >> "$GITHUB_OUTPUT"
+          echo preview_date=$(date -Ru) >> "$GITHUB_OUTPUT"
+      - uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: pr-netlify
+          message: |
+            Preview available (last updated ${{ steps.deploy.outputs.preview_date }} via workflow run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))
+            
+            - [Techniques](${{ steps.deploy.outputs.preview_url }}/techniques)
+            - [Understanding](${{ steps.deploy.outputs.preview_url }}/understanding)

--- a/.github/workflows/netlify-preview.yaml
+++ b/.github/workflows/netlify-preview.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - kgf-preview-workflow
 permissions:
   pull-requests: write
 


### PR DESCRIPTION
This PR adds a github workflow as an alternative to Netlify's automatic PR deploys.

**Note:** Turn off Deploy Previews in Netlify site configuration > build & deploy before merging, to avoid duplicate builds/comments.

## Motivation

Using a GitHub action allows us to customize the comment that appears in the PR, e.g. to specify more useful preview links. Unfortunately this sort of customization doesn't seem to be possible through Netlify's own PR deploy preview feature.

[Example custom PR comment using this branch](https://github.com/kfranqueiro/wcag/pull/1#issuecomment-2250905598) (note, this intentionally shows a failed check, as explained under Behavior)

Contrast with Netlify's comment format, which will appear below this post.

## Behavior

- The workflow triggers when a PR is newly opened, reopened, or synchronized (i.e. branch update pushed)
- Upon a first successful build, the action will add a PR comment
- Upon subsequent successful builds, the action will update the existing comment; the links should remain the same since they use an alias based on the PR number, but the date and workflow run link will update
- Upon build failure, the comment will not change (so the last successful build will still be visible), but the action will still reflect as failed under Checks

## GitHub Secrets

This requires 2 github secrets which I've set up:

- `NETLIFY_SITE_ID` - the ID found under site information in Netlify
- `NETLIFY_AUTH_TOKEN` - a personal access token generated in [Netlify user settings](https://app.netlify.com/user/applications/personal)