### PR TITLE
Change specStatus back to ED after republication for github.io pushes

### DIFF
--- a/guidelines/respec-config.js
+++ b/guidelines/respec-config.js
@@ -8,7 +8,7 @@ var respecConfig = {
 	permalinkHide:     false,
 	tocIntroductory: true,
 	// specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
-	specStatus:           "REC",
+	specStatus:           "ED",
 	//crEnd:                "2012-04-30",
 	//perEnd:               "2013-07-23",
 	publishDate:          "2024-12-12",


### PR DESCRIPTION
I noticed that the latest at https://w3c.github.io/wcag/guidelines/22/ incorrectly states it is a Recommendation, not Editor's Draft; this is likely because 079df5e5 was committed in preparation for the December 2024 republication, then never reverted.