### PR TITLE
Replace mentions of "WCAG 2.0" with "WCAG 2"

### DIFF
--- a/techniques/client-side-script/SCR38.html
+++ b/techniques/client-side-script/SCR38.html
@@ -31,7 +31,7 @@
       <section class="example">
 				<h3>Using JavaScript</h3>
 				<p>The example uses JavaScript in the "accToggle.js" file to store the initial pre-enhanced version of the web page, created solely from the HTML in the source code, so that it can act as a "conforming alternate version" for any later enhanced versions of the web page; and inserts a toggle link into all enhanced versions of the web page which allows a user to revert the web page back to the stored pre-enhanced "Conforming Alternate Version". Note: The "sayhello.js" file is simply there as an example payload external file, and is to be replaced by any other external scripts which are desired.</p>
-				<p>The script in the acctoggle.js file stores the pre-enhanced version - assigning the version the url postfix #accessible. Clicking the "WCAG 2.0 conforming alternate version" link (inserted as the first child of the <code class="language-html">body</code> element in any enhanced versions) changes the url to include the postfix "#accessible" which then resets the html located in the <code class="language-html">body</code> element and the <code class="language-html">head</code> element to pre-enhanced code. The pre-enhanced state can be reached from the link, or directly from a url typed into the browser. In addition, a link is inserted into the pre-enhanced "Conforming Alternate Version" which allows the user to re-enhance the web page (something which can also be done using the web browser's back button).</p>
+				<p>The script in the acctoggle.js file stores the pre-enhanced version - assigning the version the url postfix #accessible. Clicking the "WCAG 2 conforming alternate version" link (inserted as the first child of the <code class="language-html">body</code> element in any enhanced versions) changes the url to include the postfix "#accessible" which then resets the html located in the <code class="language-html">body</code> element and the <code class="language-html">head</code> element to pre-enhanced code. The pre-enhanced state can be reached from the link, or directly from a url typed into the browser. In addition, a link is inserted into the pre-enhanced "Conforming Alternate Version" which allows the user to re-enhance the web page (something which can also be done using the web browser's back button).</p>
 				<section id="the-javscript">
 				<h4>acctoggle.js JavaScript:</h4>
 <pre xml:space="preserve"><code class="language-javascript">window.onload = function(event) {
@@ -56,7 +56,7 @@ var setup = function() {
   var nel = document.createElement("a");
   nel.id = "acctoggle";
   nel.setAttribute("href", "#accessible");
-  nel.innerHTML = "WCAG 2.0 conforming alternate version";
+  nel.innerHTML = "WCAG 2 conforming alternate version";
   document.body.insertBefore(nel, document.body.firstChild);
 
   // payload
@@ -122,7 +122,7 @@ change.innerText = "Hello";</code></pre>
 			<h3>Procedure</h3>
 			<ol>
 				<li>Check enhanced versions of the web page contain a link to the "Conforming Alternate Version".</li>
-				<li>Check that the alternate version is a <a>conforming alternate version</a> of the original page and that it conforms to WCAG 2.0 at the claimed conformance level.</li>
+				<li>Check that the alternate version is a <a>conforming alternate version</a> of the original page and that it conforms to WCAG 2 at the claimed conformance level.</li>
 			</ol>
     </section>
     <section class="results">

--- a/techniques/flash/FLASH18.html
+++ b/techniques/flash/FLASH18.html
@@ -142,7 +142,7 @@
       <section class="procedure"><h3>Procedure</h3>
          <p>For Flash movies that automatically start playing sound after   loading: </p>
          <ol>
-            <li> Confirm that an HTML control that conforms to WCAG 2.0 is placed at the   beginning of the document's tab order </li>
+            <li> Confirm that an HTML control that conforms to WCAG 2 is placed at the   beginning of the document's tab order </li>
             <li> If there is no HTML-based control, confirm that an accessible   control is placed at the beginning of the Flash movie's tab order. </li>
             <li> Activate the HTML or Flash-based control </li>
             <li> Verify that audio playback stops </li>

--- a/techniques/general/G101.html
+++ b/techniques/general/G101.html
@@ -14,7 +14,7 @@
       <section class="example">
          <h3>A term used in a restricted way</h3>
          
-            <p>The word "technology" is widely used to cover everything from the stone tools used by early humans to contemporary digital devices such as cell phones.  But in WCAG 2.0, the word technology is used in a more restricted way:  it means a mechanism for encoding instructions to be rendered, played or executed by user agents, including  markup languages, data formats, and programming languages used in producing and delivering Web content.</p>
+            <p>The word "technology" is widely used to cover everything from the stone tools used by early humans to contemporary digital devices such as cell phones.  But in WCAG 2, the word technology is used in a more restricted way:  it means a mechanism for encoding instructions to be rendered, played or executed by user agents, including  markup languages, data formats, and programming languages used in producing and delivering Web content.</p>
          
       </section>
       <section class="example">

--- a/techniques/general/G136.html
+++ b/techniques/general/G136.html
@@ -15,7 +15,7 @@
             <li>Determine if the page contains a link to a conforming alternate version of the page.</li>
             <li>Determine if the alternate version is a
                   <a>conforming alternate version</a>
-                  of the original page and that it conforms to WCAG 2.0 at the claimed conformance level.</li>
+                  of the original page and that it conforms to WCAG 2 at the claimed conformance level.</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>

--- a/techniques/general/G151.html
+++ b/techniques/general/G151.html
@@ -2,7 +2,7 @@
       <p>All technologies that present live audio-only information</p>
    </section><section id="description"><h2>Description</h2>
       <p>The objective of this technique is to provide a transcript or script if the live audio content is following a set script. Because it is prepared in advance, the script can be more accurate and complete than live transcription. However, the script will not be synchronized with the audio as it plays. Live audio should not deviate from the script for this technique.</p>
-      <p>With this technique, a link to the transcript or script is provided and should conform to WCAG 2.0 and could either be included at another location on the same web page or at another URI.</p>
+      <p>With this technique, a link to the transcript or script is provided and should conform to WCAG 2 and could either be included at another location on the same web page or at another URI.</p>
    </section><section id="examples"><h2>Examples</h2>
       <ul>
          <li>A live radio play of a fringe theatre group is being broadcast to the Web. As the actors stick largely to a set script, and the budget for the program is small, the producers provide a link (with the playwright's permission) to the script of the play in HTML.</li>

--- a/techniques/html/H60.html
+++ b/techniques/html/H60.html
@@ -14,7 +14,7 @@ obsoleteSince: 20
           easily.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
-         <h3> The WCAG 2.0 Glossary. </h3>
+         <h3> The WCAG 2 Glossary. </h3>
          <pre xml:space="preserve"> &lt;link rel="glossary" href="https://www.w3.org/TR/WCAG20/#glossary"&gt;</pre>
       </section>
    </section><section id="tests"><h2>Tests</h2>

--- a/techniques/pdf/PDF13.html
+++ b/techniques/pdf/PDF13.html
@@ -32,7 +32,7 @@
       <p>Authors can replace the default link text by providing an <code>/Alt</code> entry
     				for the <code>Link</code> tag. When the <code>Link</code> tag has an <code>/Alt</code> entry, screen readers ignore the value of any visible text objects in the <code>Link</code> tag and use the <code>/Alt</code> entry value for the link text.</p>
       <p>The simplest way to provide context-independent link text that complies
-    				with the WCAG 2.0 success criteria is to create them when authoring
+    				with the WCAG 2 success criteria is to create them when authoring
     				the document, before conversion to PDF. In some cases, it may not be
     				possible to create the links using the original authoring tool. When editing PDF documents with Adobe Acrobat Pro, the best way to create accessible links is to use the Create Link command.</p>
       <p>Authors should make sure that the alternate text makes sense in context of the screen text before and after the link.</p>

--- a/understanding/20/accessibility-support-documenting.html
+++ b/understanding/20/accessibility-support-documenting.html
@@ -9,7 +9,7 @@
    			
    			
    <p>The documentation of accessibility support for uses of a web technology  provides
-      the information needed to determine whether it is possible to  satisfy the WCAG 2.0
+      the information needed to determine whether it is possible to  satisfy the WCAG 2
       Success Criteria for a particular environment. 
    </p>
    			

--- a/understanding/20/meaningful-sequence.html
+++ b/understanding/20/meaningful-sequence.html
@@ -62,7 +62,7 @@
          
          <li>Providing a particular linear order is only required where it affects meaning.</li>
          
-         <li>There may be more than one order that is "correct" (according to the WCAG 2.0 definition).</li>
+         <li>There may be more than one order that is "correct" (according to the WCAG 2 definition).</li>
          
          <li>Only one correct order needs to be provided.</li>
          

--- a/understanding/20/seizures.html
+++ b/understanding/20/seizures.html
@@ -22,7 +22,7 @@
       
       
       <p>The objective of this guideline is to ensure that content that is marked as conforming
-         to WCAG 2.0 avoids the types of flash that are most likely to cause seizure when viewed
+         to WCAG 2 avoids the types of flash that are most likely to cause seizure when viewed
          even for a second or two.
       </p>
       

--- a/understanding/20/understanding-metadata.html
+++ b/understanding/20/understanding-metadata.html
@@ -8,7 +8,7 @@
    <h1>Understanding Metadata</h1>
    			
    			
-   <p>This section discusses metadata techniques that can be employed to  satisfy WCAG 2.0
+   <p>This section discusses metadata techniques that can be employed to  satisfy WCAG 2
       success criteria. For more information about metadata  see resources below. 
    </p>
    			

--- a/understanding/20/unusual-words.html
+++ b/understanding/20/unusual-words.html
@@ -73,8 +73,8 @@
                materials in the order most likely to bring up the right definition. This controls
                the order to follow when searching for definitions.)</dd>
          <dt>Including definitions in the glossary</dt>
-         <dd>WCAG 2.0 uses the word "text" in a specific way. Thus, when the word "text" is used
-               within WCAG 2.0 it is linked to the definition of "text" provided in a glossary within
+         <dd>WCAG 2 uses the word "text" in a specific way. Thus, when the word "text" is used
+               within WCAG 2 it is linked to the definition of "text" provided in a glossary within
                the same web page.</dd>
          <dt>The specific definition of a word is provided at the bottom of the page</dt>
          <dd>The internal link from the word to the corresponding definition is also provided within the page.</dd>

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -1050,7 +1050,7 @@
                <li>
                   										                    
                   <a href="../Techniques/general/G136">Providing a link at the beginning of the nonconforming content that points to an alternate
-                     version that does meet WCAG 2.0 Level A Success Criteria
+                     version that does meet WCAG 2 Level A Success Criteria
                   </a>
                   									                  
                </li>


### PR DESCRIPTION
Follow-up to https://github.com/w3c/wcag/pull/3588 where we held off updating mentions because, if i recall correctly, at the time older versions of the spec were also being generated from the same sources. As this has now been addressed, it may make  sense to revisit this.

https://github.com/w3c/wcag/issues/4328#issuecomment-2794872091

This is a more comprehensive update compared to https://github.com/w3c/wcag/pull/4361