### PR TITLE
Fix link to Understanding Test Rules from techniques pages

### DIFF
--- a/_includes/test-rules.html
+++ b/_includes/test-rules.html
@@ -1,6 +1,6 @@
 {% if testRules.size > 0 %}
 {%- if isTechniques -%}
-  {% assign understandingActRulesHref = "/understanding/understanding-act-rules.html" %}
+  {% assign understandingActRulesHref = "../../understanding/understanding-act-rules.html" %}
 {%- else -%}
   {% assign understandingActRulesHref = "understanding-act-rules.html" %}
 {%- endif -%}


### PR DESCRIPTION
I stumbled across this bug today, which has unfortunately probably existed since the new build system was put into place.

It specifically affects the link to "Understanding Test Rules for WCAG Success Criteria" found under Test Rules sections in techniques pages only (understanding pages do not have this bug). The link has the wrong base path, causing a 404 when built for GitHub Pages or the W3C site.

This PR fixes it by properly referencing `understanding` relatively from pages under `techniques`; in the full scope of the build system, this then ends up replaced with a fully-qualified URL when processed through `CustomLiquid.ts`.

Example from https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA4:

```
<a href="/understanding/understanding-act-rules.html">
```

Example of same link built in `publication` mode from this PR:

```
<a href="https://www.w3.org/WAI/WCAG22/Understanding/understanding-act-rules.html">
```