### PR TITLE
Add more information/links to HTML-related obsolete messages

### DIFF
--- a/techniques/html/H35.html
+++ b/techniques/html/H35.html
@@ -1,8 +1,8 @@
 ---
 obsoleteMessage: |
-  The Java-specific <code class="el">applet</code> element is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
-  Use <code class="el">embed</code> or <code class="el">object</code> instead.
+  The Java-specific <code>applet</code> element is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#applet">obsolete since 2014 in HTML</a>.
+  Use <code>embed</code> or <code>object</code> instead.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title> Providing text alternatives on applet elements </title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1> Providing text alternatives on <code class="el">applet</code> elements </h1><section class="meta"><p class="id">ID: H35</p><p class="technology">Technology: html</p><p class="type">Type: Technique</p></section><section id="applicability"><h2>When to Use</h2>

--- a/techniques/html/H35.html
+++ b/techniques/html/H35.html
@@ -1,5 +1,8 @@
 ---
-obsoleteMessage: The Java-specific <code class="el">applet</code> element is obsolete.
+obsoleteMessage: |
+  The Java-specific <code class="el">applet</code> element is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
+  Use <code class="el">embed</code> or <code class="el">object</code> instead.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title> Providing text alternatives on applet elements </title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1> Providing text alternatives on <code class="el">applet</code> elements </h1><section class="meta"><p class="id">ID: H35</p><p class="technology">Technology: html</p><p class="type">Type: Technique</p></section><section id="applicability"><h2>When to Use</h2>

--- a/techniques/html/H35.html
+++ b/techniques/html/H35.html
@@ -1,7 +1,7 @@
 ---
 obsoleteMessage: |
   The Java-specific <code>applet</code> element is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#applet">obsolete since 2014 in HTML</a>.
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#applet">obsolete in the HTML Living Standard</a>.
   Use <code>embed</code> or <code>object</code> instead.
 obsoleteSince: 20
 ---

--- a/techniques/html/H45.html
+++ b/techniques/html/H45.html
@@ -1,5 +1,9 @@
 ---
-obsoleteMessage: The <code class="att">longdesc</code> attribute is obsolete and not widely supported.
+obsoleteMessage: |
+  The <code class="att">longdesc</code> attribute is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>,
+  and not widely supported.
+  Use an <code class="el">a</code> element or an image map to link to the description.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using longdesc</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Using longdesc</h1><section class="meta"><p class="id">ID: H45</p><p class="technology">Technology: html</p><p class="type">Type: Technique</p></section><section id="applicability"><h2>When to Use</h2>

--- a/techniques/html/H45.html
+++ b/techniques/html/H45.html
@@ -1,9 +1,9 @@
 ---
 obsoleteMessage: |
-  The <code class="att">longdesc</code> attribute is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>,
+  The <code>longdesc</code> attribute is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-img-longdesc">obsolete since 2014 in HTML</a>,
   and not widely supported.
-  Use an <code class="el">a</code> element or an image map to link to the description.
+  Use an <code>a</code> element or an image map to link to the description.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using longdesc</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Using longdesc</h1><section class="meta"><p class="id">ID: H45</p><p class="technology">Technology: html</p><p class="type">Type: Technique</p></section><section id="applicability"><h2>When to Use</h2>

--- a/techniques/html/H45.html
+++ b/techniques/html/H45.html
@@ -1,8 +1,8 @@
 ---
 obsoleteMessage: |
   The <code>longdesc</code> attribute is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-img-longdesc">obsolete since 2014 in HTML</a>,
-  and not widely supported.
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-img-longdesc">obsolete in the HTML Living Standard</a>,
+  and was never widely supported.
   Use an <code>a</code> element or an image map to link to the description.
 obsoleteSince: 20
 ---

--- a/techniques/html/H46.html
+++ b/techniques/html/H46.html
@@ -1,5 +1,8 @@
 ---
-obsoleteMessage: <code class="el">noembed</code> is obsolete. Use <code class="el">object</code> instead when fallback is necessary.
+obsoleteMessage: |
+  <code class="el">noembed</code> is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
+  Use <code class="el">object</code> instead when fallback is necessary.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using noembed with embed

--- a/techniques/html/H46.html
+++ b/techniques/html/H46.html
@@ -1,8 +1,8 @@
 ---
 obsoleteMessage: |
-  <code class="el">noembed</code> is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
-  Use <code class="el">object</code> instead when fallback is necessary.
+  <code>noembed</code> is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#noembed">obsolete since 2014 in HTML</a>.
+  Use <code>object</code> instead when fallback is necessary.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using noembed with embed

--- a/techniques/html/H46.html
+++ b/techniques/html/H46.html
@@ -1,7 +1,7 @@
 ---
 obsoleteMessage: |
   <code>noembed</code> is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#noembed">obsolete since 2014 in HTML</a>.
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#noembed">obsolete in the HTML Living Standard</a>.
   Use <code>object</code> instead when fallback is necessary.
 obsoleteSince: 20
 ---

--- a/techniques/html/H59.html
+++ b/techniques/html/H59.html
@@ -1,5 +1,5 @@
 ---
-obsoleteMessage: <code class="att">prev</code> and <code class="att">next</code> typically have no effect on browser navigation controls.
+obsoleteMessage: <code>prev</code> and <code>next</code> typically have no effect on browser navigation controls.
 obsoleteSince: 20
 ---
 <!DOCTYPE html>

--- a/techniques/html/H70.html
+++ b/techniques/html/H70.html
@@ -1,8 +1,8 @@
 ---
 obsoleteMessage: |
-  The <code class="el">frameset</code> and <code class="el">frame</code> elements are
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
-  Either use <code class="el">iframe</code> and CSS instead,
+  The <code>frameset</code> and <code>frame</code> elements are
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features:frameset">obsolete since 2014 in HTML</a>.
+  Either use <code>iframe</code> and CSS instead,
   or use server-side includes to generate complete pages with the various invariant parts merged in.
 obsoleteSince: 20
 ---

--- a/techniques/html/H70.html
+++ b/techniques/html/H70.html
@@ -1,5 +1,9 @@
 ---
-obsoleteMessage: The <code class="el">frameset</code> and <code class="el">frame</code> elements are obsolete.
+obsoleteMessage: |
+  The <code class="el">frameset</code> and <code class="el">frame</code> elements are
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
+  Either use <code class="el">iframe</code> and CSS instead,
+  or use server-side includes to generate complete pages with the various invariant parts merged in.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using frame elements to group blocks of repeated material</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></link></head><body><h1>Using frame elements to group blocks of repeated material</h1><section class="meta"><p class="id">ID: H70</p><p class="technology">Technology: html</p><p class="type">Type: Technique</p></section><section id="applicability"><h2>When to Use</h2>

--- a/techniques/html/H70.html
+++ b/techniques/html/H70.html
@@ -1,7 +1,7 @@
 ---
 obsoleteMessage: |
   The <code>frameset</code> and <code>frame</code> elements are
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features:frameset">obsolete since 2014 in HTML</a>.
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features:frameset">obsolete in the HTML Living Standard</a>.
   Either use <code>iframe</code> and CSS instead,
   or use server-side includes to generate complete pages with the various invariant parts merged in.
 obsoleteSince: 20

--- a/techniques/html/H73.html
+++ b/techniques/html/H73.html
@@ -1,7 +1,7 @@
 ---
 obsoleteMessage: |
-  The <code class="att">summary</code> attribute is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
+  The <code>summary</code> attribute is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-summary">obsolete since 2014 in HTML</a>.
   Use one of the <a href="https://html.spec.whatwg.org/multipage/tables.html#table-descriptions-techniques">techniques for describing tables</a> instead.
 obsoleteSince: 20
 ---

--- a/techniques/html/H73.html
+++ b/techniques/html/H73.html
@@ -1,5 +1,8 @@
 ---
-obsoleteMessage: The <code class="att">summary</code> attribute is obsolete as of HTML5.
+obsoleteMessage: |
+  The <code class="att">summary</code> attribute is
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features">obsolete as of HTML5</a>.
+  Use one of the <a href="https://html.spec.whatwg.org/multipage/tables.html#table-descriptions-techniques">techniques for describing tables</a> instead.
 obsoleteSince: 20
 ---
 <!DOCTYPE html><html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><title>Using the summary attribute of the table element to give an overview of data

--- a/techniques/html/H73.html
+++ b/techniques/html/H73.html
@@ -1,7 +1,7 @@
 ---
 obsoleteMessage: |
   The <code>summary</code> attribute is
-  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-summary">obsolete since 2014 in HTML</a>.
+  <a href="https://html.spec.whatwg.org/multipage/obsolete.html#attr-table-summary">obsolete in the HTML Living Standard</a>.
   Use one of the <a href="https://html.spec.whatwg.org/multipage/tables.html#table-descriptions-techniques">techniques for describing tables</a> instead.
 obsoleteSince: 20
 ---


### PR DESCRIPTION
This is a follow-up to #3975 related to @bruce-usab's feedback.

Previews: [H35](https://deploy-preview-4027--wcag2.netlify.app/techniques/html/h35), [H45](https://deploy-preview-4027--wcag2.netlify.app/techniques/html/h45), [H46](https://deploy-preview-4027--wcag2.netlify.app/techniques/html/h46), [H70](https://deploy-preview-4027--wcag2.netlify.app/techniques/html/h70), [H73](https://deploy-preview-4027--wcag2.netlify.app/techniques/html/h73)