### PR TITLE
Update understanding conformance and technique G73 to remove mention of `longdesc`

### DIFF
--- a/techniques/general/G73.html
+++ b/techniques/general/G73.html
@@ -4,9 +4,7 @@
       <p>Applies to all technologies</p>
    </section><section id="description"><h2>Description</h2>
       <p>The objective of this technique is to provide a way to link to remote long
-            descriptions in technologies that do not have a long description feature
-            built directly into them (e.g., longdesc) or where the feature is known to
-            not be supported.</p>
+            descriptions.</p>
       <p>With this technique, the long description is provided in another location
             than the non-text content. This could be at another location within the same
             URI or at another URI. A link to that long description is provided that is
@@ -16,11 +14,6 @@
             when to stop reading and return to the main content. If a "Back" button will
             not take the person back to the point from which they jumped, then a link
             back to the non-text content location is provided.</p>
-      <p>This technique was commonly used in HTML before 'longdesc' was added to the
-            specification. In HTML it was called a D-Link because it was usually
-            implemented by putting a D next to images and using the D as a link to the
-            long description. This technique is not technology specific and can be used
-            in any technology that supports links.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>Bar chart</h3>

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -109,12 +109,10 @@
          </p>
          
          <p>Sometimes, supplemental information may be available from another page for information
-            on a page. The longdesc attribute in HTML is an example. With longdesc, a long description of a graphic might be on a separate page that the user can jump
-            to from the page with the graphic. This makes it clear that such content is considered
-            part of the web page, so that requirement #2 is satisfied for the combined set of
-            web pages considered as a single web page. Alternatives can also be provided on the
-            same page. For example creating an equivalent to a user interface control.
-            
+            on a page. For instance, a graphic may have a link to a longer description on a separate
+            page. Such content is considered part of the web page, so that requirement #2 is satisfied
+            for the combined set of web pages considered as a single web page. Alternatives can also
+            be provided on the same page. For example creating an equivalent to a user interface control.
          </p>
          
          <div class="note">


### PR DESCRIPTION
The attribute is deprecated, so shouldn't be mentioned/referenced.

Closes https://github.com/w3c/wcag/issues/4243