### PR TITLE
Fix typos and clarify “starts automatically” in 2.2.2 Pause, Stop, Hide Understanding

### DIFF
--- a/understanding/20/pause-stop-hide.html
+++ b/understanding/20/pause-stop-hide.html
@@ -92,7 +92,7 @@
       <div class="note">
          <p>This success criterion is specifically concerned with moving, blinking, scrolling, and
             auto-updating visual content. For audio content that starts automatically, refer to <a href="audio-control">1.4.2 Audio Control</a>.</p>
-         <p>Content <em>starts automatically</em> when the its moving/blinking/scrolling/auto-updating starts without direct user interaction (such as activating a button). Indirect interactions include focusing/hovering over an element or scrolling an element into view. Content that starts automatically this way is also a potential failure of <a href="animation-from-interactions">2.3.3 Animation from Interactions</a>.</p>
+         <p>Content <em>starts automatically</em> when the moving/blinking/scrolling/auto-updating begins without direct user interaction (such as activating a button). Indirect interactions include focusing/hovering over an element or scrolling an element into view. Content that starts automatically this way is also a potential failure of <a href="animation-from-interactions">2.3.3 Animation from Interactions</a>.</p>
       </div>
 
       <p>It is important to note that the terms "blinking" and "flashing" can sometimes refer to the same content.</p>


### PR DESCRIPTION
Previously, the word provide was used twice (typo) and the link to 2.3.3 Animation from Interactions pointed to a non-existing URL and was titled “2.3.3 Animation from Interaction”.

This was one long sentence with two parentheses before, and it was difficult to decipher. This is an attempt to make it easier to read.

## Before

```html
<p>Moving, blinking, scrolling content that starts automatically because of a general user interaction (such as focusing/hovering over an element,
            or scrolling the page), rather than as a result of an intentional <em>activation</em> (such as activating a button),
            and which doesn't provide provide a way to Pause, Stop, or Hide, will fail this Criterion, and potentially
            <a href="animation=from=interaction">2.3.3 Animation from Interaction</a>.</p>
```

## After

```html
<p>Content <em>starts automatically</em> when the moving/blinking/scrolling/auto-updating 
begins without direct user interaction (such as activating a button). Indirect interactions 
include focusing/hovering over an element or scrolling an element into view. Content that 
starts automatically this way is also a potential failure of 
<a href="animation-from-interactions">2.3.3 Animation from Interactions</a>.</p>
```
