### PR TITLE
Fix typo/incorrect word in input purpose listing

### DIFF
--- a/guidelines/input-purposes.html
+++ b/guidelines/input-purposes.html
@@ -29,7 +29,7 @@
 		<li><strong>address-level1</strong> - The broadest administrative level in the address, i.e., the province within which the locality is found; for example, in the US, this would be the state; in Switzerland it would be the canton; in the UK, the post town</li>
 		<li><strong>country</strong> - Country code</li>
 		<li><strong>country-name</strong> - Country name</li>
-		<li><strong>postal-code</strong> - Postal code, post code, ZIP code, CEDEX code (if CEDEX, append "CEDEX", and the <i lang="fr">dissement</i>, if relevant, to the <strong>address-level2</strong> field)</li>
+		<li><strong>postal-code</strong> - Postal code, post code, ZIP code, CEDEX code (if CEDEX, append "CEDEX", and the <i lang="fr">arrondissement</i>, if relevant, to the <strong>address-level2</strong> field)</li>
 		<li><strong>cc-name</strong> - Full name as given on the payment instrument</li>
 		<li><strong>cc-given-name</strong> - Given name as given on the payment instrument (in some Western cultures, also known as the <i>first name</i>)</li>
 		<li><strong>cc-additional-name</strong> - Additional names given on the payment instrument (in some Western cultures, also known as <i>middle names</i>, forenames other than the first name)</li>


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/4033