### PR TITLE
Add top-level index.html for dev only (not GH Pages / W3C site)

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,5 +1,6 @@
-*.*
+*.md
 11ty/
+acknowledgements.html
 acknowledgements/
 conformance-challenges/
 guidelines/

--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -89,6 +89,8 @@ export class CustomLiquid extends Liquid {
       const isIndex = indexPattern.test(filepath);
       const isTechniques = techniquesPattern.test(filepath);
       const isUnderstanding = understandingPattern.test(filepath);
+      
+      if (!isTechniques && !isUnderstanding) return super.parse(html);
 
       const $ = flattenDom(html, filepath);
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Web Content Accessibility Guidelines {{ versionDecimal }}</title>
+	</head>
+	<body>
+		<h1>Web Content Accessibility Guidelines {{ versionDecimal }}</h1>
+		<ul>
+			<li><a href="techniques/">Techniques</a></li>
+			<li><a href="understanding/">Understanding Docs</a></li>
+		</ul>
+	</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "liquidjs": "^10.17.0",
         "lodash-es": "^4.17.21",
         "mkdirp": "^3.0.1",
+        "rimraf": "^5.0.10",
         "tsx": "^4.11.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "liquidjs": "^10.17.0",
     "lodash-es": "^4.17.21",
     "mkdirp": "^3.0.1",
+    "rimraf": "^5.0.10",
     "tsx": "^4.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a re-do of #4076, with one change: it only pre-clears the output folder (`_site`) for W3C site builds, not for GitHub Pages builds. The deploy script for the latter depends on the output folder _not_ being cleared, in order to layer the new build on top of existing contents. (Fortunately this failed loudly the first time upon deploy, so it didn't affect the contents of the gh-pages branch.)

I [tested using my own fork](https://github.com/kfranqueiro/wcag/actions/runs/10964516195/job/30448309053) this time to make sure the GitHub Pages build would complete, and confirmed that the top-level index.html added in this PR does _not_ output for that build, leaving the existing top-level index.html in the gh-pages branch intact.