### PR TITLE
Remove duplicate links

### DIFF
--- a/techniques/general/G141.html
+++ b/techniques/general/G141.html
@@ -75,9 +75,6 @@
 				<a href="https://webaim.org/techniques/semanticstructure/">WebAIM: Semantic Structure</a>
 			</li>
 			<li>
-				<a href="https://webaim.org/techniques/semanticstructure/">WebAIM: Semantic Structure</a>
-			</li>
-			<li>
 				<a href="https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">HTML - The <code class="language-html">h1</code>, <code class="language-html">h2</code>, <code class="language-html">h3</code>, <code class="language-html">h4</code>, <code class="language-html">h5</code>, and <code class="language-html">h6</code> elements</a>
 			</li>
 		</ul>

--- a/techniques/html/H63.html
+++ b/techniques/html/H63.html
@@ -99,26 +99,5 @@
 			</li>
 		</ul> 
    </section>
-   <section id="related">
-      <h2>Related Techniques</h2>
-      <ul>
-         <li><a href="../html/H43">H43</a></li>
-         <li><a href="../html/H51">H51</a></li>
-      </ul>
-   </section>
-   <section id="resources">
-      <h2>Resources</h2>
-         <ul>
-            <li>
-               <a href="https://html.spec.whatwg.org/multipage/tables.html#attr-th-scope">HTML - the <code class="att">scope</code> attribute</a>.
-            </li>
-            <li>
-               <a href="https://html.spec.whatwg.org/multipage/tables.html#the-th-element">HTML - the <code class="el">th</code> element</a>.
-            </li>
-            <li>
-               <a href="https://html.spec.whatwg.org/multipage/tables.html#the-td-element">HTML - the <code class="el">td</code> element</a>.
-            </li>
-         </ul>
-      </section>
    </body>
 </html>


### PR DESCRIPTION
Removing duplicate information from several technique pages, where either links or entire sections were repeated.