### PR TITLE
Add F42 as failure for 4.1.2

### DIFF
--- a/understanding/20/name-role-value.html
+++ b/understanding/20/name-role-value.html
@@ -1,50 +1,41 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-   <meta charset="UTF-8"></meta>
+   <meta charset="UTF-8"/>
    <title>Understanding Name, Role, Value</title>
    <link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
 </head>
 <body>
    <h1>Understanding Name, Role, Value</h1>
-   
    <section id="brief">
 		<h2>In brief</h2>
 		<dl>
          <dt>Goal</dt><dd>People using assistive technology understand all components.</dd>
          <dt>What to do</dt><dd>Give components correct names, roles, states, and values.</dd>
-         <dt>Why it's important</dt><dd>Assistive technology only works well when code is done properly.</dd> 
+         <dt>Why it's important</dt><dd>Assistive technology only works well when code is done properly.</dd>
       </dl>
-
    </section>
-   
    <section id="intent">
       <h2>Intent of Name, Role, Value</h2>
-      
-      
       <p>The intent of this Success Criterion is to ensure that Assistive Technologies (AT)
          can gather appropriate information about, activate (or set) and keep up to date on the status of
          user interface controls in the content.
       </p>
-      
       <p>When standard controls from accessible technologies are used, this process is straightforward.
          If the user interface elements are used according to specification the conditions
          of this provision will be met. (See examples of Success Criterion 4.1.2 below)
       </p>
-      
       <p>If custom controls are created, however, or interface elements are programmed (in
          code or script) to have a different role and/or function than usual, then additional
          measures need to be taken to ensure that the controls provide important and appropriate information
          to assistive technologies and allow themselves to be controlled by assistive technologies.
       </p>
-     
       <p>What roles and states are appropriate to convey to assistive technology will depend
          on what the control represents. Specifics about such information are defined by other
          specifications, such as <a href="https://www.w3.org/TR/wai-aria/">WAI-ARIA</a>, or the
          relevant platform standards. Another factor to consider is whether there is sufficient
          <a>accessibility support</a> with assistive technologies to convey the information as specified.
       </p>
-      
       <p>A particularly important state of a user interface control is whether or not it has
          focus. The focus state of a control can be programmatically determined, and notifications
          about change of focus are sent to user agents and assistive technology. Other examples
@@ -52,48 +43,32 @@
          been selected, or whether a collapsible tree view or accordion is expanded or collapsed.
       </p>
 
-     
       <div class="note">
-         
          <p>Success Criterion 4.1.2 requires a programmatically determinable name for all user
             interface components. Names may be visible or invisible. Occasionally, the name needs
             to be visible, in which case it is identified as a label. Refer to the definition of
             name and label in the glossary for more information.
          </p>
-         
       </div>
-      
-      
    </section>
    <section id="benefits">
       <h2>Benefits of Name, Role, Value</h2>
-      
-      
       <ul>
-         
          <li>Providing role, state, and value information on all user interface components enables
             compatibility with assistive technology, such as screen readers, screen magnifiers,
             and speech recognition software, used by people with disabilities.
          </li>
-         
       </ul>
-      
    </section>
-   
    <section id="examples">
       <h2>Examples of Name, Role, Value</h2>
-      
       <dl>
          <dt>Accessible APIs</dt>
          <dd>A Java applet uses the accessibility API defined by the language.</dd>
       </dl>
-      
    </section>
-   
    <section id="resources">
       <h2>Resources for Name, Role, Value</h2>
-      
-      
       <ul>
          <li>
             <a href="https://www.w3.org/WAI/PF/roadmap/">Dynamic Accessible Web Content Roadmap</a>
@@ -105,270 +80,155 @@
             <a href="https://www.w3.org/TR/wai-aria/">Web Accessibility Initiative - Accessible Rich Internet Applications (ARIA)</a>
          </li>
       </ul>
-      
    </section>
-   
    <section id="techniques">
       <h2>Techniques for Name, Role, Value</h2>
-      
-      
       <section id="sufficient">
          <h3>Sufficient Techniques for Name, Role, Value</h3>
-         
-         
          <section class="situation" id="name-role-value-situation-0">
-            
             <h4>Situation A: If using a standard user interface component in a markup language (e.g.,
                HTML):
             </h4>
-            
             <ul>
-               
                <li>
-                  
                   <a href="../Techniques/aria/ARIA14" class="aria"></a>
-                  
                </li>
-               
                <li>
-                  
                   <a href="../Techniques/aria/ARIA16" class="aria"></a>
-                  
                </li>
-               
                <li>
-                  
-                  <p> 
-                     
+                  <p>
                      <a href="../Techniques/general/G108" class="general">Using markup features to expose the name and role, allow user-settable properties
                         to be directly set, and provide notification of changes
                      </a> using technology-specific techniques below:
                   </p>
-                  
                   <ul>
-                     
                      <li>
-                        												               
                         <a href="../Techniques/html/H91" class="html">Using HTML form controls and links</a>
-                        											             
                      </li>
-                     
                      <li>
-                        												               
                         <a href="../Techniques/html/H44" class="html">Using label elements to associate text labels with form controls</a>
-                        											             
                      </li>
-                     
                      <li>
-                        												               
                         <a href="../Techniques/html/H64" class="html">Using the title attribute of the frame element</a>
-                        											             
                      </li>
-                     
                      <li>
-                        												               
                         <a href="../Techniques/html/H65" class="html">Using the title attribute to identify form controls when the label element cannot
                            be used
                         </a>
-                        											             
                      </li>
-                     
                      <li>
-                        												               
                         <a href="../Techniques/html/H88" class="html">Using (X)HTML according to spec</a>
-                        											             
                      </li>
-                     
                   </ul>
-                  
                </li>
-               
             </ul>
-            
          </section>
-         
          <section class="situation" id="name-role-value-situation-1">
-            
             <h4>Situation B: If using script or code to re-purpose a standard user interface component
                in a markup language:
             </h4>
-            
             <ul>
-               
                <li>
-                  
                   <p>Exposing the names and roles, allowing user-settable properties to be directly set,
                      and providing notification of changes using one of the following techniques:
                   </p>
-                  
                   <ul>
-                     
                      <li>
-                        
                         <a href="../Techniques/aria/ARIA16" class="aria"></a>
-                        
                      </li>
-                     
                   </ul>
-                  
                </li>
-               
             </ul>
-            
          </section>
-         
          <section class="situation" id="name-role-value-situation-2">
-            
             <h4>Situation C: If using a standard user interface component in a programming technology:</h4>
-            
             <ul>
-               
                <li>
-                  
                   <p>
-                     										           
                      <a href="../Techniques/general/G135" class="general">Using the accessibility API features of a technology to expose the names and roles,
                         allow user-settable properties to be directly set, and provide notification of changes
                      </a> using technology-specific techniques below:
-                     									
                   </p>
-                  
                   <ul>
-                                        
                      <li>
-                        
                         <a href="../Techniques/pdf/PDF10" class="pdf"></a>
-                        
                      </li>
-                     
                      <li>
-                        
                         <a href="../Techniques/pdf/PDF12" class="pdf"></a>
-                        
                      </li>
-                     
                   </ul>
-                  
                </li>
-               
             </ul>
-            
          </section>
-         
          <section class="situation" id="name-role-value-situation-3">
-            
             <h4>Situation D: If creating your own user interface component in a programming language:</h4>
-            
             <ul>
-               
                <li>
-                  
                   <p>
-                     										           
                      <a href="../Techniques/general/G10" class="general">Creating components using a technology that supports the accessibility API features
                         of the platforms on which the user agents will be run to expose the names and roles,
                         allow user-settable properties to be directly set, and provide notification of changes
                      </a> using technology-specific techniques below:
-                     									
                   </p>
-                  
                   <ul>
-                     
                      <li>
-                        
                         <a href="../Techniques/aria/ARIA4" class="aria"></a>
-                        
                      </li>
-                     
                      <li>
-                        
                         <a href="../Techniques/aria/ARIA5" class="aria"></a>
-                        
                      </li>
-                     
                      <li>
-                        
                         <a href="../Techniques/aria/ARIA16" class="aria"></a>
-                        
                      </li>
-                     
                   </ul>
-                  
                </li>
-               
             </ul>
-            
          </section>
-         
       </section>
-      
       <section id="advisory">
          <h3>Additional Techniques (Advisory) for Name, Role, Value</h3>
-         
       </section>
-      
       <section id="failure">
          <h3>Failures for Name, Role, Value</h3>
-         
-         
          <ul>
-            
             <li>
-								         
                <a href="../Techniques/failures/F59" class="failure">Failure due to using script to make div or span a user interface control in HTML</a>
-               
             </li>
-            
             <li>
-               									         
                <a href="../Techniques/failures/F15" class="failure">Failure due to implementing custom controls that do not use an accessibility API</a>
-               								       
             </li>
-            
             <li>
-               									         
                <a href="../Techniques/failures/F20" class="failure">Failure due to not updating text alternatives when changes to non-text content occur</a>
-               								       
             </li>
-            
             <li>
-               									         
+               <a href="../Techniques/failures/F42" class="failure">Failure of Success Criterion 1.3.1 and 2.1.1 due to using scripting events to emulate
+                  links
+               </a>
+            </li>
+            <li>
                <a href="../Techniques/failures/F68" class="failure">Failure of 1.3.1 and 4.1.2 due to the association of label and user interface controls
                   not being programmatically determinable
                </a>
-               								       
             </li>
-            
             <li>
-               									         
                <a href="../Techniques/failures/F79" class="failure">Failure of Success Criterion 4.1.2 due to the focus state of a user interface component
                   not being programmatically determinable or no notification of change of focus state
                   available
                </a>
-               								       
             </li>
-            
             <li>
-               									         
                <a href="../Techniques/failures/F86" class="failure">Failure of Success Criterion 4.1.2 due to not providing names for each part of a multi-part
                   form field, such as a US telephone number
                </a>
-               								       
             </li>
-            
             <li>
-               									         
                <a href="../Techniques/failures/F89" class="failure">Failure of 2.4.4 due to using null alt on an image where the image is the only content
                   in a link
                </a>
-               								       
             </li>
-            
          </ul>
-         
       </section>
-      
    </section>
-   
 </body>
 </html>

--- a/understanding/20/name-role-value.html
+++ b/understanding/20/name-role-value.html
@@ -98,27 +98,23 @@
                </li>
                <li>
                   <p>
-                     <a href="../Techniques/general/G108" class="general">Using markup features to expose the name and role, allow user-settable properties
-                        to be directly set, and provide notification of changes
-                     </a> using technology-specific techniques below:
+                     <a href="../Techniques/general/G108" class="general"></a> using technology-specific techniques below:
                   </p>
                   <ul>
                      <li>
-                        <a href="../Techniques/html/H91" class="html">Using HTML form controls and links</a>
+                        <a href="../Techniques/html/H91" class="html"></a>
                      </li>
                      <li>
-                        <a href="../Techniques/html/H44" class="html">Using label elements to associate text labels with form controls</a>
+                        <a href="../Techniques/html/H44" class="html"></a>
                      </li>
                      <li>
-                        <a href="../Techniques/html/H64" class="html">Using the title attribute of the frame element</a>
+                        <a href="../Techniques/html/H64" class="html"></a>
                      </li>
                      <li>
-                        <a href="../Techniques/html/H65" class="html">Using the title attribute to identify form controls when the label element cannot
-                           be used
-                        </a>
+                        <a href="../Techniques/html/H65" class="html"></a>
                      </li>
                      <li>
-                        <a href="../Techniques/html/H88" class="html">Using (X)HTML according to spec</a>
+                        <a href="../Techniques/html/H88" class="html"></a>
                      </li>
                   </ul>
                </li>
@@ -146,9 +142,7 @@
             <ul>
                <li>
                   <p>
-                     <a href="../Techniques/general/G135" class="general">Using the accessibility API features of a technology to expose the names and roles,
-                        allow user-settable properties to be directly set, and provide notification of changes
-                     </a> using technology-specific techniques below:
+                     <a href="../Techniques/general/G135" class="general"></a> using technology-specific techniques below:
                   </p>
                   <ul>
                      <li>
@@ -166,10 +160,7 @@
             <ul>
                <li>
                   <p>
-                     <a href="../Techniques/general/G10" class="general">Creating components using a technology that supports the accessibility API features
-                        of the platforms on which the user agents will be run to expose the names and roles,
-                        allow user-settable properties to be directly set, and provide notification of changes
-                     </a> using technology-specific techniques below:
+                     <a href="../Techniques/general/G10" class="general"></a> using technology-specific techniques below:
                   </p>
                   <ul>
                      <li>
@@ -193,39 +184,28 @@
          <h3>Failures for Name, Role, Value</h3>
          <ul>
             <li>
-               <a href="../Techniques/failures/F59" class="failure">Failure due to using script to make div or span a user interface control in HTML</a>
+               <a href="../Techniques/failures/F59" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F15" class="failure">Failure due to implementing custom controls that do not use an accessibility API</a>
+               <a href="../Techniques/failures/F15" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F20" class="failure">Failure due to not updating text alternatives when changes to non-text content occur</a>
+               <a href="../Techniques/failures/F20" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F42" class="failure">Failure of Success Criterion 1.3.1 and 2.1.1 due to using scripting events to emulate
-                  links
-               </a>
+               <a href="../Techniques/failures/F42" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F68" class="failure">Failure of 1.3.1 and 4.1.2 due to the association of label and user interface controls
-                  not being programmatically determinable
-               </a>
+               <a href="../Techniques/failures/F68" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F79" class="failure">Failure of Success Criterion 4.1.2 due to the focus state of a user interface component
-                  not being programmatically determinable or no notification of change of focus state
-                  available
-               </a>
+               <a href="../Techniques/failures/F79" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F86" class="failure">Failure of Success Criterion 4.1.2 due to not providing names for each part of a multi-part
-                  form field, such as a US telephone number
-               </a>
+               <a href="../Techniques/failures/F86" class="failure"></a>
             </li>
             <li>
-               <a href="../Techniques/failures/F89" class="failure">Failure of 2.4.4 due to using null alt on an image where the image is the only content
-                  in a link
-               </a>
+               <a href="../Techniques/failures/F89" class="failure"></a>
             </li>
          </ul>
       </section>


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/1263

(also cleans up the markup of 4.1.2 understanding, removing all unnecessary/excessive line breaks, fixes the invalid use of `</meta>`, and removes the unnecessary techniques link text which is autopopulated at publish time)