### PR TITLE
Limit Errata table of contents to one level

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -115,10 +115,6 @@ export class CustomLiquid extends Liquid {
         $childList = null;
         $tocList.append(`<li><a href="#${el.attribs.id}">${$(h2El).text()}</a></li>`);
       });
-      $el.find("> h3:first-child").each((_, h3El) => {
-        if (!$childList) $childList = $(`<ol class="toc"></ol>`).appendTo($tocList);
-        $childList.append(`<li><a href="#${el.attribs.id}">${$(h3El).text()}</a></li>`);
-      });
     });
 
     return $.html();


### PR DESCRIPTION
This removes the nested level (containing Substantive and Editorial within each publication section) from the table of contents in each errata document.

@netlify /errata/21.html