### PR TITLE
Tweak language around modal dialogs

### DIFF
--- a/understanding/20/focus-order.html
+++ b/understanding/20/focus-order.html
@@ -134,7 +134,8 @@
          
          <li>A web page implements modal dialogs via scripting. When the trigger button is activated,
             a dialog opens and focus is set within the dialog. As
-            long as the dialog is open, focus is limited to the elements of the dialog. When the
+            long as the dialog is open, focus is generally limited to the elements of the dialog (though,
+            depending on the implementation, focus may also cycle through the user agent controls). When the
             dialog is dismissed, focus returns to the button or the element following the button.
          </li>
          

--- a/understanding/20/no-keyboard-trap.html
+++ b/understanding/20/no-keyboard-trap.html
@@ -64,7 +64,7 @@
                prior to the applet as well as within the applet itself.</dd>
          <dt>A modal dialog box</dt>
          <dd>A web application brings up a dialog box. At the bottom of the dialog are two buttons,
-               Cancel and OK. When the dialog has been opened, focus is trapped within the dialog;
+               Cancel and OK. When the dialog has been opened, focus is generally trapped within the dialog:
                tabbing from the last control in the dialog takes focus to the first control in the
                dialog. The dialog is dismissed by activating the Cancel button or the OK button.</dd>
       </dl>


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/4185

Note that this only softens/expands some of the example language in the understanding documents. The original issue #4185 seems to conflate non-normative examples in a non-normative document with requirements of how modal dialogs should be implemented ... they are not. They provide examples of appropriate focus order and absence of keyboard traps. They are not the only ways in which focus order or absence of keyboard traps can be achieved. Examples are non-exhaustive, and there is no need - in my view - to expand these further to specifically address variations that result from different behaviours related to `<dialog>`