### PR TITLE
Specify WCAG-2.1 branch in respec github config

### DIFF
--- a/guidelines/respec-config.js
+++ b/guidelines/respec-config.js
@@ -41,7 +41,10 @@ var respecConfig = {
   
   // Name of the WG
   group: "ag",
-  github: "w3c/wcag",
+  github: {
+    repoURL: "https://github.com/w3c/wcag",
+    branch: "WCAG-2.1"
+  },
 	
 	// editors, add as many as you like
 	// only "name" is required


### PR DESCRIPTION
Refs #1808.

This updates the respec config for WCAG 2.1 to reference this `WCAG-2.1` branch, which impacts the commit history link included in the details at the top of the document.

[Preview](https://raw.githack.com/w3c/wcag/refs/heads/kgf-wcag21-github-branch/guidelines/index.html)