### PR TITLE
Update errata/21.html for previous publications

### DIFF
--- a/errata/21.html
+++ b/errata/21.html
@@ -52,7 +52,52 @@
       </section>
     </section>
 
-{%- assign trDate = "2024-12-12" -%}
+    {%- assign trDate = "2024-12-12" -%}
+    {%- capture trUrl -%}
+      https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG{{ page.fileSlug }}-{{ trDate | replace: "-", "" }}/
+    {%- endcapture -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata have been recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <ul>
+          <li>
+            2025-03-20:
+            Making editorial changes to improve consistent use of the terms
+            "success criteria/criterion", "web", "website", and "web page"
+            ({% gh "d920ac2" %})
+          </li>
+          <li>
+            2025-03-20:
+            In the definition for <a href="{{ trUrl }}#dfn-single-pointer">single pointer</a>,
+            updating to further enumerate interaction types and distinguish input modalities.
+            ({% gh "cec6f8e" %}, {% gh "e51f2b1" %})
+          </li>
+          <li>
+            2025-03-20:
+            In <a href="{{ trUrl }}#abstract">Abstract</a>, modifying language regarding devices.
+            ({% gh "13b37d7" %})
+          </li>
+          <li>
+            2025-03-20:
+            In the definition for <a href="{{ trUrl }}#dfn-used-in-an-unusual-or-restricted-way">used in an unusual or restricted way</a>,
+            genericizing WCAG version reference from "2.1" to "2".
+            ({% gh "9bfa2aa" %})
+          </li>
+          <li>
+            2025-03-20:
+            Making editorial changes to improve consistent use of definitions in the success criteria
+            ({% gh "8a5e642" %}, {% gh "e3ff8cd" %})
+          </li>
+        </ul>
+      </section>
+    </section>
+
+    {%- assign trDate = "2023-09-21" -%}
     {%- capture trUrl -%}
       https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG{{ page.fileSlug }}-{{ trDate | replace: "-", "" }}/
     {%- endcapture -%}
@@ -67,36 +112,9 @@
         <ul>
           <li>
             2024-11-19:
-            Making editorial changes to improve consistent use of the terms
-            "success criteria/criterion", "web", "website", and "web page"
-            ({% gh "#4080" %})
-          </li>
-          <li>
-            2024-11-19:
-            In the definition for <a href="{{ trUrl }}#dfn-single-pointer">single pointer</a>,
-            updating to further enumerate interaction types and distinguish input modalities.
-            ({% gh "#4070" %}, {% gh "#3536" %})
-          </li>
-          <li>
-            2024-11-19:
             In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>,
             correcting the word <span lang="fr">"dissement"</span> to <span lang="fr">"arrondissement"</span>.
-            ({% gh "#4034" %})
-          </li>
-          <li>
-            2024-11-19:
-            In <a href="{{ trUrl }}#abstract">Abstract</a>, modifying language regarding devices.
-            ({% gh "#3776" %})
-          </li>
-          <li>
-            2024-11-19:
-            In the definition for <a href="{{ trUrl }}#dfn-used-in-an-unusual-or-restricted-way">used in an unusual or restricted way</a>,
-            genericizing WCAG version reference from "2.1" to "2".
-            ({% gh "#3707" %})
-          </li>
-          <li>
-            2024-11-19:
-            Making editorial changes to improve consistent use of definitions in the success criteria ({% gh "#3038" %})
+            ({% gh "2dd3043" %})
           </li>
         </ul>
       </section>

--- a/errata/21.html
+++ b/errata/21.html
@@ -51,6 +51,56 @@
         <p>No editorial errata have been recorded at present.</p>
       </section>
     </section>
+
+{%- assign trDate = "2024-12-12" -%}
+    {%- capture trUrl -%}
+      https://www.w3.org/TR/{{ trDate | split: "-" | first }}/REC-WCAG{{ page.fileSlug }}-{{ trDate | replace: "-", "" }}/
+    {%- endcapture -%}
+    <section id="since-{{ trDate }}">
+      <h2>Errata since <a href="{{ trUrl }}">{{ trDate | date: "%d %B %Y" }} Publication</a></h2>
+      <section id="substantive-{{ trDate }}">
+        <h3>Substantive Errata</h3>
+        <p>No substantive errata have been recorded at present.</p>
+      </section>
+      <section id="editorial-{{ trDate }}">
+        <h3>Editorial Errata</h3>
+        <ul>
+          <li>
+            2024-11-19:
+            Making editorial changes to improve consistent use of the terms
+            "success criteria/criterion", "web", "website", and "web page"
+            ({% gh "#4080" %})
+          </li>
+          <li>
+            2024-11-19:
+            In the definition for <a href="{{ trUrl }}#dfn-single-pointer">single pointer</a>,
+            updating to further enumerate interaction types and distinguish input modalities.
+            ({% gh "#4070" %}, {% gh "#3536" %})
+          </li>
+          <li>
+            2024-11-19:
+            In <a href="{{ trUrl }}#input-purposes">7. Input Purposes for User Interface Components</a>,
+            correcting the word <span lang="fr">"dissement"</span> to <span lang="fr">"arrondissement"</span>.
+            ({% gh "#4034" %})
+          </li>
+          <li>
+            2024-11-19:
+            In <a href="{{ trUrl }}#abstract">Abstract</a>, modifying language regarding devices.
+            ({% gh "#3776" %})
+          </li>
+          <li>
+            2024-11-19:
+            In the definition for <a href="{{ trUrl }}#dfn-used-in-an-unusual-or-restricted-way">used in an unusual or restricted way</a>,
+            genericizing WCAG version reference from "2.1" to "2".
+            ({% gh "#3707" %})
+          </li>
+          <li>
+            2024-11-19:
+            Making editorial changes to improve consistent use of definitions in the success criteria ({% gh "#3038" %})
+          </li>
+        </ul>
+      </section>
+    </section>
     
     {%- assign trDate = "2018-06-05" -%}
     {%- capture trUrl -%}


### PR DESCRIPTION
This documents the errata that occurred since each of the 2 previous (not current) publications, i.e. the publications in September 2023 and December 2024.

This directly references commit hashes on the WCAG-2.1 branch and their respective dates (which occurred later), rather than referencing the original pull requests and the dates they were merged into main.

https://deploy-preview-4424--wcag2.netlify.app/errata/21