### PR TITLE
Typo: Change all instances of dismissable to dismissible

### DIFF
--- a/guidelines/wcag.json
+++ b/guidelines/wcag.json
@@ -3457,7 +3457,7 @@
 		"TECH:future-content-on-hover-or-focus-1"
 		,
 		"title": 
-		"Failure to make content dismissable without moving pointer hover or keyboard focus (Potential future technique)"
+		"Failure to make content dismissible without moving pointer hover or keyboard focus (Potential future technique)"
 		}
 		,
 		{

--- a/understanding/21/content-on-hover-or-focus.html
+++ b/understanding/21/content-on-hover-or-focus.html
@@ -34,14 +34,14 @@
 
 			<p>There are usually more predictable and accessible means of adding content to the page, which authors are recommended to employ. If an author <em>does</em> choose to make additional content appear and disappear in coordination with hover and keyboard focus, this success criterion specifies three conditions that must be met:</p>
 				<ul>
-					<li>dismissable</li>
+					<li>dismissible</li>
 					<li>hoverable</li>
 					<li>persistent</li>
 				</ul>
 				<p>Each of these is discussed in a separate section.</p>
 
 			<section>
-			<h3>Dismissable</h3>
+			<h3>Dismissible</h3>
 			<p>The intent of this condition is to ensure that the additional content does not interfere with viewing or operating the page's original content. When magnified, the portion of the page visible in the viewport can be significantly reduced. Mouse users frequently move the pointer to pan the magnified viewport and display another portion of the screen. However, almost the entire portion of the page visible in this restricted viewport may trigger the additional content, making it difficult for a user to pan without re-triggering the content. A keyboard means of dismissing the additional content provides a workaround.</p>
 			<p>Alternatively, low vision users who can only navigate via the keyboard do not want the small area of their magnified viewport cluttered with hover text. They need a keyboard method of dismissing something that is obscuring the current focal area.</p>
 			<p>Two methods may be used to satisfy this condition and prevent such interference:</p>
@@ -62,7 +62,7 @@
 			<p>The intent of this condition is to ensure users have adequate time to perceive the additional content after it becomes visible.  Users with disabilities may require more time for many reasons, such as to change magnification, move the pointer, or simply to bring the new content into their visual field.  Once it appears, the content should remain visible until:</p>
 			<ul>
 				<li>The user removes hover or focus from the trigger and the additional content, consistent with the typical user experience;</li>
-				<li>The user dismisses the additional content via the mechanism provided to satisfy the Dismissable condition; or</li>
+				<li>The user dismisses the additional content via the mechanism provided to satisfy the Dismissible condition; or</li>
 				<li>The information conveyed by the additional content becomes invalid, such as a 'busy' message that is no longer valid.</li>
 			</ul>
 			</section>
@@ -90,7 +90,7 @@
 			<h2>Examples</h2>
 
 			<section class="example">
-				<h3>Example 1: Dismissable Tooltip</h3>
+				<h3>Example 1: Dismissible Tooltip</h3>
 				<figure id="figure-mouse-tooltip-below">
 				<img src="img/button-pointer-tooltip.png" alt="Screenshot of a button with a mouse pointer over it, and a tooltip displayed  below the button"/>
 				<img src="img/button-pointer.png" alt="Screenshot of a button with a mouse pointer over it, and no tooltip"/>
@@ -136,7 +136,7 @@
 				<h2>Failure</h2>
 				<ul>
 					<li><a href="../../techniques/failures/F95.html">F95</a></li>
-					<li>Failure to make content dismissable without moving pointer hover or keyboard focus (Potential future technique)</li>
+					<li>Failure to make content dismissible without moving pointer hover or keyboard focus (Potential future technique)</li>
 					<li>Failure to meet by content on hover or focus not remaining visible until dismissed or invalid (Potential future technique)</li>
 				</ul>
 			</section>


### PR DESCRIPTION
This is a clean redo of https://github.com/w3c/wcag/pull/4265 (which seems to have some unforeseen additional changes)