### PR TITLE
Add errata to w3c/wcag repo and cross-reference from informative docs

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,4 +1,5 @@
 *.md
+**/README.md
 11ty/
 acknowledgements.html
 acknowledgements/

--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -468,10 +468,15 @@ export class CustomLiquid extends Liquid {
           });
           for (const name of termNames) {
             const term = this.termsMap[name]; // Already verified existence in the earlier loop
-            $termsList.append(
-              `<dt id="${term.id}">${term.name}</dt>` +
-                `<dd><definition>${term.definition}</definition></dd>`
-            );
+            let termBody = term.definition;
+            if (scope.errata[term.id]) {
+              termBody += `
+                <p><strong>Errata:</strong></p>
+                <ul>${scope.errata[term.id].map((erratum) => `<li>${erratum}</li>`)}</ul>
+                <p><a href="https://www.w3.org/WAI/WCAG${scope.version}/errata/">View all errata</a></p>
+              `;
+            }
+            $termsList.append(`<dt id="${term.id}">${term.name}</dt><dd>${termBody}</dd>`);
           }
 
           // Iterate over non-href links once more in now-expanded document to add hrefs

--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -92,9 +92,36 @@ export class CustomLiquid extends Liquid {
     super(options);
     this.termsMap = options.termsMap;
   }
+
+  private renderErrata(html: string) {
+    const $ = load(html);
+
+    const $tocList = $("#contents .toc");
+    let $childList: CheerioAnyNode | null = null;
+    $("main section[id]:has(h2:first-child, h3:first-child)").each((_, el) => {
+      const $el = $(el);
+      // Only one of the following queries will match for each section
+      $el.find("> h2:first-child").each((_, h2El) => {
+        $childList = null;
+        $tocList.append(`<li><a href="#${el.attribs.id}">${$(h2El).text()}</a></li>`);
+      });
+      $el.find("> h3:first-child").each((_, h3El) => {
+        if (!$childList) $childList = $(`<ol class="toc"></ol>`).appendTo($tocList);
+        $childList.append(`<li><a href="#${el.attribs.id}">${$(h3El).text()}</a></li>`);
+      });
+    });
+
+    return $.html();
+  }
+
   public parse(html: string, filepath?: string) {
     // Filter out Liquid calls for computed data and includes themselves
-    if (filepath && !filepath.includes("_includes/") && isHtmlFileContent(html)) {
+    if (
+      filepath &&
+      !filepath.includes("_includes/") &&
+      !filepath.includes("errata/") &&
+      isHtmlFileContent(html)
+    ) {
       const isIndex = indexPattern.test(filepath);
       const isTechniques = techniquesPattern.test(filepath);
       const isUnderstanding = understandingPattern.test(filepath);
@@ -309,6 +336,7 @@ export class CustomLiquid extends Liquid {
     // html contains markup after Liquid tags/includes have been processed
     const html = (await super.render(templates, scope, options)).toString();
     if (!isHtmlFileContent(html) || !scope || scope.page.url === false) return html;
+    if (scope.page.inputPath.includes("errata/")) return this.renderErrata(html);
 
     const $ = load(html);
 

--- a/11ty/cp-cvs.ts
+++ b/11ty/cp-cvs.ts
@@ -51,3 +51,9 @@ for (const [srcDir, destDir] of Object.entries(dirs)) {
     await copyFile(srcPath, destPath);
   }
 }
+
+await mkdirp(join(wcagBase, "errata"));
+await copyFile(
+  join(outputBase, "errata", `${wcagVersion}.html`),
+  join(wcagBase, "errata", "Overview.html")
+);

--- a/11ty/guidelines.ts
+++ b/11ty/guidelines.ts
@@ -310,7 +310,7 @@ export const getErrataForVersion = async (version: WcagVersion) => {
   const errata: Record<string, string[]> = {};
 
   $("main > section[id]")
-    .last()
+    .first()
     .find(`li:has(${aSelector})`)
     .each((_, el) => {
       const $el = $(el);

--- a/README.md
+++ b/README.md
@@ -240,6 +240,14 @@ To create a working example:
 * Reference working examples from techniques using the rawgit URI to the example in its development branch, e.g., `https://rawgit.com/w3c/wcag/main/working-examples/alt-attribute/`. Editors will update links when examples are approved.
 * When the example is complete and functional, submit a pull request into the main branch.
 
+## Errata
+
+The errata documents for WCAG 2.1 and 2.2 are now maintained in this repository.
+See the [Errata README](errata/README.md) for authoring details.
+
+**Note:** The errata for both versions are maintained on the `main` branch for use in builds.
+Direct edits to the guidelines for WCAG 2.1 must be performed under `guidelines/` on the `WCAG-2.1` branch.
+
 ## Translations
 
 WCAG 2.2 is ready for translation. To translate WCAG 2.2, follow instructions at [How to Translate WCAG 2](https://www.w3.org/WAI/about/translating/wcag/).

--- a/_includes/understanding/about.html
+++ b/_includes/understanding/about.html
@@ -1,9 +1,18 @@
-{%- if guideline.type == "SC" -%}
-  {% sectionbox "success-criterion" "Success Criterion (SC)" -%}
-    {{ guideline.content }}
-  {%- endsectionbox %}
-{%- elsif guideline.type == "Guideline" -%}
-  {% sectionbox "guideline" "Guideline" -%}
-    {{ guideline.content }}
-  {%- endsectionbox %}
-{%- endif -%}
+{%- capture section_id -%}
+  {%- if guideline.type == "SC" -%}success-criterion{%- else -%}guideline{%- endif -%}
+{%- endcapture -%}
+{%- capture section_title -%}
+  {%- if guideline.type == "SC" -%}Success Criterion (SC){%- else -%}Guideline{%- endif -%}
+{%- endcapture -%}
+{% sectionbox section_id section_title -%}
+  {{ guideline.content }}
+  {%- if errata[guideline.id] %}
+    <h3>Errata</h3>
+    <ul>
+      {%- for erratum in errata[guideline.id] %}
+        <li>{{ erratum }}</li>
+      {%- endfor -%}
+    </ul>
+    <p><a href="https://www.w3.org/WAI/WCAG{{ version }}/errata/">View all errata</a></p>
+  {% endif -%}
+{%- endsectionbox %}

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -385,6 +385,19 @@ export default function (eleventyConfig: any) {
     }
   );
 
+  // Renders a link to a GitHub commit or pull request, in parentheses
+  eleventyConfig.addShortcode("gh", (id: string) => {
+    if (/^#\d+$/.test(id)) {
+      const num = id.slice(1);
+      return `<a href="https://github.com/${GH_ORG}/${GH_REPO}/pull/${num}" aria-label="pull request ${num}">${id}</a>`
+    }
+    else if (/^[0-9a-f]{7,}$/.test(id)) {
+      const sha = id.slice(0, 7); // Truncate in case full SHA was passed
+      return `<a href="https://github.com/${GH_ORG}/${GH_REPO}/commit/${sha}" aria-label="commit ${sha}">${sha}</a>`
+    }
+    else throw new Error(`Invalid SHA or PR ID passed to gh tag: ${id}`);
+  });
+
   // Renders a section box (used for About this Technique and Guideline / SC)
   eleventyConfig.addPairedShortcode(
     "sectionbox",

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -11,6 +11,7 @@ import { resolveDecimalVersion } from "11ty/common";
 import {
   actRules,
   assertIsWcagVersion,
+  getErrataForVersion,
   getFlatGuidelines,
   getPrinciples,
   getPrinciplesForVersion,
@@ -110,6 +111,7 @@ const termsMap = process.env.WCAG_VERSION ? await getTermsMap(version) : await g
 const globalData = {
   version,
   versionDecimal: resolveDecimalVersion(version),
+  errata: process.env.WCAG_VERSION ? await getErrataForVersion(version) : {},
   techniques, // Used for techniques/index.html
   technologies, // Used for techniques/index.html
   technologyTitles, // Used for techniques/index.html

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -385,7 +385,7 @@ export default function (eleventyConfig: any) {
     }
   );
 
-  // Renders a link to a GitHub commit or pull request, in parentheses
+  // Renders a link to a GitHub commit or pull request
   eleventyConfig.addShortcode("gh", (id: string) => {
     if (/^#\d+$/.test(id)) {
       const num = id.slice(1);

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -279,6 +279,7 @@ export default function (eleventyConfig: any) {
       root: ["_includes", "."],
       jsTruthy: true,
       strictFilters: true,
+      timezoneOffset: 0, // Avoid off-by-one YYYY-MM-DD date stamp conversions
       termsMap,
     })
   );

--- a/errata/21.html
+++ b/errata/21.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Web Content Accessibility Guidelines (WCAG) 2.1 Errata</title>
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/base.css" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+<body>
+  <div class="head">
+    <p><a href="https://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72" /></a></p>
+    <h1 id="title">Web Content Accessibility Guidelines (WCAG) 2.1 Errata</h1>
+    <p>Last modified: $Date: 2024/02/01 14:32:47 $</p>
+    <p class="copyright">Copyright © 2024 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#disclaimers">liability</a>, <a href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules apply.</p>
+  </div>
+  <hr/>
+  <section id="abstract">
+    <h2>Abstract</h2>
+    <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a> specification.</p>
+    <p>The errata are numbered, classified as <a href="#substantive">Substantive</a> or <a href="#editorial">Editorial</a>, and listed in reverse chronological order of their date of publication in each category. </p>
+    <p>Each entry has the following information:</p>
+    <ul>
+      <li>A unique entry number</li>
+      <li>The date it was added to the errata page.</li>
+      <li>The section referred to.</li>
+      <li>A description of the problem and correction if applicable.</li>
+      <li>A rationale for making the change (not required for editorial errata).</li>
+    </ul>
+    <p>Substantive corrections are proposed by the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a>, which has consensus that they are appropriate; they are not to be considered normative until a new Recommendation is published following the <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">process to revise a Recommendation</a>.</p>
+    <p>Please view the <a href="/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly  available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
+  </section>
+  <section id="contents">
+    <h2>Table of Contents</h2>
+    <ol class="toc">
+      <li><a href="#substantive">Substantive Errata</a></li>
+      <li><a href="#editorial">Editorial Errata</a></li>
+    </ol>
+  </section>
+  <hr/>
+  <main>
+    <section id="substantive">
+      <h2>Substantive Errata</h2>
+      <p>No substantive errata have been recorded at present.</p>
+    </section>
+    <section id="editorial">
+      <h2>Editorial Errata</h2>
+      <ul>
+        <li>In the <a href="https://www.w3.org/TR/WCAG21/#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
+        <li>In the <a href="https://www.w3.org/TR/WCAG21/#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
+        <li>In the <a href="https://www.w3.org/TR/WCAG21/#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
+        <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
+        <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-technologies">technology</a>, the third note should instead be an example.</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
+        <li>In the <a href="https://www.w3.org/TR/WCAG21/#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
+        <li>In <a href="https://www.w3.org/TR/WCAG21/#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/errata/21.html
+++ b/errata/21.html
@@ -16,50 +16,66 @@
   <section id="abstract">
     <h2>Abstract</h2>
     <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a> specification.</p>
-    <p>The errata are numbered, classified as <a href="#substantive">Substantive</a> or <a href="#editorial">Editorial</a>, and listed in reverse chronological order of their date of publication in each category. </p>
+    <p>The errata are classified as Substantive or Editorial, and listed in chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
-      <li>A unique entry number</li>
-      <li>The date it was added to the errata page.</li>
       <li>The section referred to.</li>
       <li>A description of the problem and correction if applicable.</li>
       <li>A rationale for making the change (not required for editorial errata).</li>
     </ul>
     <p>Substantive corrections are proposed by the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a>, which has consensus that they are appropriate; they are not to be considered normative until a new Recommendation is published following the <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">process to revise a Recommendation</a>.</p>
-    <p>Please view the <a href="/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly  available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
+    <p>Please view the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly  available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
   </section>
   <section id="contents">
     <h2>Table of Contents</h2>
     <ol class="toc">
-      <li><a href="#substantive">Substantive Errata</a></li>
-      <li><a href="#editorial">Editorial Errata</a></li>
+      {%- # Leave this empty - populated during the build process -%}
     </ol>
   </section>
   <hr/>
   <main>
-    <section id="substantive">
-      <h2>Substantive Errata</h2>
-      <p>No substantive errata have been recorded at present.</p>
+    {%- assign trDate = "2018-06-05" -%}
+    {%- capture trUrl -%}https://www.w3.org/TR/2018/REC-WCAG21-{{ trDate | replace: "-", "" }}/{%- endcapture -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata have been recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <ul>
+          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
+          <li>In the <a href="{{ trUrl }}#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
+          <li>In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
+          <li>In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
+          <li>In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
+          <li>In <a href="{{ trUrl }}#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
+          <li>In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
+          <li>In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
+          <li>In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
+          <li>In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, the third note should instead be an example.</li>
+          <li>In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
+          <li>In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
+          <li>In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
+          <li>In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
+          <li>In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
+        </ul>
+      </section>
     </section>
-    <section id="editorial">
-      <h2>Editorial Errata</h2>
-      <ul>
-        <li>In the <a href="https://www.w3.org/TR/WCAG21/#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
-        <li>In the <a href="https://www.w3.org/TR/WCAG21/#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
-        <li>In the <a href="https://www.w3.org/TR/WCAG21/#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
-        <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
-        <li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-technologies">technology</a>, the third note should instead be an example.</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
-        <li>In the <a href="https://www.w3.org/TR/WCAG21/#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
-        <li>In <a href="https://www.w3.org/TR/WCAG21/#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
-      </ul>
+
+    {%- assign trDate = "current" -%}
+    {%- assign trUrl = "https://www.w3.org/TR/WCAG21/" -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">Current Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata have been recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <p>No editorial errata have been recorded at present.</p>
+      </section>
     </section>
   </main>
 </body>

--- a/errata/21.html
+++ b/errata/21.html
@@ -65,21 +65,91 @@
       <section id="editorial-{{ trDate }}">
         <h3>Editorial Errata</h3>
         <ul>
-          <li>2023-04-18: In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a>, removing one note and adding two new notes, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
-          <li>2022-02-02: In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, updating "Conformance Criterion" references to "Conformance Requirement".</li>
-          <li>2022-02-22: In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, updating the red threshold from 0.03928 to 0.04045.</li>
-          <li>2019-05-09: In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, clarifying the note referencing "binary display orientation" to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, correcting the word "dismissable" to "dismissible".</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#robust">4. Robust</a>, removing repetition of the word "by".</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, removing "New" from the beginning of the third note.</li>
-          <li>2018-07-11: In the <a href="{{ trUrl }}#intro">Introduction</a>, correcting several (but not all) "WCAG 2.0" references to "WCAG 2.1".</li>
-          <li>2018-07-11: In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, correcting the words "critera" and "ccriteria" to "criteria".</li>
-          <li>2018-07-11: In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, removing a supernumary "Note" indicator from the first note.</li>
-          <li>2018-07-11: In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> removing the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec."</li>
-          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, updating the second (of three) notes to be an example of the first note, leaving only two actual notes.</li>
-          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, updating the third note to instead be an example.</li>
-          <li>2018-06-08: In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, correcting the word "county" to "country".</li>
-          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> removing the first instance of the repeated paragraph beginning "This document has been reviewed by W3C Members...".</li>
+          <li>
+            2023-04-18:
+            In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a>,
+            removing one note and adding two new notes, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."
+            ({% gh "#3152" %})
+          </li>
+          <li>
+            2022-02-22:
+            In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>,
+            updating the red threshold from 0.03928 to 0.04045.
+            ({% gh "#1780" %})
+          </li>
+          <li>
+            2022-02-02:
+            In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>,
+            updating "Conformance Criterion" references to "Conformance Requirement".
+            ({% gh "#1777" %})
+          </li>
+          <li>
+            2019-05-09:
+            In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>,
+            clarifying the note referencing "binary display orientation" to read "content is not necessarily restricted to landscape or portrait display orientation".
+            ({% gh "#724" %})
+          </li>
+          <li>
+            2018-08-06:
+            In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>,
+            correcting the word "dismissable" to "dismissible".
+            ({% gh "b043430" %})
+          </li>
+          <li>
+            2018-08-06:
+            In <a href="{{ trUrl }}#robust">4. Robust</a>, removing repetition of the word "by".
+            ({% gh "6f883b5" %})
+          </li>
+          <li>
+            2018-08-06:
+            In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, removing "New" from the beginning of the third note.
+            ({% gh "5d42e28" %})
+          </li>
+          <li>
+            2018-07-11:
+            In the <a href="{{ trUrl }}#intro">Introduction</a>,
+            correcting several (but not all) "WCAG 2.0" references to "WCAG 2.1".
+            ({% gh "#430" %}, {% gh "#426" %}, {% gh "170c48a" %})
+          </li>
+          <li>
+            2018-07-11:
+            In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>,
+            removing a supernumary "Note" indicator from the first note.
+            ({% gh "#429" %})
+          </li>
+          <li>
+            2018-07-11:
+            In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>,
+            updating the second (of three) notes to be an example of the first note, leaving only two actual notes.
+            ({% gh "#428" %})
+          </li>
+          <li>
+            2018-07-11:
+            In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>,
+            updating the third note to instead be an example.
+            ({% gh "#428" %})
+          </li>
+          <li>
+            2018-07-11:
+            In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a>,
+            removing the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec."
+            ({% gh "#427" %})
+          </li>
+          <li>
+            2018-07-11:
+            In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>,
+            correcting the words "critera" and "ccriteria" to "criteria".
+            ({% gh "#426" %})
+          </li>
+          <li>
+            2018-06-08:
+            In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>,
+            correcting the word "county" to "country".
+            ({% gh "426e131" %})
+          </li>
+          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a>,
+            removing the first instance of the repeated paragraph beginning "This document has been reviewed by W3C Members...".
+          </li>
         </ul>
       </section>
     </section>

--- a/errata/21.html
+++ b/errata/21.html
@@ -19,6 +19,7 @@
     <p>The errata are classified as Substantive or Editorial, and listed in chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
+      <li>The date it was added to the errata page.</li>
       <li>The section referred to.</li>
       <li>A description of the problem and correction if applicable.</li>
       <li>A rationale for making the change (not required for editorial errata).</li>
@@ -46,20 +47,20 @@
         <h3>Editorial Errata</h3>
         <ul>
           <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
-          <li>In the <a href="{{ trUrl }}#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
-          <li>In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
-          <li>In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
-          <li>In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
-          <li>In <a href="{{ trUrl }}#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
-          <li>In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
-          <li>In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
-          <li>In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
-          <li>In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, the third note should instead be an example.</li>
-          <li>In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
-          <li>In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
-          <li>In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
-          <li>In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
-          <li>In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
+          <li>2018-07-11: In the <a href="{{ trUrl }}#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
+          <li>2018-07-11: In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
+          <li>2018-07-11: In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
+          <li>2018-07-11: In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
+          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
+          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, the third note should instead be an example.</li>
+          <li>2018-06-08: In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
+          <li>2019-05-09: In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
+          <li>2022-02-02: In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
+          <li>2022-02-22: In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
+          <li>2023-04-18: In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
         </ul>
       </section>
     </section>

--- a/errata/21.html
+++ b/errata/21.html
@@ -18,7 +18,7 @@
   <section id="abstract">
     <h2>Abstract</h2>
     <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a> specification.</p>
-    <p>The errata are classified as Substantive or Editorial, and listed in reverse chronological order based on the date of publication to which they are applicable.</p>
+    <p>The errata are classified as Substantive or Editorial, as classified by the W3C <a href="https://www.w3.org/policies/process/20231103/#correction-classes">Classes of Changes</a>, and listed in reverse chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
       <li>The date it was added to the errata page.</li>
@@ -65,21 +65,21 @@
       <section id="editorial-{{ trDate }}">
         <h3>Editorial Errata</h3>
         <ul>
-          <li>2023-04-18: In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
-          <li>2022-02-02: In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
-          <li>2022-02-22: In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
-          <li>2019-05-09: In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
-          <li>2018-07-11: In the <a href="{{ trUrl }}#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
-          <li>2018-07-11: In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
-          <li>2018-07-11: In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
-          <li>2018-07-11: In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
-          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
-          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, the third note should instead be an example.</li>
-          <li>2018-06-08: In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
-          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
+          <li>2023-04-18: In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a>, removing one note and adding two new notes, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
+          <li>2022-02-02: In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, updating "Conformance Criterion" references to "Conformance Requirement".</li>
+          <li>2022-02-22: In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, updating the red threshold from 0.03928 to 0.04045.</li>
+          <li>2019-05-09: In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, clarifying the note referencing "binary display orientation" to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, correcting the word "dismissable" to "dismissible".</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#robust">4. Robust</a>, removing repetition of the word "by".</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, removing "New" from the beginning of the third note.</li>
+          <li>2018-07-11: In the <a href="{{ trUrl }}#intro">Introduction</a>, correcting several (but not all) "WCAG 2.0" references to "WCAG 2.1".</li>
+          <li>2018-07-11: In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, correcting the words "critera" and "ccriteria" to "criteria".</li>
+          <li>2018-07-11: In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, removing a supernumary "Note" indicator from the first note.</li>
+          <li>2018-07-11: In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> removing the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec."</li>
+          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, updating the second (of three) notes to be an example of the first note, leaving only two actual notes.</li>
+          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, updating the third note to instead be an example.</li>
+          <li>2018-06-08: In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, correcting the word "county" to "country".</li>
+          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> removing the first instance of the repeated paragraph beginning "This document has been reviewed by W3C Members...".</li>
         </ul>
       </section>
     </section>

--- a/errata/21.html
+++ b/errata/21.html
@@ -54,7 +54,7 @@
     
     {%- assign trDate = "2018-06-05" -%}
     {%- capture trUrl -%}
-      https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG21-{{ trDate | replace: "-", "" }}/
+      https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG{{ page.fileSlug }}-{{ trDate | replace: "-", "" }}/
     {%- endcapture -%}
     <section id="since-{{ trDate }}">
       <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>

--- a/errata/21.html
+++ b/errata/21.html
@@ -1,3 +1,5 @@
+{%- # PLEASE READ errata/README.md BEFORE EDITING -%}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,7 +18,7 @@
   <section id="abstract">
     <h2>Abstract</h2>
     <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a> specification.</p>
-    <p>The errata are classified as Substantive or Editorial, and listed in chronological order based on the date of publication to which they are applicable.</p>
+    <p>The errata are classified as Substantive or Editorial, and listed in reverse chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
       <li>The date it was added to the errata page.</li>
@@ -26,6 +28,7 @@
     </ul>
     <p>Substantive corrections are proposed by the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a>, which has consensus that they are appropriate; they are not to be considered normative until a new Recommendation is published following the <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">process to revise a Recommendation</a>.</p>
     <p>Please view the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly  available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
+    <p>The <a href="https://github.com/w3c/wcag/commits/WCAG-2.1/guidelines">full commit history</a> can be viewed on GitHub.</p>
   </section>
   <section id="contents">
     <h2>Table of Contents</h2>
@@ -35,36 +38,6 @@
   </section>
   <hr/>
   <main>
-    {%- assign trDate = "2018-06-05" -%}
-    {%- capture trUrl -%}https://www.w3.org/TR/2018/REC-WCAG21-{{ trDate | replace: "-", "" }}/{%- endcapture -%}
-    <section id="since-{{ trDate }}">
-      <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
-      <section id="substantive-{{ trDate }}">
-        <h3>Substantive Errata</h3>
-        <p>No substantive errata have been recorded at present.</p>
-      </section>
-      <section id="editorial-{{ trDate }}">
-        <h3>Editorial Errata</h3>
-        <ul>
-          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
-          <li>2018-07-11: In the <a href="{{ trUrl }}#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
-          <li>2018-07-11: In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
-          <li>2018-07-11: In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
-          <li>2018-08-06: In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
-          <li>2018-07-11: In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
-          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
-          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, the third note should instead be an example.</li>
-          <li>2018-06-08: In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
-          <li>2019-05-09: In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
-          <li>2022-02-02: In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
-          <li>2022-02-22: In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
-          <li>2023-04-18: In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
-        </ul>
-      </section>
-    </section>
-
     {%- assign trDate = "current" -%}
     {%- assign trUrl = "https://www.w3.org/TR/WCAG21/" -%}
     <section id="since-{{ trDate }}">
@@ -76,6 +49,38 @@
       <section id="editorial-{{ trDate }}">
         <h3>Editorial Errata</h3>
         <p>No editorial errata have been recorded at present.</p>
+      </section>
+    </section>
+    
+    {%- assign trDate = "2018-06-05" -%}
+    {%- capture trUrl -%}
+      https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG21-{{ trDate | replace: "-", "" }}/
+    {%- endcapture -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata have been recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <ul>
+          <li>2023-04-18: In <a href="{{ trUrl }}#parsing">4.1.1 Parsing</a> one note should be  deleted, and two notes added, including: "This Success Criterion should be considered as always satisfied for any content using HTML or XML."</li>
+          <li>2022-02-02: In <a href="{{ trUrl }}#issue-container-generatedID-43">a note in the definition of accessibility supported</a>, references to "Conformance Criterion" were changed to "Conformance Requirement".</li>
+          <li>2022-02-22: In the <a href="{{ trUrl }}#dfn-relative-luminance">definition of relative luminance</a>, the red threshold was updated from 0.03928 to 0.04045.</li>
+          <li>2019-05-09: In <a href="{{ trUrl }}#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" should be "dismissible".</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#robust">4. Robust</a>, the word "by" is repeated but should be present only once.</li>
+          <li>2018-08-06: In <a href="{{ trUrl }}#cc2">5.2.2 Full pages</a>, the third note began with "New" which should be removed.</li>
+          <li>2018-07-11: In the <a href="{{ trUrl }}#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" should be "WCAG 2.1".</li>
+          <li>2018-07-11: In the <a href="{{ trUrl }}#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" should be "criteria".</li>
+          <li>2018-07-11: In <a href="{{ trUrl }}#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which should be removed.</li>
+          <li>2018-07-11: In <a href="{{ trUrl }}#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." should be removed.</li>
+          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note should be an example of the first note, leaving only two actual notes.</li>
+          <li>2018-07-11: In the definition for <a href="{{ trUrl }}#dfn-technologies">technology</a>, the third note should instead be an example.</li>
+          <li>2018-06-08: In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" should be "country".</li>
+          <li>In the <a href="{{ trUrl }}#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph should be removed.</li>
+        </ul>
       </section>
     </section>
   </main>

--- a/errata/22.html
+++ b/errata/22.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Web Content Accessibility Guidelines (WCAG) 2.2 Errata</title>
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/base.css" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+<body>
+  <div class="head">
+    <p><a href="https://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72" /></a></p>
+    <h1 id="title">Web Content Accessibility Guidelines (WCAG) 2.2 Errata</h1>
+    <p>Last modified: $Date: 2023/07/21 18:31:26 $</p>
+    <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). <abbr title="World Wide Web Consortium">W3C</abbr><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents" rel="license">document use</a> rules apply. </p>
+  </div>
+  <hr />
+  <section id="abstract">
+    <h2>Abstract</h2>
+    <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a> specification.</p>
+    <p>The errata are numbered, classified as <a href="#substantive">Substantive</a> or <a href="#editorial">Editorial</a>, and listed in reverse chronological order of their date of publication in each category. </p>
+    <p>Each entry has the following information:</p>
+    <ul>
+      <li>A unique entry number</li>
+      <li>The date it was added to the errata page.</li>
+      <li>The section referred to.</li>
+      <li>A description of the problem and correction if applicable.</li>
+      <li>A rationale for making the change (not required for editorial errata).</li>
+    </ul>
+    <p>Substantive corrections are proposed by the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a>, which has consensus that they are appropriate; they are not to be considered normative until a new Recommendation is published following the <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">process to revise a Recommendation</a>.</p>
+    <p>Please view the <a href="/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
+  </section>
+  <section id="contents">
+    <h2>Table of Contents</h2>
+    <ol class="toc">
+      <li><a href="#substantive">Substantive Errata</a></li>
+      <li><a href="#editorial">Editorial Errata</a></li>
+    </ol>
+  </section>
+  <hr />
+  <main>
+    <section id="substantive">
+      <h2>Substantive Errata</h2>
+      <p>No substantive errata recorded at present.</p>
+    </section>
+    <section id="editorial">
+      <h2>Editorial Errata</h2>
+    </section>
+    <p>No editorial errata recorded at present.</p>
+  </main>
+</body>
+</html>

--- a/errata/22.html
+++ b/errata/22.html
@@ -18,7 +18,7 @@
   <section id="abstract">
     <h2>Abstract</h2>
     <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a> specification.</p>
-    <p>The errata are classified as Substantive or Editorial, and listed in reverse chronological order based on the date of publication to which they are applicable.</p>
+    <p>The errata are classified as Substantive or Editorial, as classified by the W3C <a href="https://www.w3.org/policies/process/20231103/#correction-classes">Classes of Changes</a>, and listed in reverse chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
       <li>The date it was added to the errata page.</li>

--- a/errata/22.html
+++ b/errata/22.html
@@ -19,6 +19,7 @@
     <p>The errata are classified as Substantive or Editorial, and listed in chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
+      <li>The date it was added to the errata page.</li>
       <li>The section referred to.</li>
       <li>A description of the problem and correction if applicable.</li>
       <li>A rationale for making the change (not required for editorial errata).</li>

--- a/errata/22.html
+++ b/errata/22.html
@@ -1,3 +1,5 @@
+{%- # PLEASE READ errata/README.md BEFORE EDITING -%}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,7 +18,7 @@
   <section id="abstract">
     <h2>Abstract</h2>
     <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a> specification.</p>
-    <p>The errata are classified as Substantive or Editorial, and listed in chronological order based on the date of publication to which they are applicable.</p>
+    <p>The errata are classified as Substantive or Editorial, and listed in reverse chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
       <li>The date it was added to the errata page.</li>
@@ -26,6 +28,7 @@
     </ul>
     <p>Substantive corrections are proposed by the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a>, which has consensus that they are appropriate; they are not to be considered normative until a new Recommendation is published following the <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">process to revise a Recommendation</a>.</p>
     <p>Please view the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
+    <p>The <a href="https://github.com/w3c/wcag/commits/main/guidelines">full commit history</a> can be viewed on GitHub.</p>
   </section>
   <section id="contents">
     <h2>Table of Contents</h2>

--- a/errata/22.html
+++ b/errata/22.html
@@ -16,35 +16,37 @@
   <section id="abstract">
     <h2>Abstract</h2>
     <p>This document records all known errors in the <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a> specification.</p>
-    <p>The errata are numbered, classified as <a href="#substantive">Substantive</a> or <a href="#editorial">Editorial</a>, and listed in reverse chronological order of their date of publication in each category. </p>
+    <p>The errata are classified as Substantive or Editorial, and listed in chronological order based on the date of publication to which they are applicable.</p>
     <p>Each entry has the following information:</p>
     <ul>
-      <li>A unique entry number</li>
-      <li>The date it was added to the errata page.</li>
       <li>The section referred to.</li>
       <li>A description of the problem and correction if applicable.</li>
       <li>A rationale for making the change (not required for editorial errata).</li>
     </ul>
     <p>Substantive corrections are proposed by the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a>, which has consensus that they are appropriate; they are not to be considered normative until a new Recommendation is published following the <a href="https://www.w3.org/2018/Process-20180201/#revised-rec">process to revise a Recommendation</a>.</p>
-    <p>Please view the <a href="/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
+    <p>Please view the <a href="https://www.w3.org/WAI/standards-guidelines/wcag/commenting/">public comment instructions</a> if you would like to comment to the Working Group. Comments submitted are publicly available in the <a href="http://lists.w3.org/Archives/Public/public-agwg-comments/">archive for the Accessibility Guidelines Working Group public comments mailing list</a>.</p>
   </section>
   <section id="contents">
     <h2>Table of Contents</h2>
     <ol class="toc">
-      <li><a href="#substantive">Substantive Errata</a></li>
-      <li><a href="#editorial">Editorial Errata</a></li>
+      {%- # Leave this empty - populated during the build process -%}
     </ol>
   </section>
   <hr />
   <main>
-    <section id="substantive">
-      <h2>Substantive Errata</h2>
-      <p>No substantive errata recorded at present.</p>
+    {%- assign trDate = "current" -%}
+    {%- assign trUrl = "https://www.w3.org/TR/WCAG22/" -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">Current Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <p>No editorial errata recorded at present.</p>
+      </section>
     </section>
-    <section id="editorial">
-      <h2>Editorial Errata</h2>
-    </section>
-    <p>No editorial errata recorded at present.</p>
   </main>
 </body>
 </html>

--- a/errata/22.html
+++ b/errata/22.html
@@ -51,6 +51,82 @@
         <p>No editorial errata recorded at present.</p>
       </section>
     </section>
+
+    {%- assign trDate = "2023-10-05" -%}
+    {%- capture trUrl -%}
+      https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG{{ page.fileSlug }}-{{ trDate | replace: "-", "" }}/
+    {%- endcapture -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata have been recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <ul>
+          <li>
+            2024-11-22:
+            Modifying visual presentation for content identified as New
+            ({% gh "#1481" %}, {% gh "#4145" %})
+          </li>
+          <li>
+            2024-11-19:
+            Making editorial changes to improve consistent use of the terms
+            "success criteria/criterion", "web", "website", and "web page"
+            ({% gh "#4080" %})
+          </li>
+          <li>
+            2024-11-19:
+            In the definition for <a href="{{ trUrl }}#dfn-single-pointer">single pointer</a>,
+            updating to further enumerate interaction types and distinguish input modalities.
+            ({% gh "#4070" %}, {% gh "#3536" %})
+          </li>
+          <li>
+            2024-11-19:
+            In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>,
+            correcting the word <span lang="fr">"dissement"</span> to <span lang="fr">"arrondissement"</span>.
+            ({% gh "#4034" %})
+          </li>
+          <li>
+            2024-11-19:
+            In the definition for <a href="{{ trUrl }}#dfn-cognitive-function-test">cognitive function test</a>,
+            updating the term from uppercase to lowercase.
+            ({% gh "#3943" %})
+          </li>
+          <li>
+            2024-11-19:
+            In <a href="{{ trUrl }}#abstract">Abstract</a>, modifying language regarding devices.
+            ({% gh "#3776" %})
+          </li>
+          <li>
+            2024-11-19:
+            In <a href="{{ trUrl }}#accessible-authentication-minimum">3.3.8 Accessible Authentication (Minimum)</a>
+            and the definitions for <a href="{{ trUrl }}#dfn-change-of-context">change of context</a>,
+            <a href="{{ trUrl }}#dfn-general-flash-and-red-flash-thresholds">general flash and red flash thresholds</a>, and
+            <a href="{{ trUrl }}#dfn-structure">structure</a>, changing ordered lists to unordered lists when no order is intended.
+            ({% gh "#3756" %})
+          </li>
+          <li>
+            2024-11-19:
+            In the definition for <a href="{{ trUrl }}#dfn-used-in-an-unusual-or-restricted-way">used in an unusual or restricted way</a>,
+            genericizing WCAG version reference from "2.1" to "2".
+            ({% gh "#3707" %})
+          </li>
+          <li>
+            2024-11-19: Removing the defunct "encloses" definition. ({% gh "#3636" %})</li>
+          <li>
+            2024-11-19:
+            In <a href="{{ trUrl }}#target-size-minimum">2.5.8 Target Size (Minimum)</a>, updating formatting, grammar, and punctuation of exceptions.
+            ({% gh "#3189" %})
+          </li>
+          <li>
+            2024-11-19:
+            Making editorial changes to improve consistent use of definitions in the success criteria ({% gh "#3038" %})
+          </li>
+        </ul>
+      </section>
+    </section>
   </main>
 </body>
 </html>

--- a/errata/README.md
+++ b/errata/README.md
@@ -1,0 +1,36 @@
+# Errata Editing Instructions
+
+Errata are listed in reverse-chronological order, first sectioned by publish date,
+then within each section based on when each erratum was added.
+
+The first top-level section under `<main>` corresponds to the latest version / unpinned URL;
+subsequent sections correspond to previous versions / date-stamped URLs.
+
+Each top-level section should be preceded by `trDate` and `trUrl` variable assignments.
+These variables reduce the chance of copy-paste errors within individual errata.
+For sections corresponding to previous versions, assignments should follow this pattern
+(only `YYYY-MM-DD` should need to be replaced):
+
+```
+{%- assign trDate = "YYYY-MM-DD" -%}
+{%- capture trUrl -%}
+  https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG21-{{ trDate | replace: "-", "" }}/
+{%- endcapture -%}
+```
+
+The level 2 heading in the top-level section for each previous version should use this code
+(no replacements necessary, making use of the preceding variable reassignments):
+
+```html
+<h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
+```
+
+Each erratum should be in the following format
+(replacing `YYYY-MM-DD`, `Section Title`, and `details of what happened`):
+
+```html
+<li>YYYY-MM-DD: In <a href="{{ trUrl }}#sectionid">Section Title</a>, details of what happened.</li>
+```
+
+Adhering to this format is important, as any entries under the latest version will also be
+parsed for inclusion within Guideline/SC boxes and Key Terms definitions within Understanding pages.

--- a/errata/README.md
+++ b/errata/README.md
@@ -30,7 +30,7 @@ The level 2 heading in the top-level section for each previous version should us
 ## Erratum format
 
 Each erratum should be in the following format
-(replacing `YYYY-MM-DD`, `Section Title`, `details of changes`, and `#NNNN`):
+(replacing `YYYY-MM-DD`, `Section Title`, `sectionid`, `details of changes`, and `#NNNN`):
 
 ```html
 <li>

--- a/errata/README.md
+++ b/errata/README.md
@@ -3,6 +3,8 @@
 Errata are listed in reverse-chronological order, first sectioned by publish date,
 then within each section based on when each erratum was added.
 
+## Sections
+
 The first top-level section under `<main>` corresponds to the latest version / unpinned URL;
 subsequent sections correspond to previous versions / date-stamped URLs.
 
@@ -14,7 +16,7 @@ For sections corresponding to previous versions, assignments should follow this 
 ```
 {%- assign trDate = "YYYY-MM-DD" -%}
 {%- capture trUrl -%}
-  https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG21-{{ trDate | replace: "-", "" }}/
+  https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG{{ page.fileSlug }}-{{ trDate | replace: "-", "" }}/
 {%- endcapture -%}
 ```
 
@@ -24,6 +26,8 @@ The level 2 heading in the top-level section for each previous version should us
 ```html
 <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
 ```
+
+## Erratum format
 
 Each erratum should be in the following format
 (replacing `YYYY-MM-DD`, `Section Title`, and `details of what happened`):

--- a/errata/README.md
+++ b/errata/README.md
@@ -32,5 +32,14 @@ Each erratum should be in the following format
 <li>YYYY-MM-DD: In <a href="{{ trUrl }}#sectionid">Section Title</a>, details of what happened.</li>
 ```
 
-Adhering to this format is important, as any entries under the latest version will also be
+Adhering to this format is important, as any entries under the latest published version will also be
 parsed for inclusion within Guideline/SC boxes and Key Terms definitions within Understanding pages.
+
+`details of what happened` should be expressed in present progressive tense
+(e.g. "updating", "removing", "adding"), with the desired outcome listed first.
+For example:
+
+- updating the red threshold from ... to ...
+- removing one note and adding two new notes, including ...
+- removing a supernumary "Note" indicator from the first note.
+- correcting the word ... to ...

--- a/errata/README.md
+++ b/errata/README.md
@@ -30,14 +30,45 @@ The level 2 heading in the top-level section for each previous version should us
 ## Erratum format
 
 Each erratum should be in the following format
-(replacing `YYYY-MM-DD`, `Section Title`, and `details of what happened`):
+(replacing `YYYY-MM-DD`, `Section Title`, `details of changes`, and `#NNNN`):
 
 ```html
-<li>YYYY-MM-DD: In <a href="{{ trUrl }}#sectionid">Section Title</a>, details of what happened.</li>
+<li>
+  YYYY-MM-DD:
+  In <a href="{{ trUrl }}#sectionid">Section Title</a>,
+  details of changes.
+  ({% gh #NNNN %})
+</li>
 ```
 
 Adhering to this format is important, as any entries under the latest published version will also be
 parsed for inclusion within Guideline/SC boxes and Key Terms definitions within Understanding pages.
+(Newlines are insignificant and are suggested for source code readability.)
+
+Each piece of this format is further explained in the subsections below.
+
+### Section reference
+
+When applicable, errata should begin with an indication of the section they relate to, including a link.
+
+Example phrasing when linking to a section, e.g. a success criterion:
+
+```html
+In <a href="{{ trUrl }}#target-size-minimum">2.5.8 Target Size (Minimum)</a>
+```
+
+Example phrasing when linking to a term definition:
+
+```html
+In the definition for <a href="{{ trUrl }}#dfn-single-pointer">single pointer</a>
+```
+
+(Remember that term definition fraagments always begin with `dfn-`.)
+
+It is possible to reference multiple sections/terms from one erratum,
+so long as all of the links remain front-loaded prior to the erratum's details.
+
+### Details of changes
 
 `details of what happened` should be expressed in present progressive tense
 (e.g. "updating", "removing", "adding"), with the desired outcome listed first.
@@ -47,3 +78,16 @@ For example:
 - removing one note and adding two new notes, including ...
 - removing a supernumary "Note" indicator from the first note.
 - correcting the word ... to ...
+
+### GitHub PR or commit
+
+When possible, provide a reference to one or more GitHub pull requests or commit hashes
+at the end of each erratum, in the format `({% gh "..." %})`.
+
+The format breaks down as follows:
+
+- `{% gh "..." %}` is a custom shortcode, which accepts one of the following:
+  - A PR number prefixed with `#`, e.g. `"#4080"` (this is the preferred option when available)
+  - A commit hash of 7 or more characters, with no prefix, e.g. `"b043430"`
+- The quotes around the parameter passed to the `gh` shortcode are necessary for template parsing
+- The outer parentheses exist only for punctuation, and are directly output

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@ const prNumber = process.env.REVIEW_ID;
     </p>
     {%- endif %}
 		<ul>
+      <li><a href="errata/21.html">Errata for 2.1</a>
+      <li><a href="errata/22.html">Errata for 2.2</a>
       {% if includeGuidelines -%}
         <li><a href="guidelines/">Guidelines</a></li>
       {%- endif %}


### PR DESCRIPTION
This adds the following:

- Imports the 2.1 and 2.2 errata pages into this repo
  - Reorganizes existing 2.1 errata in reverse-chronological order
  - Adds date stamps for all existing errata I could trace back to a commit
  - Makes use of variables and Liquid expressions to minimize potential for copy-paste errors between sections
  - Auto-generates table of contents within `CustomLiquid.ts` to avoid desync when adding versions
  - Documents patterns/formats for authoring errata in `errata/README.md` (with mention in top-level README)
- Adds logic to parse information from errata pages and include relevant errata within Guideline/SC boxes and term definitions within informative docs pages
  - Errata are only included when building for a specific version (i.e. not the editor's draft, in which case corrections are expected to already be inlined)
  - Only errata against the latest published version are included in informative docs
- Updates `publish-w3c` script to also copy relevant errata file for version being published
- Adds links to errata pages in top-level index used for dev server and PR builds

Examples of how errata appear:

For a success criterion (as an additional subheading):
![Errata inserted at the bottom of a SC box](https://github.com/user-attachments/assets/e7afa663-a4f8-4b75-b2bf-f48d92b867ea)

For a key term definition (as an additional paragraph + list):
![Errata inserted at the bottom of a key terms definition](https://github.com/user-attachments/assets/39965f9f-841d-474b-b372-d39360f175ba)
