### PR TITLE
Add GitHub action to publish 2.1 ED updates

### DIFF
--- a/.github/workflows/21ed-publish.yaml
+++ b/.github/workflows/21ed-publish.yaml
@@ -1,0 +1,39 @@
+name: Push 2.1 ED to gh-pages branch
+
+# Reference documentation: https://docs.github.com/en/actions/reference
+
+# See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
+on:
+  push:
+    branches: [WCAG-2.1]
+
+jobs:
+  main:
+    name: deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: WCAG-2.1
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: _site
+          token: ${{ secrets.W3CGRUNTBOT_TOKEN }}
+      - name: Build
+        run: |
+          cp guidelines/guidelines.css guidelines/relative-luminance.html _site/guidelines
+          curl https://labs.w3.org/spec-generator/?type=respec"&"url=https://raw.githack.com/$GITHUB_REPOSITORY/WCAG-2.1/guidelines/index.html -o _site/guidelines/index.html -f  --retry 3
+      - name: Push
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          repository: _site
+          branch: gh-pages
+          commit_user_name: w3cgruntbot
+          commit_user_email: 87540780+w3cgruntbot@users.noreply.github.com
+          commit_author: "w3cgruntbot <87540780+w3cgruntbot@users.noreply.github.com>"
+          commit_message: ":robot: Deploy to GitHub Pages: ${{ github.sha }} from branch ${{ github.ref }}"
+          skip_fetch: true
+          skip_checkout: true


### PR DESCRIPTION
This adds an action to the `WCAG-2.1` branch to update files on the gh-pages branch related to 2.1 guidelines, which reside directly under `guidelines/` (not under a subfolder). Prior to this, the editor's draft for WCAG 2.1 has not been updated since shortly after its first publication.

- [Test commit on fork used to trigger action](https://github.com/kfranqueiro/wcag/commit/9383b93391f44964394166c30df2cb42bde554e0)
- [Successful action run on fork](https://github.com/kfranqueiro/wcag/actions/runs/12419617657/job/34675309110)
- [gh-pages commit produced by the action](https://github.com/kfranqueiro/wcag/commit/58110ff65bfbda13af4aa2e8adbec15ce7f06a65)
- [The document produced](https://kfranqueiro.github.io/wcag/guidelines/)
- [Diff between ED on w3c.github.io vs. latest update](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fwcag%2Fguidelines%2F&doc2=https%3A%2F%2Fkfranqueiro.github.io%2Fwcag%2Fguidelines%2F)
