### PR TITLE
Add note markup to user inactivity definition

### DIFF
--- a/guidelines/terms/21/user-inactivity.html
+++ b/guidelines/terms/21/user-inactivity.html
@@ -1,5 +1,5 @@
 <dt><dfn id="dfn-user-inactivity">user inactivity</dfn></dt>
 <dd>
   <p>any continuous period of time where no user actions occur</p>
-	<p>The method of tracking will be determined by the web site or application.</p>
+	<p class="note">The method of tracking will be determined by the web site or application.</p>
 </dd>


### PR DESCRIPTION
The second sentence of the user inactivity glossary item is a note.

- Fixes: https://github.com/w3c/wcag/issues/4117


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yatil/wcag/pull/4118.html" title="Last updated on Oct 26, 2024, 7:46 AM UTC (4beb569)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/4118/bfa7f4c...yatil:4beb569.html" title="Last updated on Oct 26, 2024, 7:46 AM UTC (4beb569)">Diff</a>