### PR TITLE
Pin definitions when building an older version

### DIFF
--- a/11ty/types.ts
+++ b/11ty/types.ts
@@ -9,7 +9,7 @@ interface EleventyPage {
   outputPath: string;
   rawInput: string;
   templateSyntax: string;
-  url: string;
+  url: string | false; // (false when permalink is set to false for the page)
 }
 
 interface EleventyDirectories {

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -14,6 +14,7 @@ import {
   getFlatGuidelines,
   getPrinciples,
   getPrinciplesForVersion,
+  getTermsMap,
   scSlugOverrides,
   type FlatGuidelinesMap,
   type Guideline,
@@ -102,6 +103,8 @@ for (const [technology, list] of Object.entries(techniques)) {
 
 const understandingDocs = await getUnderstandingDocs(version);
 const understandingNav = await generateUnderstandingNavMap(principles, understandingDocs);
+
+const termsMap = process.env.WCAG_VERSION ? await getTermsMap(version) : await getTermsMap();
 
 // Declare static global data up-front so we can build typings from it
 const globalData = {
@@ -274,6 +277,7 @@ export default function (eleventyConfig: any) {
       root: ["_includes", "."],
       jsTruthy: true,
       strictFilters: true,
+      termsMap,
     })
   );
 


### PR DESCRIPTION
This is a follow-up to #4007, in which I had neglected to pin definitions for key terms to the published recommendation when building for 2.1.

- Moves `termsMap` definition to the Eleventy config (where all other target-version-dependent assignments are made), to be passed into the `CustomLiquid` constructor
- Updates `termsMap` references within `CustomLiquid` to use an instance variable set in the constructor
- Updates `loadRemoteGuidelines` to account for pre-processed terms content
  - Also updates to account for #4124
- Skips entirety of custom `render` processing for pages not being output for 2.1 (to avoid irrelevant error messages as well as save time)