### PR TITLE
Address remaining unresolved biblio references

### DIFF
--- a/11ty/biblio.ts
+++ b/11ty/biblio.ts
@@ -1,11 +1,19 @@
 import axios from "axios";
 import { readFile } from "fs/promises";
 import { glob } from "glob";
+import invert from "lodash-es/invert";
 import uniq from "lodash-es/uniq";
+import { join } from "path";
 
+import { loadFromFile } from "./cheerio";
 import { wrapAxiosRequest } from "./common";
 
 export const biblioPattern = /\[\[\??([\w-]+)\]\]/g;
+
+// Resolve necessary aliases locally rather than requiring an extra round trip to specref
+const aliases = {
+  "css3-values": "css-values-3",
+};
 
 /** Compiles URLs from local biblio + specref for linking in Understanding documents. */
 export async function getBiblio() {
@@ -21,19 +29,32 @@ export async function getBiblio() {
     let match;
     while ((match = biblioPattern.exec(content))) if (!localBiblio[match[1]]) refs.push(match[1]);
   }
-  const uniqueRefs = uniq(refs);
+  const uniqueRefs = uniq(refs).map((ref) =>
+    ref in aliases ? aliases[ref as keyof typeof aliases] : ref
+  );
 
   const response = await wrapAxiosRequest(
     axios.get(`https://api.specref.org/bibrefs?refs=${uniqueRefs.join(",")}`)
   );
-  const fullBiblio = {
+  for (const [from, to] of Object.entries(invert(aliases)))
+    response.data[to] = response.data[from];
+
+  return {
     ...response.data,
     ...localBiblio,
   };
+}
 
-  const resolvedRefs = Object.keys(fullBiblio);
-  const unresolvedRefs = uniqueRefs.filter((ref) => !resolvedRefs.includes(ref));
-  if (unresolvedRefs.length) console.warn(`Unresolved biblio refs: ${unresolvedRefs.join(", ")}`);
-
-  return fullBiblio;
+/** Returns mapping of references included in WCAG 2.0, which largely lack URLs */
+export async function getXmlBiblio() {
+  const xmlRefs: Record<string, string> = {};
+  const $ = await loadFromFile(join("wcag20", "sources", "guide-to-wcag2-src.xml"));
+  $("bibl[id]").each((_, el) => {
+    const $ref = $(`#${el.attribs.id}`);
+    if (!$ref.length) return;
+    // Note: Using text() drops links (<loc> tags in the XML),
+    // but the only link within refs that are actually used seems to be broken
+    xmlRefs[el.attribs.id] = $ref.text();
+  });
+  return xmlRefs;
 }

--- a/_includes/dl-section.html
+++ b/_includes/dl-section.html
@@ -1,0 +1,6 @@
+<section id="{{ title | slugify }}">
+  <details>
+    <summary><h2>{{ title }}</h2></summary>
+    <dl></dl>
+  </details>
+</section>

--- a/_includes/understanding/key-terms.html
+++ b/_includes/understanding/key-terms.html
@@ -1,6 +1,0 @@
-<section id="key-terms">
-  <details>
-    <summary><h2>Key Terms</h2></summary>
-    <dl></dl>
-  </details>
-</section>


### PR DESCRIPTION
Resolves #2535.

This resolves the remaining unresolved references by implementing the following:

- Local aliases map for querying specref (fixes broken ref for css3-values, which is an alias of css-values-3)
- References section, appearing after Key Terms for any pages that cite references that only ever existed in WCAG 2.0's XML sources

I also improved output source formatting for Key Terms while adding the new `dl` for References, and repurposed the Key Terms template to be reusable for both.

Understanding pages with References sections:

- [Contrast (Minimum)](https://deploy-preview-4174--wcag2.netlify.app/understanding/contrast-minimum)
- [Contrast (Enhanced)](https://deploy-preview-4174--wcag2.netlify.app/understanding/contrast-enhanced)
- [Low or No Background Audio](https://deploy-preview-4174--wcag2.netlify.app/understanding/low-or-no-background-audio)

Understanding pages that reference css3-values:

- [Reflow](https://deploy-preview-4174--wcag2.netlify.app/understanding/reflow)
- [Three Flashes or Below Threshold](https://deploy-preview-4174--wcag2.netlify.app/understanding/three-flashes-or-below-threshold)
- [Focus Appearance](https://deploy-preview-4174--wcag2.netlify.app/understanding/focus-appearance)
- [Target Size (Enhanced)](https://deploy-preview-4174--wcag2.netlify.app/understanding/target-size-enhanced)
- [Target Size (Minimum)](https://deploy-preview-4174--wcag2.netlify.app/understanding/target-size-minimum)
