### PR TITLE
Minor errata for 1.4.13 Content on Hover or Focus

### DIFF
--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -4,7 +4,7 @@
    					
    <p class="conformance-level">AA</p>
        
-    	<p>Where receiving and then removing pointer hover or keyboard focus triggers additional content to become visible and then hidden, the following are true:</p>
+    	<p>Where receiving and then removing pointer hover or keyboard focus triggers additional content to become visible and then hidden, all of the following are true:</p>
 
   <dl>
 


### PR DESCRIPTION
Closes: #4303

Description: updated 1.4.13 Content on Hover or Focus, to clarify that all the requirements must be met.