### PR TITLE
Check TypeScript during check-files workflow

### DIFF
--- a/.github/workflows/check-files.yaml
+++ b/.github/workflows/check-files.yaml
@@ -42,6 +42,13 @@ jobs:
             echo "::notice title=Mixed TR and informative docs changes::Please submit changes to TR space separately from changes to informative docs."
             echo "CHECK_FAILED=1" >> "$GITHUB_ENV"
           fi
+      - name: Check TypeScript
+        run: |
+          npm ci
+          if test $(npx tsc | wc -l) -gt 0; then
+            echo '::notice title=Branch contains TypeScript errors::Run `npm run check` locally for details.'
+            echo "CHECK_FAILED=1" >> "$GITHUB_ENV"
+          fi
       - name: Reflect status
         run: |
           test ! $CHECK_FAILED


### PR DESCRIPTION
This adds a `tsc` run to the workflow that performs various file checks on pull requests.

As of now this only really impacts work on the build system, but after #4509 it will also be potentially useful for catching any issue in `associatedTechniques` that the build system doesn't go out of its way to validate.

Tested both success and failure. Example failure: https://github.com/kfranqueiro/wcag/actions/runs/16624969588