### PR TITLE
Generate guidelines during Netlify PR preview builds

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Push to gh-pages branch
 
 # Reference documentation: https://docs.github.com/en/actions/reference
 

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,0 @@
-{
-    "src_file": "guidelines/index.html",
-    "type": "respec"
-}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 ---js
 // Same condition used for copying guidelines assets in eleventy.config.ts
 const includeGuidelines = process.env.COMMIT_REF && !process.env.WCAG_MODE;
+const repoUrl = process.env.REPOSITORY_URL;
+const prNumber = process.env.REVIEW_ID;
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -10,6 +12,12 @@ const includeGuidelines = process.env.COMMIT_REF && !process.env.WCAG_MODE;
 	</head>
 	<body>
 		<h1>Web Content Accessibility Guidelines {{ versionDecimal }}</h1>
+    {% if repoUrl and prNumber -%}
+    <p>
+      <strong>Note:</strong> This is a <strong>preview</strong> for
+      <a href="{{ repoUrl }}/pull/{{ prNumber }}">PR #{{ prNumber }}</a>.
+    </p>
+    {%- endif %}
 		<ul>
       {% if includeGuidelines -%}
         <li><a href="guidelines/">Guidelines</a></li>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,7 @@
+---js
+// Same condition used for copying guidelines assets in eleventy.config.ts
+const includeGuidelines = process.env.COMMIT_REF && !process.env.WCAG_MODE;
+---
 <!DOCTYPE html>
 <html lang="en">
 	<head>
@@ -7,6 +11,9 @@
 	<body>
 		<h1>Web Content Accessibility Guidelines {{ versionDecimal }}</h1>
 		<ul>
+      {% if includeGuidelines -%}
+        <li><a href="guidelines/">Guidelines</a></li>
+      {%- endif %}
 			<li><a href="techniques/">Techniques</a></li>
 			<li><a href="understanding/">Understanding Docs</a></li>
 		</ul>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "W3C",
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
+    "axios": "^1.7.7",
     "cheerio": "^1.0.0",
     "glob": "^10.3.16",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
This effectively replaces what the pr-preview bot currently does (and what #2220 sought to do within the repo). The problem with the pr-preview bot is its previews don't fully work (e.g. as seen in #4123).

## Changes

- Remove `.pr-preview.json` to stop pr-preview bot from running
- Add logic to `eleventy.config.ts` to copy `guidelines` folder assets and run through spec-generator (the same thing we use for GH Pages builds; also the same thing used by the pr-preview bot, IIUC) when running a standard build through netlify
- Conditionally add guidelines list item to top-level `index.html` (which is only used for local dev and PR builds)
- Tangentially, rename our github-pages push workflow to be more distinguishable in the Actions tab