### PR TITLE
Number examples/notes when there are multiple in one SC or definition

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -563,6 +563,18 @@ export class CustomLiquid extends Liquid {
       $el.prepend(`<p class="example-title marker">Example</p>`);
     });
 
+    // Perform second pass over notes/examples, to number when there are multiple in one section or dd
+    $("#key-terms dd, #success-criterion").each((_, containerEl) => {
+      for (const selector of [".example-title", ".note-title"]) {
+        const $titles = $(containerEl).find(selector);
+        if ($titles.length > 1) {
+          $titles.each((i, el) => {
+            $(el).text(`${$(el).text()} ${i + 1}`);
+          });
+        }
+      }
+    });
+
     // We don't need to do any more processing for index/about pages other than stripping comments
     if (indexPattern.test(scope.page.inputPath)) return stripHtmlComments($.html());
 


### PR DESCRIPTION
Fixes #4229.

This adds logic akin to `numberNotes` and `renumberExamples` in `wcag.js` (used in ReSpec post-processing) to the build system, to also number notes and examples in informative docs when multiple appear in a single success criterion or term definition.

@iadawn initially suggested investigating using CSS counters for this. That is mostly feasible, but with the following caveats:

- It would still need some kind of logic to signal cases that do/don't warrant numbering, consistent with the spec
- As far as I could tell, it required a rather verbose amount of styling to get the numbers correct (attempting to combine selectors resulted in incorrect numbering)
- Would need to ensure the use of generated content would not cause issues with AT

Solving this in `CustomLiquid.ts` resolves all cases with less code.