### PR TITLE
Update header to use header element instead of div

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@ isUnderstanding and isTechniques (each set to true in respective folder)
 {% endcomment %}
 <a href="#main" class="button button--skip-link">Skip to content</a>
 <div class="minimal-header-container default-grid">
-  <div class="minimal-header" id="site-header">
+  <header class="minimal-header" id="site-header">
     <div class="minimal-header-name">
       <a href="{{ headerUrl }}">WCAG {{ versionDecimal }} {{ headerLabel }}</a>
     </div>
@@ -40,5 +40,5 @@ isUnderstanding and isTechniques (each set to true in respective folder)
         </svg>
       </a>
     </div>
-  </div>
+  </header>
 </div>


### PR DESCRIPTION
Update the site header to use a `header` element instead of a `div`.

Closes #3974