### PR TITLE
Contrast minimum: Address the active (pressed) state

### DIFF
--- a/understanding/20/contrast-minimum.html
+++ b/understanding/20/contrast-minimum.html
@@ -119,7 +119,9 @@
       <p>This Success Criterion applies to text in the page, including
          placeholder text and text that is shown when a pointer is hovering over an object
          or when an object has keyboard focus. If any of these are used in a page, the text
-         needs to provide sufficient contrast.
+         needs to provide sufficient contrast. The active state (the typically split-second
+         state when a button or control is being clicked or pressed) is not explicitly
+         required to meet the contrast requirement.
       </p>
       
       <p>Although this Success Criterion only applies to text, similar issues occur for content presented


### PR DESCRIPTION
From #157: the active state (the typically split-second state when a button or control is being clicked or pressed) is not explicitly required to meet the contrast requirement.

This question comes up from time to time. The answer to this is provided in #157 but you have to dig to find it. Hopefully this change will make it easier to find the answer.