### PR TITLE
Add "modality" to single pointer definition with examples of single pointer interactions

### DIFF
--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
-   <p>an input mechanism that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
+   <p>an input modality that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
    <p class="note">Single pointer interactions include clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
-   <p>an input that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
+   <p>an input mechanism that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
    <p class="note">In contrast to single pointer inputs, multipoint interactions involve the use of two or more pointers at the same time – such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
    <p>an input mechanism that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
-   <p class="note">In contrast to single pointer inputs, multipoint interactions involve the use of two or more pointers at the same time – such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
+   <p class="note">In contrast to single pointer interactions, multipoint interactions involve the use of two or more pointers at the same time – such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
    <p>an input mechanism that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
-   <p class="note">In contrast to single pointer interactions, multipoint interactions involve the use of two or more pointers at the same time – such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
+   <p class="note">Single pointer interactions include clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
    <p>an input modality that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
-   <p class="note">Single pointer interactions include clicks, double clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
+   <p class="note">Single pointer interactions include clicks, double clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two-finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
    <p>an input modality that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus.</p>
-   <p class="note">Single pointer interactions include clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
+   <p class="note">Single pointer interactions include clicks, double clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 


### PR DESCRIPTION
Follow-up to https://github.com/w3c/wcag/pull/3536#issuecomment-2352336750 to potentially address concerns by @WilcoFiers @dbjorge

Tries to more clearly differentiate "input" as in the *modality* from the gestures/interactions that are the *result* of using a particular input *modality*


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/4070.html" title="Last updated on Sep 20, 2024, 8:10 PM UTC (a79bb49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/4070/4213bf6...a79bb49.html" title="Last updated on Sep 20, 2024, 8:10 PM UTC (a79bb49)">Diff</a>