### PR TITLE
Update runner image away from deprecated 20.04

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   main:
     name: deploy (11ty)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The 20.04 image will be fully unsupported by April 1, 2025.

Test run from my fork: https://github.com/kfranqueiro/wcag/actions/runs/13268653388/job/37042510288