### PR TITLE
Fix unclosed </a> tags in understanding pages

### DIFF
--- a/understanding/20/non-text-content.html
+++ b/understanding/20/non-text-content.html
@@ -79,7 +79,7 @@
 
       <section>
          <h3>Note on alternatives matching the language of content</h3>
-         <p>Text alternatives and equivalents should match the human language of the original content (normally the default human language of the page). The <a href="https://www.w3.org/TR/WCAG22/#conformance-reqs">5.2 Conformance Requirements<a> section, through the defined terms used there, states that success criteria be met through accessibility-supported ways (5.2.4), where the technology is used “in the human language of the content.” Where an alternative version is used (5.2.1), it is defined as something that “provides all of the same information and functionality in the same human language.”</p>
+         <p>Text alternatives and equivalents should match the human language of the original content (normally the default human language of the page). The <a href="https://www.w3.org/TR/WCAG22/#conformance-reqs">5.2 Conformance Requirements</a> section, through the defined terms used there, states that success criteria be met through accessibility-supported ways (5.2.4), where the technology is used “in the human language of the content.” Where an alternative version is used (5.2.1), it is defined as something that “provides all of the same information and functionality in the same human language.”</p>
       </section>
       
       <section>

--- a/understanding/20/text-alternatives.html
+++ b/understanding/20/text-alternatives.html
@@ -35,7 +35,7 @@
       
    </section>
    <section><h3>Text alternatives and equivalents match the language of the content</h3>
-      <p>Text alternatives and equivalents should match the human language of the original content (normally the default human language of the page). The <a href="https://www.w3.org/TR/WCAG22/#conformance-reqs">5.2 Conformance Requirements<a> section, through the defined terms used there, states that success criteria be met through accessibility-supported ways (5.2.4), where the technology is used “in the human language of the content.” Where an alternative version is used (5.2.1), it is defined as something that “provides all of the same information and functionality in the same human language.”</p>
+      <p>Text alternatives and equivalents should match the human language of the original content (normally the default human language of the page). The <a href="https://www.w3.org/TR/WCAG22/#conformance-reqs">5.2 Conformance Requirements</a> section, through the defined terms used there, states that success criteria be met through accessibility-supported ways (5.2.4), where the technology is used “in the human language of the content.” Where an alternative version is used (5.2.1), it is defined as something that “provides all of the same information and functionality in the same human language.”</p>
    </section>
    
    <section id="advisory">

--- a/understanding/20/time-based-media.html
+++ b/understanding/20/time-based-media.html
@@ -90,7 +90,7 @@
    </section>
 
    <section><h3>Text alternatives and equivalents match the language of the content</h3>
-      <p>Text alternatives and equivalents should match the human language of the original content (normally the default human language of the page). The <a href="https://www.w3.org/TR/WCAG22/#conformance-reqs">5.2 Conformance Requirements<a> section, through the defined terms used there, states that success criteria be met through accessibility-supported ways (5.2.4), where the technology is used “in the human language of the content.” Where an alternative version is used (5.2.1), it is defined as something that “provides all of the same information and functionality in the same human language.”</p>
+      <p>Text alternatives and equivalents should match the human language of the original content (normally the default human language of the page). The <a href="https://www.w3.org/TR/WCAG22/#conformance-reqs">5.2 Conformance Requirements</a> section, through the defined terms used there, states that success criteria be met through accessibility-supported ways (5.2.4), where the technology is used “in the human language of the content.” Where an alternative version is used (5.2.1), it is defined as something that “provides all of the same information and functionality in the same human language.”</p>
       <p>For time-based media, that normally means that where the spoken language of the media is, for example, Spanish, the language used in captions, audio descriptions, and media alternatives will also be Spanish.</p>
          </p>
       </section>


### PR DESCRIPTION
Some of the content added by #4262 contained links that were closed with ``<a>`` tags instead of ``</a>``. That in turn caused large chunks of content to be transformed into hash (``#``) links.

Specifically:
* Understanding Guideline 1.1: Text Alternatives
  * https://w3c.github.io/wcag/understanding/text-alternatives.html#text-alternatives-and-equivalents-match-the-language-of-the-content
* Understanding SC 1.1.1: Non-text Content (Level A)
  * https://w3c.github.io/wcag/understanding/non-text-content.html#note-on-alternatives-matching-the-language-of-content
* Understanding Guideline 1.2: Time-based Media
  * https://w3c.github.io/wcag/understanding/time-based-media.html#text-alternatives-and-equivalents-match-the-language-of-the-content

This resolves it by replacing the affected ``<a>`` tags with ``</a>``.

CC @mbgower

**PS:**
I'm not currently a W3C member. But it should be possible for any member to make this PR merge-able by [marking it as non-substantive](https://github.com/w3c/wcag/pull/3540#issuecomment-2207050405).