### PR TITLE
Update changelog in guidelines/index.html

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -794,6 +794,19 @@
 				<li>2022-03-22: Added <a href="#focus-not-obscured-minimum">Focus Not Obscured (Minimum)</a>.</li>
 				<li>2022-05-30: Added <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a>.</li>
 				<li>2023-06-05: Added privacy and security sections within conformance.</li>
+                <li>2024-11-15: Republished WCAG 2.2, incorporating the following substantive errata:
+                    <ul>
+                        <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
+                        <li>modified the formatting of definitions for <a>changes of content</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>and <a>structure</a></li>
+                        <li>removed the defunct <q>encloses</q> definition</li>
+                        <li>updated and corrected the <a>input purposes</a> list</li>
+                        <li>modified the formatting of Target Size (Minimum) and Accessible Authentication (Minimum)</li>
+                        <li>modified the visual presentation for content identified as New</li>
+                        <li>modified the language covering devices in the <a>abstract</a></li>
+                        <li>made editorial changes to improve consistent use of definitions in success criteria</li>
+                        <li>made editorial changes to improve consistent use of the term <q>success criteria/criterion</q></li>
+                    </ul>
+                </li>
     		</ul>
     	</section>
     	<section class="appendix informative section" id="acknowledgements">

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -797,14 +797,14 @@
                 <li>2024-11-15: Republished WCAG 2.2, incorporating the following errata:
                     <ul>
                         <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
-                        <li>modified the formatting of definitions for <a>changes of content</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>and <a>structure</a></li>
+                        <li>modified the formatting of definitions for <a>changes of content</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>, and <a>structure</a></li>
                         <li>removed the defunct <q>encloses</q> definition</li>
                         <li>updated and corrected the <a>input purposes</a> list</li>
                         <li>modified the formatting of Target Size (Minimum) and Accessible Authentication (Minimum)</li>
                         <li>modified the visual presentation for content identified as New</li>
-                        <li>modified the language covering devices in the <a>abstract</a></li>
-                        <li>made editorial changes to improve consistent use of definitions in success criteria</li>
-                        <li>made editorial changes to improve consistent use of the term <q>success criteria/criterion</q></li>
+                        <li>modified the language covering devices in the <a>Abstract</a></li>
+                        <li>made editorial changes to improve consistent use of definitions in the success criteria</li>
+                        <li>made editorial changes to improve consistent use of the terms <q>success criteria/criterion</q>, <q>web</q>, <q>website</q>, and <q>web page</q></li>
                     </ul>
                 </li>
     		</ul>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -799,7 +799,7 @@
                         <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
                         <li>modified the formatting of definitions for <a>changes of context</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>, and <a>structure</a></li>
                         <li>removed the defunct <q>encloses</q> definition</li>
-                        <li>updated and corrected the <a>input purposes</a> list</li>
+                        <li>updated and corrected the <a href="#input-purposes">input purposes</a> list</li>
                         <li>modified the formatting of Target Size (Minimum) and Accessible Authentication (Minimum)</li>
                         <li>modified the visual presentation for content identified as New</li>
                         <li>modified the language covering devices in the <a>Abstract</a></li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -794,7 +794,7 @@
 				<li>2022-03-22: Added <a href="#focus-not-obscured-minimum">Focus Not Obscured (Minimum)</a>.</li>
 				<li>2022-05-30: Added <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a>.</li>
 				<li>2023-06-05: Added privacy and security sections within conformance.</li>
-                <li>2024-11-15: Republished WCAG 2.2, incorporating the following substantive errata:
+                <li>2024-11-15: Republished WCAG 2.2, incorporating the following errata:
                     <ul>
                         <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
                         <li>modified the formatting of definitions for <a>changes of content</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>and <a>structure</a></li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -799,7 +799,7 @@
                         <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
                         <li>modified the formatting of definitions for <a>changes of context</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>, and <a>structure</a></li>
                         <li>removed the defunct <q>encloses</q> definition</li>
-                        <li>updated and corrected the <a href="#input-purposes">input purposes</a> list</li>
+                        <li>corrected typo in <a href="#input-purposes">input purposes</a> list</li>
                         <li>modified the formatting of Target Size (Minimum) and Accessible Authentication (Minimum)</li>
                         <li>modified the visual presentation for content identified as New</li>
                         <li>modified the language covering devices in the <a href="#abstract">Abstract</a></li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -789,7 +789,7 @@
     			<li>2020-03-30: Added <a href="#accessible-authentication-minimum">Accessible Authentication (Minimum)</a>.</li>
     			<li>2020-05-27: Added <q>Dragging</q> (later renamed <a href="#dragging-movements">Dragging Movements</a>).</li>
     			<li>2020-07-19: Added <q>Findable Help</q> (later renamed to <a href="#consistent-help">Consistent Help</a>), <q>Pointer Target Spacing</q> (later renamed <a href="#target-size-minimum">Target Size (Minimum)</a>), and <a href="#redundant-entry">Redundant Entry</a>.</li>
-    			<li>2020-08-04: Added Focus Appearance (Minimum) (later renamed to <a href="#focus-appearance">Focus Appearance</a>).</li>
+    			<li>2020-08-04: Added <q>Focus Appearance (Minimum)</q> (later renamed to <a href="#focus-appearance">Focus Appearance</a>).</li>
 				<li>2021-09-21: Added <q>Accessible Authentication (No Exception)</q> (later renamed <a href="#accessible-authentication-enhanced">Accessible Authentication (Enhanced))</a>.</li>
 				<li>2022-03-22: Added <a href="#focus-not-obscured-minimum">Focus Not Obscured (Minimum)</a>.</li>
 				<li>2022-05-30: Added <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a>.</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -783,7 +783,7 @@
       
     	<section class="appendix" id="changelog">
     		<h2>Change Log</h2>
-    		<p>This section shows substantive changes incorporated into WCAG 2.2 since WCAG 2.1 and changes made since its original publication on 05 October 2023. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
+    		<p>This section shows substantive changes incorporated into WCAG 2.2 since WCAG 2.1 and changes made to 2.2 since its original publication on 05 October 2023. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
     		<p>The full <a href="https://github.com/w3c/wcag/commits/main/guidelines">commit history to WCAG 2.2</a> is available.</p>
     		<ul>
     			<li>2020-03-30: Added <a href="#accessible-authentication-minimum">Accessible Authentication (Minimum)</a>.</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -783,23 +783,16 @@
       
     	<section class="appendix" id="changelog">
     		<h2>Change Log</h2>
-    		<p>This section shows substantive changes made in WCAG 2.2 since WCAG 2.1. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
+    		<p>This section shows substantive changes incorporated into WCAG 2.2 since WCAG 2.1 and changes made since its original publication on 05 October 2023. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
     		<p>The full <a href="https://github.com/w3c/wcag/commits/main/guidelines">commit history to WCAG 2.2</a> is available.</p>
     		<ul>
-    			<li>2019-11-10: Promoted <a href="#focus-visible">Focus Visible</a> from Level AA to Level A.</li>
-    			<li>2020-01-14: Added <q>Focus Visible (Enhanced)</q>, later renamed to Focus Appearance (Enhanced), later removed.</li>
-				<li>2020-03-10: Renamed <q>Pointer Target Spacing</q> to <q>Target Size (Minimum)</q></li>
     			<li>2020-03-30: Added <a href="#accessible-authentication-minimum">Accessible Authentication (Minimum)</a>.</li>
     			<li>2020-05-27: Added <q>Dragging</q> (later renamed <a href="#dragging-movements">Dragging Movements</a>).</li>
-    			<li>2020-07-19: Added <q>Findable Help</q> (later renamed to <a href="#consistent-help">Consistent Help</a>), <q>Fixed Reference Points</q> (Page Break Navigation), <q>Hidden Controls</q> (later renamed Visible Controls), <q>Pointer Target Spacing</q> (later renamed <a href="#target-size-minimum">Target Size (Minimum)</a>), <a href="#redundant-entry">Redundant Entry</a>.</li>
-    			<li>2020-08-04: Added Focus Appearance (Minimum) (later renamed to <a href="#focus-appearance">Focus Appearance</a>) and renamed <q>Focus Visible (Enhanced)</q> to <q>Focus Appearance (Enhanced)</q>.</li>
-    			<li>2020-11-02: Renamed <q>Dragging</q> to <a href="#dragging-movements">Dragging Movements</a>.</li>
-    			<li>2020-12-08: Renamed <q>Hidden Controls</q> to Visible Controls.</li>
-				<li>2021-09-21: Added <a href="#accessible-authentication-enhanced">Accessible Authentication (No Exception)</a>.</li>
+    			<li>2020-07-19: Added <q>Findable Help</q> (later renamed to <a href="#consistent-help">Consistent Help</a>), <q>Pointer Target Spacing</q> (later renamed <a href="#target-size-minimum">Target Size (Minimum)</a>), and <a href="#redundant-entry">Redundant Entry</a>.</li>
+    			<li>2020-08-04: Added Focus Appearance (Minimum) (later renamed to <a href="#focus-appearance">Focus Appearance</a>).</li>
+				<li>2021-09-21: Added <q>Accessible Authentication (No Exception)</q> (later renamed <a href="#accessible-authentication-enhanced">Accessible Authentication (Enhanced))</a>.</li>
 				<li>2022-03-22: Added <a href="#focus-not-obscured-minimum">Focus Not Obscured (Minimum)</a>.</li>
-				<li>2022-05-13: Removed Visible Controls.</li>
 				<li>2022-05-30: Added <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a>.</li>
-				<li>2022-07-15: Removed Page Break Navigation.</li>
 				<li>2023-06-05: Added privacy and security sections within conformance.</li>
     		</ul>
     	</section>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -783,7 +783,7 @@
       
     	<section class="appendix" id="changelog">
     		<h2>Change Log</h2>
-    		<p>This section shows substantive changes incorporated into WCAG 2.2 since WCAG 2.1 and changes made to 2.2 since its original publication on 05 October 2023. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
+    		<p>This section shows substantive changes incorporated into WCAG 2.2 since WCAG 2.1, as well as changes made to 2.2 since its original publication on 05 October 2023. <a href="https://www.w3.org/WAI/WCAG21/errata/">Errata fixes to WCAG 2.1</a> have also been incorporated into WCAG 2.2.</p>
     		<p>The full <a href="https://github.com/w3c/wcag/commits/main/guidelines">commit history to WCAG 2.2</a> is available.</p>
     		<ul>
     			<li>2020-03-30: Added <a href="#accessible-authentication-minimum">Accessible Authentication (Minimum)</a>.</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -802,7 +802,7 @@
                         <li>updated and corrected the <a href="#input-purposes">input purposes</a> list</li>
                         <li>modified the formatting of Target Size (Minimum) and Accessible Authentication (Minimum)</li>
                         <li>modified the visual presentation for content identified as New</li>
-                        <li>modified the language covering devices in the <a>Abstract</a></li>
+                        <li>modified the language covering devices in the <a href="#abstract">Abstract</a></li>
                         <li>made editorial changes to improve consistent use of definitions in the success criteria</li>
                         <li>made editorial changes to improve consistent use of the terms <q>success criteria/criterion</q>, <q>web</q>, <q>website</q>, and <q>web page</q></li>
                     </ul>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -797,7 +797,7 @@
                 <li>2024-11-15: Republished WCAG 2.2, incorporating the following errata:
                     <ul>
                         <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
-                        <li>modified the formatting of definitions for <a>changes of content</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>, and <a>structure</a></li>
+                        <li>modified the formatting of definitions for <a>changes of context</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>, and <a>structure</a></li>
                         <li>removed the defunct <q>encloses</q> definition</li>
                         <li>updated and corrected the <a>input purposes</a> list</li>
                         <li>modified the formatting of Target Size (Minimum) and Accessible Authentication (Minimum)</li>


### PR DESCRIPTION
Updated changelog to only record changes made that were preserved through WCAG 2.2's Oct 2023 publication.
Added normative errata to the change log incorporated into the republication
**NOTE** @iadawn, I took a guess on the actual republication date of Nov 15, which will need to be updated to match the real date.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/pull/4123.html" title="Last updated on Nov 1, 2024, 5:23 PM UTC (bc23f43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag/4123/b99ada8...bc23f43.html" title="Last updated on Nov 1, 2024, 5:23 PM UTC (bc23f43)">Diff</a>