### PR TITLE
Update 3.3.2 Labels or Instructions Understanding Doc

### DIFF
--- a/understanding/20/labels-or-instructions.html
+++ b/understanding/20/labels-or-instructions.html
@@ -12,7 +12,7 @@
 		<h2>In brief</h2>
 		<dl>
          <dt>Goal</dt><dd>Users know what information to enter.</dd>
-         <dt>What to do</dt><dd>Provide labels or instructions for inputs.</dd>
+         <dt>What to do</dt><dd>Provide accurate and descriptive labels or instructions for inputs.</dd>
          <dt>Why it's important</dt><dd>Everyone, especially those with cognitive disabilities, will know how to respond.</dd> 
       </dl>
 
@@ -21,12 +21,12 @@
    <section id="intent">
       <h2>Intent of Labels or Instructions</h2>
       
-      <p>The intent of this Success Criterion is to have content authors present instructions
-         or labels that identify the controls in a form so that users know what input data
+      <p>The intent of this Success Criterion is to have content authors present accurate instructions
+         or labels that precisely and clearly identify the controls in a form so that users know what input data
          is expected. In the case of radio buttons, checkboxes, comboboxes, or similar controls
-         that provide users with options, each option must have an appropriate label so that
+         that provide users with options, each option must have an accurate and descriptive label so that
          users know what they are actually selecting. 
-         Instructions or labels may also specify data formats for data entry fields, especially
+         Instructions or labels may also accurately specify data formats for data entry fields, especially
          if they are out of the customary formats or if there are specific rules for correct
          input. Content authors may also choose to make such instructions available to users
          only when the individual control has focus especially when instructions are long and
@@ -34,16 +34,16 @@
       </p>
       
       <p>The intent of this Success Criterion is not to clutter the page with unnecessary information
-         but to provide important cues and instructions that will benefit people with disabilities.
+         but to provide accurate and essential cues and instructions that will benefit people with disabilities.
          Too much information or instruction can be just as harmful as too little.
-         The goal is to make certain that enough information is provided for the user to accomplish
+         The goal is to make certain that enough accurate information is provided for the user to accomplish
          the task without undue confusion or navigation.
       </p>
          
       <p>This Success Criterion does not require that labels or instructions be correctly marked up, 
          identified, or associated with their respective controls - this aspect is covered separately by
          <a href="info-and-relationships">1.3.1: Info and Relationships</a>. It is possible for content
-         to pass this Success Criterion (providing relevant labels and instructions) while failing
+         to pass this Success Criterion (providing relevant, accurate labels and instructions) while failing
          Success Criterion 1.3.1 (if the labels or instructions aren't correctly marked up, identified, or associated).
       </p>
       <p>Further, this Success Criterion does not take into consideration whether or not alternative methods of
@@ -56,9 +56,7 @@
       <p>This Success Criterion does not apply to links or other controls (such as an expand/collapse widget, or similar
          interactive components) that are not associated with data entry.
       </p>
-      <p>While this Success Criterion requires that controls and inputs have labels or instructions, whether or
-         not labels (if used) are sufficiently clear or descriptive is covered separately by
-         <a href="headings-and-labels">2.4.6: Headings and Labels</a>.
+      <p>While this Success Criterion requires that controls and inputs have labels or instructions, it is crucial that these labels or instructions are not only present but also accurate. The clarity and descriptiveness of labels are further addressed by <a href="headings-and-labels">2.4.6: Headings and Labels</a>.
       </p> 
 
    </section>
@@ -68,12 +66,12 @@
       
       <ul>
          
-         <li>Providing labels and instructions (including examples of expected
+         <li>Providing accurate labels and instructions (including examples of expected
             data formats) helps all users - but particularly those with cognitive, language, and learning
             disabilities - to enter information correctly.
          </li>
          
-         <li>Providing labels and instructions (including identification of required
+         <li>Providing accurate labels and instructions (including identification of required
             fields) can prevent users from making incomplete or incorrect form submissions, which prevents
             users from having to navigate once more through a page/form in order to fix submission errors.
          </li>
@@ -97,8 +95,8 @@
          </li>
          
          <li>To enter their name, users are provided with two separate text fields. Rather than
-            having a single label "Name" (which would appear to leave the second text field unlabelled),
-            each field is given an explicit label - "Given Name" and "Family Name".
+            having a single, imprecise label "Name" (which would appear to leave the second text field unlabelled),
+            each field is given an explicit and accurate label - "Given Name" and "Family Name". This accurate labeling helps users understand where to input their first and last names, reducing confusion and ensuring correct data entry.
          </li>
          
          <li>A U.S. phone number separates the area code, exchange, and number into three fields.


### PR DESCRIPTION
An attempt at restoring the need for accuracy/correctness to 3.3.2 Labels or Instructions, as discussed in #3984.

Inserts multiple references to _accurate_ labels and instructions, expands upon one of the examples, and addresses the overlap with 2.4.6. 

resolves #3984 