### PR TITLE
Fix year in URL to previous version in changelog

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -728,7 +728,7 @@
     		<h2>Change Log</h2>
     		<p>This section shows changes for WCAG 2.1 since its publication as a W3C Recommendation. These changes are also recorded as <a href="https://www.w3.org/WAI/WCAG21/errata/">errata</a>.</p>
 
-        <p>Changes since the <a href="https://www.w3.org/TR/2023/REC-WCAG21-20241212/">W3C Recommendation of 12 December 2024</a>:</p>
+        <p>Changes since the <a href="https://www.w3.org/TR/2024/REC-WCAG21-20241212/">W3C Recommendation of 12 December 2024</a>:</p>
         <ul>
           <li>
             Updated content to fully reflect the changes listed under "Changes since the W3C Recommendation of 21 September 2023";


### PR DESCRIPTION
@iadawn spotted this mistake in the URL intended to point to the soon-to-be-previous publication of WCAG 2.1, which went unnoticed in review of #4179.