### PR TITLE
Resolve remaning build warnings and prevent future instances

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -157,39 +157,19 @@ export class CustomLiquid extends Liquid {
             .after(generateIncludes("techniques/about"))
             .replaceWith(generateIncludes("techniques/h1"));
 
-          const sectionCounts: Record<string, number> = {};
-          let hasDuplicates = false;
+          const detectedSections: Record<string, true> = {};
           $("body > section[id]").each((_, el) => {
             const id = el.attribs.id.toLowerCase();
             // Fix non-lowercase top-level section IDs (e.g. H99)
             el.attribs.id = id;
-            // Track duplicate sections, to be processed next
-            if (id in sectionCounts) {
-              hasDuplicates = true;
-              sectionCounts[id]++;
+            // Fail on duplicate sections
+            if (id in detectedSections) {
+              console.error(`${filepath}: Multiple sections with id="${id}" found.`);
+              throw new Error("Please resolve duplicate section IDs.");
             } else {
-              sectionCounts[id] = 1;
+              detectedSections[id] = true;
             }
           });
-
-          // Avoid loop altogether in majority of (correct) cases
-          if (hasDuplicates) {
-            for (const [id, count] of Object.entries(sectionCounts)) {
-              if (count === 1) continue;
-              console.warn(
-                `${filepath}: Merging duplicate ${id} sections; please fix this in the source file.`
-              );
-              const $sections = $(`section[id='${id}']`);
-              const $first = $sections.first();
-              $sections.each((i, el) => {
-                if (i === 0) return;
-                const $el = $(el);
-                $el.find("> h2:first-child").remove();
-                $first.append($el.contents());
-                $el.remove();
-              });
-            }
-          }
 
           $("section#resources h2").after(generateIncludes("techniques/intro/resources"));
           $("section#examples section.example").each((i, el) => {
@@ -222,13 +202,11 @@ export class CustomLiquid extends Liquid {
 
           // Remove spurious copy-pasted content in 2.5.3 that doesn't belong there
           if ($("section#benefits").length > 1) $("section#benefits").first().remove();
-          // Some pages nest Benefits inside Intent; XSLT always pulls it back out
-          $("section#intent section#benefits")
-            .insertAfter("section#intent")
-            .find("h3:first-child")
-            .each((_, el) => {
-              el.tagName = "h2";
-            });
+          // Prevent pages from nesting Benefits inside Intent (old issue that has been fixed)
+          if ($("section#intent section#benefits").length) {
+            console.error(`${filepath}: Benefits section should not be nested inside Intent.`);
+            throw new Error("Incorrectly-nested Benefits section found: please resolve.");
+          }
 
           // XSLT orders resources then techniques last, opposite of source files
           $("body")
@@ -245,15 +223,14 @@ export class CustomLiquid extends Liquid {
               generateIncludes("understanding/intro/sufficient-situation")
             );
           }
-          // success-criteria section should be auto-generated;
-          // remove any handwritten ones (e.g. Input Modalities)
-          const $successCriteria = $("section#success-criteria");
-          if ($successCriteria.length) {
-            console.warn(
-              `${filepath}: success-criteria section will be replaced with ` +
-                "generated version; please remove this from the source file."
+
+          // Disallow handwritten success-criteria section (should be auto-generated)
+          if ($("section#success-criteria").length) {
+            console.error(
+              `${filepath}: success-criteria section will be auto-generated; ` +
+                "please remove this from the source file."
             );
-            $successCriteria.remove();
+            throw new Error("Please remove success-criteria section from guideline pages.");
           }
           // success-criteria template only renders content for guideline (not SC) pages
           $("body").append(generateIncludes("understanding/success-criteria"));

--- a/techniques/failures/F61.html
+++ b/techniques/failures/F61.html
@@ -41,7 +41,6 @@
             <li>If checks #3 and #4 are true, then this failure condition applies and the content fails this Success Criterion</li>
          </ul>
       </section>
-   </section><section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Measure or estimate the amount of time that the average user spends on the page.</li>

--- a/understanding/21/input-modalities.html
+++ b/understanding/21/input-modalities.html
@@ -3,29 +3,17 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 	<head>
 		<meta charset="UTF-8"/>
-		<title>Understanding Guideline 2.5 | Understanding WCAG 2.1</title>
+		<title>Understanding Input Modalities</title>
 		<link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"/>
 	</head>
 	<body>
-		<h1>Pointer Accessible:<br/>
-Understanding Guideline 2.1
-</h1>
+		<h1>Understanding Input Modalities</h1>
 		<section id="intent">
-			<h2>Intent of Guideline 2.5</h2>
+			<h2>Intent of Input Modalities</h2>
 			<p>All functionality should be accessible via pointer input devices, for example, via a mouse pointer, a finger interacting with a touch screen, an electronic pencil/stylus, or a laser pointer.</p>
       <p>People operating pointer input devices may not be able to carry out timed or complex gestures. Examples are drag-and-drop gestures and on touch screens, swiping gestures, split taps, or long presses. This Guideline does not discourage the provision of complex and timed gestures by authors. However, where they are used, an alternative method of input should be provided to enable users with motor impairments to interact with content via single untimed pointer gestures.</p>
         <p>Often, people use devices that offer several input methods, for example, mouse input, touch input, keyboard input, and speech input. These should be supported concurrently as users may at any time swich preferred input methods due to situational circumstances, for example, the availability of a flat support for mouse operation, or situational impediments through motion or changes of ambient light.</p>
       <p>A common requirement for pointer interaction is the ability of users to position the pointer over the target. With touch input, the pointer (the finger) is larger and less precise than a mouse cursor. For people with motor impairments, a larger target makes it easier to successfully position the pointer and activate the target.</p>
-    </section>
-				
-		<section id="success-criteria">
-			<h2>Success Criteria for this Guideline</h2>
-      <ul>
-        <li><a href="pointer-gestures.html">Understanding Success Criterion 2.5.1 [Pointer Gestures]</a></li>
-        <li><a href="concurrent-input-mechanisms.html">Understanding Success Criterion 2.5.2 [Concurrent Input Mechanisms]</a></li>
-        <li><a href="target-size.html">Understanding Success Criterion 2.5.3 [Target Size]</a></li>
-        <li><a href="target-size-no-exception.html">Understanding Success Criterion 2.5.4 [Target Size (No Exception)]</a></li> 
-      </ul>
     </section>
 	</body>
 </html>


### PR DESCRIPTION
Resolves #3922

This PR resolves 2 warnings that have been in the Eleventy build since its introduction, then switches those warnings to errors to prevent further instances from being introduced.

## Fixes

- Two sections with the same ID in F61
- Redundant Success Criteria section in 2.5 Input Modalities (along with some other edits to make this file consistent with other Guideline pages)

None of these fixes cause changes to output other than whitespace (because the build system was previously auto-fixing these cases).

## Preventive measures

The following will now fail the build (and PR checks):

- Presence of the same `id` on multiple `section` elements within the same page
  ```
  ./techniques/failures/F61.html: Multiple sections with id="tests" found.
  [11ty] Problem writing Eleventy templates:
  [11ty] 1. Having trouble rendering liquid template ./techniques/failures/F61.html (via TemplateContentRenderError)
  [11ty] 2. Please resolve duplicate section IDs.
  ```
- Presence of Success Criteria section (which is auto-generated)
  ```
  ./understanding/21/input-modalities.html: success-criteria section will be auto-generated; please remove this from the source file.
  [11ty] Problem writing Eleventy templates:
  [11ty] 1. Having trouble rendering liquid template ./understanding/21/input-modalities.html (via TemplateContentRenderError)
  [11ty] 2. Please remove success-criteria section from guideline pages.
  ```