### PR TITLE
Fix typo in guidelines change log

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -792,7 +792,7 @@
 				<li>2022-03-22: Added <a href="#focus-not-obscured-minimum">Focus Not Obscured (Minimum)</a>.</li>
 				<li>2022-05-30: Added <a href="#focus-not-obscured-enhanced">Focus Not Obscured (Enhanced)</a>.</li>
 				<li>2023-06-05: Added privacy and security sections within conformance.</li>
-        <li>2024-12-1w: Republished WCAG 2.2, incorporating the following errata:
+        <li>2024-12-12: Republished WCAG 2.2, incorporating the following errata:
            <ul>
               <li>modified the definitions of <a>single pointer</a>, <a>used in an unusual or restricted way</a>, <a>motion animation</a>, and <a>programmatically determined</a></li>
               <li>modified the formatting of definitions for <a>changes of context</a>, <a>general flash and red flash thresholds</a>, <a>cognitive function test</a>, and <a>structure</a></li>


### PR DESCRIPTION
I noticed this typo had somehow made it into the editor's draft in the repo. Thankfully, this typo did not make it into the newly published document.