### PR TITLE
Update HTML5, CSS2, and RFC references

### DIFF
--- a/techniques/css/C18.html
+++ b/techniques/css/C18.html
@@ -53,10 +53,10 @@ td, th { padding: .4em; border: 1px solid #000; }</code></pre>
 					<h2>Resources</h2>
 					<ul>
 						<li>
-							<a href="https://www.w3.org/TR/CSS2/box.html#margin-properties">Margin properties: '<code class="language-css">margin-top</code>', '<code class="language-css">margin-right</code>', '<code class="language-css">margin-bottom</code>', '<code class="language-css">margin-left</code>', and '<code class="language-css">margin</code>' in the CSS2 specification</a>
+							<a href="https://www.w3.org/TR/css-box-3/#margins">Margin properties: '<code class="language-css">margin-top</code>', '<code class="language-css">margin-right</code>', '<code class="language-css">margin-bottom</code>', '<code class="language-css">margin-left</code>', and '<code class="language-css">margin</code>' in the CSS Box Model Module Level 3 specification</a>
 						</li>
             <li>
-							<a href="https://www.w3.org/TR/CSS2/box.html#padding-properties">Padding properties: '<code class="language-css">padding-top</code>', '<code class="language-css">padding-right</code>', '<code class="language-css">padding-bottom</code>', '<code class="language-css">padding-left</code>', and '<code class="language-css">padding</code>' in the CSS2 specification</a>
+							<a href="https://www.w3.org/TR/css-box-3/#paddings">Padding properties: '<code class="language-css">padding-top</code>', '<code class="language-css">padding-right</code>', '<code class="language-css">padding-bottom</code>', '<code class="language-css">padding-left</code>', and '<code class="language-css">padding</code>' in the CSS Box Model Module Level 3 specification</a>
 						</li>
          </ul>
 				</section>

--- a/techniques/css/C22.html
+++ b/techniques/css/C22.html
@@ -315,6 +315,21 @@ endeavors. Never forget this in the  midst of your diagrams and equations.&lt;/p
 					<a href="https://www.w3.org/TR/CSS21/">CSS2.1 Specification</a>
 				</li>
 				<li>
+					<a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Module Level 3</a>
+				</li>
+				<li>
+					<a href="https://www.w3.org/TR/css-color-4/">CSS Color Module Level 4</a>
+				</li>
+				<li>
+					<a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
+				</li>
+				<li>
+					<a href="https://www.w3.org/TR/css-backgrounds-3/">CSS Backgrounds and Borders Module Level 3</a>
+				</li>
+				<li>
+					<a href="https://www.w3.org/TR/selectors-3/">Selectors Level 3</a>
+				</li>
+				<li>
 					<a href="https://www.w3.org/Style/CSS/learning">Learning CSS</a>
 				</li>
 				<li>

--- a/techniques/failures/F1.html
+++ b/techniques/failures/F1.html
@@ -6,7 +6,7 @@
       <p>This describes the failure condition that results when CSS, rather than
                         structural markup, is used to modify the visual layout of the content, and
                         the modified layout changes the meaning of the content. Using the
-                        positioning properties of CSS2, content may be displayed at any position on
+                        positioning properties of CSS, content may be displayed at any position on
                         the user's viewport. The order in which items appear on a screen may be
                         different than the order they are found in the source document. Assistive
                         technologies rely on the source code or other programmatically determined

--- a/techniques/failures/F24.html
+++ b/techniques/failures/F24.html
@@ -100,8 +100,8 @@
       
          <ul>
             <li>
-                  <a href="https://www.w3.org/TR/CSS2/cascade.html#inheritance">Assigning property values, Cascading, and Inheritance</a>
-               </li>
+              <a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>
+            </li>
          </ul>
       
    </section></body></html>

--- a/techniques/failures/F4.html
+++ b/techniques/failures/F4.html
@@ -50,7 +50,7 @@
    <section id="resources">
       <h2>Resources</h2>
          <ul>
-            <li><a href="https://www.w3.org/TR/CSS2/text.html#propdef-text-decoration">CSS 2 text-decoration property</a></li>
+            <li><a href="https://www.w3.org/TR/css-text-decor-3/#text-decoration-property">CSS Text Decoration Module Level 3: text-decoration property</a></li>
          </ul>
    </section>
 </body>

--- a/techniques/failures/F58.html
+++ b/techniques/failures/F58.html
@@ -57,13 +57,7 @@ out.println("&lt;/body&gt;&lt;/html&gt;");
       
          <ul>
             <li> 
-                  <a href="http://www.ietf.org/rfc/rfc1945.txt">Hypertext
-                                        Transfer Protocol -- HTTP/1.0 (IETF Request for Comments
-                                        1945)</a> (plain text) </li>
-            <li> 
-                  <a href="http://www.ietf.org/rfc/rfc2616.txt">Hypertext
-                                        Transfer Protocol -- HTTP/1.1 (IETF Request for Comments
-                                        2616)</a> (plain text) </li>
+              <a href="https://www.rfc-editor.org/rfc/rfc9110#name-redirection-3xx">RFC 9110: HTTP Semantics 15.4. Redirection 3xx</li>
             
          </ul>
       

--- a/techniques/failures/F77.html
+++ b/techniques/failures/F77.html
@@ -34,7 +34,7 @@
    </ul></section><section id="resources"><h2>Resources</h2>
       
          <ul>
-            <li>HTML 5: <a href="https://www.w3.org/TR/html5/dom.html#the-id-attribute">id attribute</a> 
+            <li>HTML: <a href="https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute">id attribute</a> 
                </li>
 			<li> 
                   <a href="https://www.w3.org/TR/2005/REC-xml-id-20050909/">xml:id Version 1.0</a> - W3C Recommendation 9 September 2005.</li>

--- a/techniques/failures/F93.html
+++ b/techniques/failures/F93.html
@@ -35,11 +35,8 @@
       
          <ul>
             <li>
-               	<a href="https://www.w3.org/TR/html5/">HTML5</a>
-               </li>
-            <li>
-                  <a href="https://html.spec.whatwg.org/">HTML5 Living Standard</a>
-               </li>
+              <a href="https://html.spec.whatwg.org/">HTML Living Standard</a>
+            </li>
          </ul>
       
    </section>

--- a/techniques/general/G112.html
+++ b/techniques/general/G112.html
@@ -19,7 +19,7 @@
          <h3>W3C key words</h3>
          
             <p>Definition: The key words "must", "must not", "required", "shall", "shall not", "should", "should not", "recommended", "may", and "optional" in this specification are to be interpreted as described in
-                <a href="http://www.faqs.org/rfcs/rfc2119.html">RFC 2119</a>.</p>
+                <a href="https://www.rfc-editor.org/rfc/rfc2119">RFC 2119</a>.</p>
          
       </section>
       <section class="example">

--- a/techniques/general/G138.html
+++ b/techniques/general/G138.html
@@ -34,11 +34,8 @@
                 	<a href="https://www.paciellogroup.com/blog/2008/02/screen-readers-lack-emphasis/">Screen Readers lack emphasis</a>
                 </li>
             <li>
-                  <a href="https://www.w3.org/TR/1999/REC-html401-19991224/struct/text.html#h-9.2.1">Phrase elements: EM, STRONG, DFN, CODE, SAMP, KBD, VAR, CITE, ABBR, and ACRONYM</a>
-                </li>
-            <li>
-                  <a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-em-element">HTML 5.0: 4.5.2 The em element</a>
-                </li>
+              <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#text-level-semantics">HTML: 4.5 Text-level semantics</a>
+            </li>
          </ul>
       
    </section></body></html>

--- a/techniques/general/G204.html
+++ b/techniques/general/G204.html
@@ -29,8 +29,8 @@
       
          <ul>
             <li>
-									         <a href="https://www.w3.org/TR/CSS2/box.html">CSS Box Model</a>
-								       </li>
+							<a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a>
+						</li>
          </ul>
       
    </section></body></html>

--- a/techniques/html/H57.html
+++ b/techniques/html/H57.html
@@ -52,7 +52,7 @@
          <p>Examine the <code class="language-html">html</code> element of the document.</p> 
          <ol>
             <li>Check that the <code class="language-html">html</code> element has a <code class="language-html">lang</code> attribute.</li>
-            <li>Check that the value of the <code class="language-html">lang</code> attribute conforms to <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47: Tags for the Identification of Languages</a> or its successor and reflects the primary language used by the Web page.</li>
+            <li>Check that the value of the <code class="language-html">lang</code> attribute conforms to <a href="https://www.rfc-editor.org/info/bcp47">BCP 47: Tags for Identifying Languages; Matching of Language Tags</a> or its successor and reflects the primary language used by the Web page.</li>
          </ol>
       </section>
       <section class="results">
@@ -78,7 +78,7 @@
             <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang">HTML "<code class="language-html">lang</code>" attribute on the Mozilla Developer Network</a>.
          </li>
          <li>
-            <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47: Tags for the Identification of Languages</a>.
+            <a href="https://www.rfc-editor.org/info/bcp47">BCP 47: Tags for Identifying Languages; Matching of Language Tags</a>.
          </li>
          <li>
             <a href="https://www.w3.org/International/articles/language-tags/">Language tags in HTML and XML</a>.

--- a/techniques/html/H58.html
+++ b/techniques/html/H58.html
@@ -50,7 +50,7 @@
          </ol>
          <p>For each <code class="language-html">lang</code> attribute in the document:</p>
          <ol>
-            <li>Check that the value of the <code class="language-html">lang</code> attribute conforms to <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47: Tags for the Identification of Languages</a> or its successor.</li>
+            <li>Check that the value of the <code class="language-html">lang</code> attribute conforms to <a href="https://www.rfc-editor.org/info/bcp47">BCP 47: Tags for Identifying Languages; Matching of Language Tags</a> or its successor.</li>
             <li>Check that the language code matches the language of the content it applies to.</li>
          </ol>
       </section>
@@ -77,7 +77,7 @@
 						<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang">HTML "<code class="language-html">lang</code>" attribute on the Mozilla Developer Network</a>.
 				</li>
 				<li>
-						<a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47: Tags for the Identification of Languages</a>.
+					<a href="https://www.rfc-editor.org/info/bcp47">BCP 47: Tags for Identifying Languages; Matching of Language Tags</a>.
 				</li>
 				<li>
 					<a href="https://www.w3.org/International/articles/language-tags/">Language tags in HTML and XML</a>.

--- a/techniques/server-side-script/SVR1.html
+++ b/techniques/server-side-script/SVR1.html
@@ -112,7 +112,7 @@ header("Location: https://www.example.com/newUserLogin.php");
 				<a href="https://www.w3.org/QA/Tips/reback">Use standard redirects: do not break the back button!</a> (W3C QA Tip).
 			</li>
 		<li> 
-			<a href="https://tools.ietf.org/html/rfc7231#section-6.4">HTTP/1.1 Status Code Definitions: Redirection 3xx</a>.
+			<a href="https://www.rfc-editor.org/rfc/rfc9110#name-redirection-3xx">RFC 9110: HTTP Semantics 15.4. Redirection 3xx</li>.
 		</li>
 		<li> 
 			<a href="http://docs.oracle.com/cd/E17802_01/products/products/servlet/2.3/javadoc/javax/servlet/http/HttpServletResponse.html">Interface javax.servlet.http.HttpServletResponse</a> in

--- a/techniques/server-side-script/SVR1.html
+++ b/techniques/server-side-script/SVR1.html
@@ -112,7 +112,7 @@ header("Location: https://www.example.com/newUserLogin.php");
 				<a href="https://www.w3.org/QA/Tips/reback">Use standard redirects: do not break the back button!</a> (W3C QA Tip).
 			</li>
 		<li> 
-			<a href="https://www.rfc-editor.org/rfc/rfc9110#name-redirection-3xx">RFC 9110: HTTP Semantics 15.4. Redirection 3xx</li>.
+			<a href="https://www.rfc-editor.org/rfc/rfc9110#name-redirection-3xx">RFC 9110: HTTP Semantics 15.4. Redirection 3xx</a>.
 		</li>
 		<li> 
 			<a href="http://docs.oracle.com/cd/E17802_01/products/products/servlet/2.3/javadoc/javax/servlet/http/HttpServletResponse.html">Interface javax.servlet.http.HttpServletResponse</a> in


### PR DESCRIPTION
Many links related to HTML5, CSS and RFCs point to outdated resources.
This PR attempts to replace those links with the latest ones.