### PR TITLE
Tolerate specref API failures during local dev

### DIFF
--- a/11ty/common.ts
+++ b/11ty/common.ts
@@ -1,5 +1,7 @@
 /** @fileoverview Common functions used by multiple parts of the build process */
 
+import { AxiosError, type AxiosResponse } from "axios";
+
 import type { Guideline, Principle, SuccessCriterion } from "./guidelines";
 
 /** Generates an ID for heading permalinks. Equivalent to wcag:generate-id in base.xslt. */
@@ -28,3 +30,23 @@ export function wcagSort(
   }
   return 0;
 }
+
+/**
+ * Handles HTTP error responses from Axios requests in local dev;
+ * re-throws error during builds to fail loudly.
+ * This should only be used for non-critical requests that can tolerate null data
+ * without major side effects.
+ */
+export const wrapAxiosRequest = <T, D>(promise: Promise<AxiosResponse<T, D>>) =>
+  promise.catch((error) => {
+    if (!(error instanceof AxiosError) || !error.response || !error.request) throw error;
+    const { response, request } = error;
+    console.warn(
+      `AxiosError: status ${response.status} received from ${
+        request.protocol + "//" + request.host
+      }${request.path || ""}`
+    );
+
+    if (process.env.ELEVENTY_RUN_MODE === "build") throw error;
+    else return { data: null };
+  });


### PR DESCRIPTION
Since #4124 was merged, all builds require an HTTP request to api.specref.org in order to resolve additional bibliographical references. This may cause issues in local dev in the case of being offline due to travel or internet hiccups, behind a proxy, etc.

This commit adds a reusable function for cases where a HTTP failure during local dev is tolerable, and uses it for the bibrefs request.

After this change, a HTTP failure on this request would look something like this, and the dev server will continue running rather than crashing with a stack trace:

`AxiosError: status 403 received from https://api.specref.org/bibrefs?refs=WCAG21,WCAG20,WAI-WEBCONTENT,RFC2119,HTML,css3-values,SRGB,UAAG10,LAALS,HEARING-AID-INT,ISO-9241-3,ANSI-HFES-100-1988,ARDITI-FAYE,ARDITI-KNOBLAUCH-1994,ARDITI-KNOBLAUCH-1996,ARDITI,GITTINGS-FOZARD,pointerevents`

Running `npm build` will still result in an immediate failure and stack trace; this is intentional to ensure that nothing slips by during builds for PR previews, GitHub Pages, or w3.org.