### PR TITLE
Fix mention of WAI-ARIA 1.0

### DIFF
--- a/techniques/failures/F59.html
+++ b/techniques/failures/F59.html
@@ -19,7 +19,7 @@
                         the script to activate the element. Additionally, these elements do not
                         generate the same operating system events as interactive elements, so
                         assistive technology may not be notified when the user activates them.</div></p>
-      <p> The W3C Candidate Recommendation "<a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA) 1.0</a>" describes mechanisms to provide the necessary role and state information to create fully accessible user interface controls.</p>
+      <p><a href="https://www.w3.org/TR/wai-aria/">Accessible Rich Internet Applications (WAI-ARIA)</a> describes mechanisms to provide the necessary role and state information to create fully accessible user interface controls.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          


### PR DESCRIPTION
F59 says:

> The W3C Candidate Recommendation "Accessible Rich Internet Applications (WAI-ARIA) 1.0" describes ....

This description is inaccurate. This PR fixes it.
