### PR TITLE
Update 11ty-publish workflow to use git-auto-commit-action

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -36,10 +36,13 @@ jobs:
           curl https://labs.w3.org/spec-generator/?type=respec"&"url=https://raw.githack.com/$GITHUB_REPOSITORY/main/requirements/22/index.html -o _site/requirements/22/index.html -f  --retry 3
           curl https://labs.w3.org/spec-generator/?type=respec"&"url=https://raw.githack.com/$GITHUB_REPOSITORY/main/conformance-challenges/index.html -o _site/conformance-challenges/index.html -f  --retry 3
       - name: Push
-        working-directory: _site
-        run: |
-          git config user.email 87540780+w3cgruntbot@users.noreply.github.com
-          git config user.name w3cgruntbot
-          git add -A .
-          git commit -m ":robot: Deploy to GitHub Pages: $GITHUB_SHA from branch $GITHUB_REF"
-          git push origin gh-pages
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          repository: _site
+          branch: gh-pages
+          commit_user_name: w3cgruntbot
+          commit_user_email: 87540780+w3cgruntbot@users.noreply.github.com
+          commit_author: "w3cgruntbot <87540780+w3cgruntbot@users.noreply.github.com>"
+          commit_message: ":robot: Deploy to GitHub Pages: ${{ github.sha }} from branch ${{ github.ref }}"
+          skip_fetch: true
+          skip_checkout: true


### PR DESCRIPTION
This update resolves spurious errors in the publish workflow in cases where a merge to `main` results in no changes to push to `gh-pages`.

- [Example of the type of error this addresses](https://github.com/kfranqueiro/wcag/actions/runs/12036136821/job/33556666057)
- [Example of the same type of run succeeding with this change](https://github.com/kfranqueiro/wcag/actions/runs/12036196134/job/33556861412)
- [Example of a run completing with this change, operating as usual when there are changes to commit to `gh-pages`](https://github.com/kfranqueiro/wcag/actions/runs/12036639462/job/33558323786)
  - [Commit from this example](https://github.com/kfranqueiro/wcag/commit/56e7ecc2330a27e74b66885690789545202c1c86)