### PR TITLE
Removed 1.2.7 reference from note 1

### DIFF
--- a/understanding/20/audio-description-or-media-alternative-prerecorded.html
+++ b/understanding/20/audio-description-or-media-alternative-prerecorded.html
@@ -57,7 +57,7 @@
       <div class="note">
          
          <p>
-            For 1.2.3, 1.2.5, and 1.2.7, if all of the important information in the video track is already
+            For 1.2.3 and 1.2.5, if all of the important information in the video track is already
             conveyed in the audio track, no additional audio description is necessary. 
             
             

--- a/understanding/20/audio-description-prerecorded.html
+++ b/understanding/20/audio-description-prerecorded.html
@@ -34,7 +34,7 @@
       <div class="note">
          
          <p>
-            For 1.2.3, 1.2.5, and 1.2.7, if all of the important information in the video track is already
+            For 1.2.3 and 1.2.5, if all of the important information in the video track is already
             conveyed in the audio track, no additional audio description is necessary. 
             
             


### PR DESCRIPTION
This change aligns the guidance in note 1 of the Understanding documents with the SC text for [1.2.7](https://www.w3.org/WAI/WCAG22/Understanding/extended-audio-description-prerecorded.html).

The preamble condition for 1.2.7 reads "Where pauses in foreground audio are insufficient to allow audio descriptions to convey the send of the video...". Based on that preamble, it makes no sense for note 1 to reference 1.2.7, since if all important information is "already conveyed in the audio track", such a video will never meet the preamble condition.

This logic is confirmed by the fact that note 1 does not exist in the 1.2.7 Understanding document.