### PR TITLE
Add 2.1 build script that reuses process from main branch

### DIFF
--- a/build-21.sh
+++ b/build-21.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# Download main branch
+curl -Lo wcag.tar.gz https://github.com/w3c/wcag/archive/refs/heads/main.tar.gz
+tar xf wcag.tar.gz
+cd wcag-main
+npm i
+
+# Run build using local 2.1 guidelines from active branch
+WCAG_VERSION=21 WCAG_FORCE_LOCAL_GUIDELINES=../guidelines/index.html npm run build


### PR DESCRIPTION
These changes are part 2 of 2 to enable preview builds against the `WCAG-2.1` branch. This part applies to the `WCAG-2.1` branch; See #4182 for part 1, which applies to `main`.

This adds a shell script which downloads a tarball of the latest `main` branch, extracts it to a subfolder, then runs the Eleventy build within it, instructing it to build against 2.1 but using the local `guidelines` folder from the active branch rather than the latest published version.

I have temporarily stood up an example site using a version of this branch modified to run against the branch on my fork used for #4182:

https://kgf-wcag21-preview-test.netlify.app/

I have verified that the only diffs between the output of this script and directly running against the latest 2.1 publication from `main` are date stamps in page footers.

Here's what the deploy options look like for the netlify site:

![Netlify deploy configuration for kgf-wcag21-preview-test, including build command set to ./build-21.sh, and publish directory set to wcag-main/_site](https://github.com/user-attachments/assets/2f94eb56-1b4e-45a1-9869-13bf4f4ba5c8)
