### PR TITLE
Audio description Understanding covers "important" visual content

### DIFF
--- a/guidelines/terms/20/audio-description.html
+++ b/guidelines/terms/20/audio-description.html
@@ -13,7 +13,7 @@
       (See also <a>extended audio description</a>.)
    </p>
    
-   <p class="note">Where all of the <a>video</a> information is already provided in existing <a>audio</a>, no additional audio description is necessary.
+   <p class="note">Where all of the important <a>video</a> information is already provided in existing <a>audio</a>, no additional audio description is necessary.
    </p>
    
    <p class="note">Also called "video description" and "descriptive narration."</p>

--- a/understanding/20/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/20/audio-description-or-media-alternative-prerecorded.html
@@ -57,8 +57,8 @@
       <div class="note">
          
          <p>
-            For 1.2.3, 1.2.5, and 1.2.7, if all of the information in the video track is already
-            provided in the audio track, no audio description is necessary. 
+            For 1.2.3, 1.2.5, and 1.2.7, if all of the important information in the video track is already
+            conveyed in the audio track, no audio description is necessary. 
             
             
          </p>

--- a/understanding/20/audio-description-prerecorded.html
+++ b/understanding/20/audio-description-prerecorded.html
@@ -34,8 +34,8 @@
       <div class="note">
          
          <p>
-            For 1.2.3, 1.2.5, and 1.2.7, if all of the information in the video track is already
-            provided in the audio track, no audio description is necessary. 
+            For 1.2.3, 1.2.5, and 1.2.7, if all of the important information in the video track is already
+            conveyed in the audio track, no audio description is necessary. 
             
             
          </p>


### PR DESCRIPTION
Two changes to the first note in the informative Understanding document:

- add "additional" to match the first change to the definition note.
- swap out the word "provided" in preference for the synonym "conveyed"

This change is made in the belief that is more accurate. For example, if a scene shows something blowing up, and there is the sound of an explosion that matches, it is more accurate to say the sound conveys the visual explosion than to say the sound "provides" the visual explosion.