### PR TITLE
Update abbreviation.html

### DIFF
--- a/guidelines/terms/20/abbreviation.html
+++ b/guidelines/terms/20/abbreviation.html
@@ -5,7 +5,7 @@
       of the language
    </p>
    
-   <p class="note">This includes initialisms and acronyms where:</p>
+   <p>This includes initialisms and acronyms where:</p>
    
    <ol>
       
@@ -15,7 +15,7 @@
             syllables contained in that name or phrase
          </p>
          
-         <p class="note">Not defined in all languages.</p>
+         <p class="note">Initialisms are not defined in all languages.</p>
          
          <aside class="example"><p>SNCF is a French initialism that contains the initial letters of the <span lang="fr">Société Nationale des Chemins de Fer</span>, the French national railroad.
          </p></aside>


### PR DESCRIPTION
Closes #4436 

Removed note class on first note so that it is now part of the definition.

The numbering of notes appears to be done by code, so I have just left the other two notes to be autonumbered, although I maintain that note numbering should not span nested material, especially where a subsequent note is actually referring to the hierarchically higher material.