### PR TITLE
Update WCAG-2.1 github action platform from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/21ed-publish.yaml
+++ b/.github/workflows/21ed-publish.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   main:
     name: deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This update is equivalent to #4228, but for the action on the WCAG-2.1 branch, which we overlooked.