### PR TITLE
Backport fixes for examples in 2.1 recommendation

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -422,7 +422,7 @@
             	<section id="cc3">
                     <h3>Complete processes</h3>
                     <p>When a <a>Web page</a> is one of a series of Web pages presenting a <a>process</a> (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all Web pages in the process conform at the specified level or better. (Conformance is not possible at a particular level if any page in the process does not conform at that level or better.)</p>
-                    <p class="example">An online store has a series of pages that are used to select and purchase products. All pages in the series from start to finish (checkout) conform in order for any page that is part of the process to conform.</p>
+                    <aside class="example"><p>An online store has a series of pages that are used to select and purchase products. All pages in the series from start to finish (checkout) conform in order for any page that is part of the process to conform.</p></aside>
                 </section>
 
             	<!-- This section is quoted in Understanding Conformance. If updated, the update needs to be copied there. -->

--- a/script/wcag.js
+++ b/script/wcag.js
@@ -82,10 +82,71 @@ function termTitles() {
 	});	
 }
 
+// number notes if there are multiple per section
+function numberNotes() {
+	var sectionsWithNotes = new Array();
+	document.querySelectorAll(".note").forEach(function(note) {
+		var container = note.closest("dd");
+		if (container == null) container = note.closest("section");
+		sectionsWithNotes.push(container);
+	});
+	
+	sectionsWithNotes.forEach(function(sec) {
+		if (sec.noteprocessed) return;
+		var notes = sec.querySelectorAll('.note');
+		// no notes, shouldn't happen
+		if (notes.length == 0) return;
+		// one note, leave alone
+		if (notes.length == 1) return;
+		// more than one note, number them
+		if (notes.length > 1) {
+			var count = 1;
+			sec.querySelectorAll(".note").forEach(function(note) {
+				var span = note.querySelector(".note-title span");
+				span.textContent = "Note " + count;
+				count++;
+			});
+		}
+		sec.noteprocessed = true;
+	});
+}
+
+// change the numbering of examples to remove number from lone examples in a section, and restart numbering for multiple in each section
+function renumberExamples() {
+	var sectionsWithExamples = new Array();
+	document.querySelectorAll(".example").forEach(function(example) {
+		var container = example.closest("dd"); // use dd container if present
+		if (container == null) container = example.closest("section"); // otherwise section
+		sectionsWithExamples.push(container);
+	});
+	
+	sectionsWithExamples.forEach(function(sec) {
+		if (sec.exprocessed) return;
+		var examples = sec.querySelectorAll(".example");
+		// no examples, shouldn't happen
+		if (examples.length == 0) return;
+		// one example, remove the numbering
+		// more than one example, number them
+		else {
+			var count = 1;
+			var rmOrAdd = examples.length == 1 ? "rm" : "add";
+			sec.querySelectorAll(".example").forEach(function(example) {
+				var marker = example.querySelector(".marker");
+				if (rmOrAdd == "rm") marker.textContent = "Example";
+				else marker.textContent = "Example " + count;
+				count++;
+			});
+		}
+		sec.exprocessed = true;
+	});
+}
+
 // scripts after Respec has run
 function postRespec() {
 	addTextSemantics();
 	swapInDefinitions();
 	termTitles();
 	linkUnderstanding();
+	numberNotes();
+	renumberExamples();
 }


### PR DESCRIPTION
Fixes #2849.

This resolves 2 issues:

- One example under 5.2.3 missing the leading "Example" text
  - This was fixed in `main` by #2719, but was incompletely backported
- Example numbering in Glossary running on consecutively between definitions
  - This was fixed in `main` by #3278, but was never backported at all

[Preview](https://raw.githack.com/w3c/wcag/kgf-wcag21-tr-examples/guidelines/index.html)