### PR TITLE
Build: Fix watching of copied resources

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -231,9 +231,6 @@ export default function (eleventyConfig: any) {
       isUnderstanding ? flatGuidelines[resolveUnderstandingFileSlug(page.fileSlug)] : null,
   });
 
-  // See https://www.11ty.dev/docs/copy/#emulate-passthrough-copy-during-serve
-  eleventyConfig.setServerPassthroughCopyBehavior("passthrough");
-
   eleventyConfig.addPassthroughCopy("techniques/*.css");
   eleventyConfig.addPassthroughCopy("techniques/*/img/*");
   eleventyConfig.addPassthroughCopy({
@@ -249,6 +246,9 @@ export default function (eleventyConfig: any) {
   });
 
   eleventyConfig.addPassthroughCopy("working-examples/**");
+  // working-examples is in .eleventyignore to avoid processing as templates,
+  // but should still be included as a watch target to pick up changes in dev
+  eleventyConfig.watchIgnores.add("!working-examples/**");
 
   eleventyConfig.on("eleventy.before", async ({ runMode }: EleventyEvent) => {
     // Clear the _site folder before builds intended for the W3C site,


### PR DESCRIPTION
This addresses issues where resources being passthrough-copied (or otherwise copied by us in `eleventy.after`) would not update at all without a full server restart.

- Turning off passthrough copy behavior forces re-copying of changed `addPassthroughCopy` assets in general
  - I had originally configured the passthrough setting in an effort to avoid a lot of unnecessary disk thrashing (more than two-thirds of the files in the build are copy operations), but it seems to come with behaviors that undermine the benefit
- Adding an exception to `watchIgnores` for `working-examples` is additionally necessary for files in that folder to hot-reload, because it is intentionally listed in `.eleventyignore` to avoid processing its HTML files as Liquid templates

This update does not change build output.