### PR TITLE
Fail build upon encountering p w/ class="instructions"

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -107,7 +107,16 @@ export class CustomLiquid extends Liquid {
       // (e.g. editors.css & sources.css, and leftover template paragraphs)
       // NOTE: some paragraphs with the "instructions" class actually have custom content,
       // but for now this remains consistent with the XSLT process by stripping all of them.
-      $(".remove, p.instructions, section#meta, section.meta").remove();
+      $(".remove, section#meta, section.meta").remove();
+
+      if ($("p.instructions").length > 0) {
+        console.error(`${filepath} contains a <p class="instructions"> element.\n` +
+          "  This suggests that a template was copied and not fully filled out.\n" +
+          "  If the paragraph has been modified and should be retained, remove the class.\n" +
+          "  Otherwise, if the corresponding section has been updated, remove the paragraph."
+        );
+        throw new Error("Instructions paragraph found; please resolve.")
+      }
 
       const prependedIncludes = ["header"];
       const appendedIncludes = ["wai-site-footer", "site-footer"];


### PR DESCRIPTION
When first implementing the Eleventy build system in #3917, I kept the existing XSLT behavior of stripping `<p class="instructions">` paragraphs.

I later cleaned up the remainder of them in #3941.

Now we have the opportunity to ensure no new ones ever sneak in, by failing the build if any are present (which will also fail the check on PRs).

With this change, any page found to contain `<p class="instructions">` will present an error, e.g.:
```
./techniques/aria/ARIA25.html contains a <p class="instructions"> element.
  This suggests that a template was copied and not fully filled out.
  If the paragraph has been modified and should be retained, remove the class.
  Otherwise, if the corresponding section has been updated, remove the paragraph.
[11ty] Problem writing Eleventy templates:
[11ty] 1. Having trouble rendering liquid template ./techniques/aria/ARIA25.html (via TemplateContentRenderError)
[11ty] 2. Instructions paragraph found; please resolve.
```

This PR causes no changes in current build output.

(Yes, I implemented this after reviewing a PR containing stray instructions paragraphs)