### PR TITLE
Fix links to Understanding WCAG 2.1 to 2.2

### DIFF
--- a/guidelines/terms/20/accessibility-supported.html
+++ b/guidelines/terms/20/accessibility-supported.html
@@ -80,7 +80,7 @@
    
    <p class="note">The Accessibility Guidelines Working Group and the W3C do not specify which or how much support by assistive
       technologies there must be for a particular use of a web technology in order for it
-      to be classified as accessibility supported. (See <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#support-level">Level of Assistive Technology Support Needed for "Accessibility Support"</a>.)
+      to be classified as accessibility supported. (See <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance#support-level">Level of Assistive Technology Support Needed for "Accessibility Support"</a>.)
    </p>
    
    <p class="note">Web technologies can be used in ways that are not accessibility supported as long
@@ -100,7 +100,7 @@
    
    <p class="note">One way for authors to locate uses of a technology that are accessibility supported
       would be to consult compilations of uses that are documented to be accessibility supported.
-      (See <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#documented-lists">Understanding Accessibility-Supported Web Technology Uses</a>.) Authors, companies, technology vendors, or others may document accessibility-supported
+      (See <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance#documented-lists">Understanding Accessibility-Supported Web Technology Uses</a>.) Authors, companies, technology vendors, or others may document accessibility-supported
       ways of using web content technologies. However, all ways of using technologies in
       the documentation would need to meet the definition of accessibility-supported Web
       content technologies above.

--- a/guidelines/terms/20/conforming-alternate-version.html
+++ b/guidelines/terms/20/conforming-alternate-version.html
@@ -64,6 +64,6 @@
       the preferences is accessibility supported.
    </p>
    
-   <p>See <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a></p>
+   <p>See <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a></p>
    
 </dd>

--- a/guidelines/terms/20/text-alternative.html
+++ b/guidelines/terms/20/text-alternative.html
@@ -10,7 +10,7 @@
       text alternative for the chart indicates that a description follows.
    </p></aside>
    
-   <p class="note">Refer to <a href="https://www.w3.org/WAI/WCAG21/Understanding/conformance#text-alternatives">Understanding Text Alternatives</a> for more information.
+   <p class="note">Refer to <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance#text-alternatives">Understanding Text Alternatives</a> for more information.
    </p>
    
 </dd>


### PR DESCRIPTION
The links in the Key Terms section of the Understanding WCAG 2.2 Docs incorrectly reference Understanding WCAG 2.1.
e.g.: <https://www.w3.org/WAI/WCAG22/Understanding/non-text-content#dfn-text-alternative>

This PR might fix not only the Key Terms sections in Understanding documents but also WCAG 2.2 §6. Glossary.