### PR TITLE
[WCAG AAA] - Move H28 from sufficient to advisory in 3.1.4 Abbreviations SC

### DIFF
--- a/techniques/html/H28.html
+++ b/techniques/html/H28.html
@@ -18,7 +18,7 @@
       <h2>Description</h2>
       <p>The objective of this technique is to provide expansions or definitions for
             abbreviations by using the <code class="language-html">abbr</code> element. It is always appropriate to use the <code class="language-html">abbr</code> element for any abbreviation, including acronyms and initialisms.</p>
-            <p>This technique has been altered from a sufficient technique to an advisory technique because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation needed to acheive a sufficient technique when used in combination with <a href="../general/G102">G102</a>. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:
+            <p>This technique has been altered from a sufficient technique to an advisory technique because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation needed to achieve a sufficient technique when used in combination with <a href="../general/G102">G102</a>. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:
 
                <q>Relying on the title attribute is currently discouraged as many user agents do not expose the attribute in an accessible manner as required by this specification (e.g., requiring a pointing device such as a mouse to cause a tooltip to appear, which excludes keyboard-only users and touch-only users, such as anyone with a modern phone or tablet).</q></p>
    </section>

--- a/techniques/html/H28.html
+++ b/techniques/html/H28.html
@@ -18,7 +18,7 @@
       <h2>Description</h2>
       <p>The objective of this technique is to provide expansions or definitions for
             abbreviations by using the <code class="language-html">abbr</code> element. It is always appropriate to use the <code class="language-html">abbr</code> element for any abbreviation, including acronyms and initialisms.</p>
-            <p>This technique has been altered from a sufficient technique to an advisory technique for G102 because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:
+            <p>This technique has been altered from a sufficient technique to an advisory technique because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation needed to acheive a sufficient technique when used in combination with <a href="../general/G102">G102</a>. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:
 
                <q>Relying on the title attribute is currently discouraged as many user agents do not expose the attribute in an accessible manner as required by this specification (e.g., requiring a pointing device such as a mouse to cause a tooltip to appear, which excludes keyboard-only users and touch-only users, such as anyone with a modern phone or tablet).</q></p>
    </section>

--- a/techniques/html/H28.html
+++ b/techniques/html/H28.html
@@ -18,7 +18,7 @@
       <h2>Description</h2>
       <p>The objective of this technique is to provide expansions or definitions for
             abbreviations by using the <code class="language-html">abbr</code> element. It is always appropriate to use the <code class="language-html">abbr</code> element for any abbreviation, including acronyms and initialisms.</p>
-            <p>This technique has been altered from a sufficient technique to an advisory technique because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation needed to achieve a sufficient technique when used in combination with <a href="../general/G102">G102</a>. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:
+            <p>This technique has been altered from a sufficient technique to an advisory technique because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation needed to achieve a sufficient technique when used in combination with <a href="../general/G102">G102</a>. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:</p>
 
                <q>Relying on the title attribute is currently discouraged as many user agents do not expose the attribute in an accessible manner as required by this specification (e.g., requiring a pointing device such as a mouse to cause a tooltip to appear, which excludes keyboard-only users and touch-only users, such as anyone with a modern phone or tablet).</q></p>
    </section>

--- a/techniques/html/H28.html
+++ b/techniques/html/H28.html
@@ -18,6 +18,9 @@
       <h2>Description</h2>
       <p>The objective of this technique is to provide expansions or definitions for
             abbreviations by using the <code class="language-html">abbr</code> element. It is always appropriate to use the <code class="language-html">abbr</code> element for any abbreviation, including acronyms and initialisms.</p>
+            <p>This technique has been altered from a sufficient technique to an advisory technique for G102 because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:
+
+               <q>Relying on the title attribute is currently discouraged as many user agents do not expose the attribute in an accessible manner as required by this specification (e.g., requiring a pointing device such as a mouse to cause a tooltip to appear, which excludes keyboard-only users and touch-only users, such as anyone with a modern phone or tablet).</q></p>
    </section>
 
    <section id="examples">

--- a/techniques/html/H28.html
+++ b/techniques/html/H28.html
@@ -20,7 +20,7 @@
             abbreviations by using the <code class="language-html">abbr</code> element. It is always appropriate to use the <code class="language-html">abbr</code> element for any abbreviation, including acronyms and initialisms.</p>
             <p>This technique has been altered from a sufficient technique to an advisory technique because it uses the <code>title</code> attribute of <code>abbr</code> to provide the expansion of the abbreviation needed to achieve a sufficient technique when used in combination with <a href="../general/G102">G102</a>. As noted in the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute"> specification</a>:</p>
 
-               <q>Relying on the title attribute is currently discouraged as many user agents do not expose the attribute in an accessible manner as required by this specification (e.g., requiring a pointing device such as a mouse to cause a tooltip to appear, which excludes keyboard-only users and touch-only users, such as anyone with a modern phone or tablet).</q></p>
+               <blockquote><p>Relying on the title attribute is currently discouraged as many user agents do not expose the attribute in an accessible manner as required by this specification (e.g., requiring a pointing device such as a mouse to cause a tooltip to appear, which excludes keyboard-only users and touch-only users, such as anyone with a modern phone or tablet).</p></blockquote>
    </section>
 
    <section id="examples">

--- a/understanding/20/abbreviations.html
+++ b/understanding/20/abbreviations.html
@@ -177,12 +177,6 @@
                      </li>
                      
                      <li>
-                        												               
-                        <a href="../Techniques/html/H28" class="html">Providing definitions for abbreviations by using the abbr and acronym elements</a>
-                        											             
-                     </li>
-                     
-                     <li>
                         
                         <a href="../Techniques/pdf/PDF8" class="pdf"></a>
                         
@@ -226,12 +220,6 @@
                      </li>
                      
                      <li>
-                        												               
-                        <a href="../Techniques/html/H28" class="html">Providing definitions for abbreviations by using the abbr and acronym elements</a>
-                        											             
-                     </li>
-                     
-                     <li>
                         
                         <a href="../Techniques/pdf/PDF8" class="pdf"></a>
                         
@@ -271,12 +259,6 @@
                      </li>
                      
                      <li>
-                        												               
-                        <a href="../Techniques/html/H28" class="html">Providing definitions for abbreviations by using the abbr and acronym elements</a>
-                        											             
-                     </li>
-                     
-                     <li>
                         
                         <a href="../Techniques/pdf/PDF8" class="pdf"></a>
                         
@@ -295,8 +277,9 @@
       
       <section id="advisory">
          <h3>Additional Techniques (Advisory) for Abbreviations</h3>
-         
-         
+         <ul>
+           <li><a href="../Techniques/html/H28" class="html">Providing definitions for abbreviations by using the abbr and acronym elements</a></li>
+         </ul>         
       </section>
       
       <section id="failure">


### PR DESCRIPTION
Closes: #3019 

[H28](https://www.w3.org/WAI/WCAG21/Techniques/html/H28) is not a sufficient technique, rather than an advisory one, since it would likely fail 2.1.1

Actions: moved H28 from sufficient to advisory.