### PR TITLE
Amend #4174 approach to still tolerate specref API call failure

### DIFF
--- a/11ty/biblio.ts
+++ b/11ty/biblio.ts
@@ -36,8 +36,10 @@ export async function getBiblio() {
   const response = await wrapAxiosRequest(
     axios.get(`https://api.specref.org/bibrefs?refs=${uniqueRefs.join(",")}`)
   );
-  for (const [from, to] of Object.entries(invert(aliases)))
-    response.data[to] = response.data[from];
+  if (response.data) {
+    for (const [from, to] of Object.entries(invert(aliases)))
+      response.data[to] = response.data[from];
+  }
 
   return {
     ...response.data,


### PR DESCRIPTION
This covers the edge case of `data` being `null` due to the API call failing in dev, which I had originally allowed for with #4167, but then missed accounting for in #4174.

FWIW, future work for this may include one or both of the following:

- Specifying typings to the axios call, which would have caused TypeScript to flag this (it didn't because `data` is typed as `any` in the Axios response, which apparently masks the possibility of `null`)
- Moving specref fetch to an on-demand task separate from the build, which I am inclined to do after also seeing at least one intermittent failure during a PR preview build