### PR TITLE
Remove incorrect "not" from 1.3.4 Orientation note

### DIFF
--- a/guidelines/sc/21/orientation.html
+++ b/guidelines/sc/21/orientation.html
@@ -6,6 +6,6 @@
    					
   <p>Content does not restrict its view and operation to a single display orientation, such as portrait or landscape, unless a specific display orientation is <a>essential</a>.</p>
    				
-   <p class="note">Examples where a particular display orientation may be essential are a bank check, a piano application, slides for a projector or television, or virtual reality content where content is not necessarily restricted to landscape or portrait display orientation.</p>
+   <p class="note">Examples where a particular display orientation may be essential are a bank check, a piano application, slides for a projector or television, or virtual reality content where content is necessarily restricted to landscape or portrait display orientation.</p>
    					
 </section>


### PR DESCRIPTION
The "not" was introduced as part of https://github.com/w3c/wcag/commit/f9a2821c2f54bf07e9146b2f30936dd4f3c58989 which rewrote the example from an early draft into simpler language, and in doing so accidentally flipped the meaning from `where binary display orientation is not applicable` to `where content is NOT necessarily restricted to landscape or portrait orientation`

Closes https://github.com/w3c/wcag/issues/4346