### PR TITLE
Generate IDs for sectionless headings, and improve/fix existing IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "W3C",
       "dependencies": {
         "@11ty/eleventy": "^3.1.2",
+        "@sindresorhus/slugify": "^2.2.1",
         "axios": "^1.11.0",
         "cheerio": "^1.0.0",
         "glob": "^10.3.16",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "W3C",
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",
+    "@sindresorhus/slugify": "^2.2.1",
     "axios": "^1.11.0",
     "cheerio": "^1.0.0",
     "glob": "^10.3.16",

--- a/understanding/understanding-techniques.html
+++ b/understanding/understanding-techniques.html
@@ -44,7 +44,7 @@
 					<p>From an evaluator's perspective: If web content implements the sufficient techniques for a given criterion correctly and it is <a href="conformance#accessibility-support">accessibility-supported</a> for the content's users, it conforms to that success criterion. (The converse is not true; if content does not implement these sufficient techniques, it does not necessarily fail the success criteria, as explained in <a href="#testing-techniques">Testing Techniques</a> below.)</p>
 				</li>
 			</ul>
-			<p>There may be other ways to meet success criteria besides the sufficient techniques in W3C's <a href="../Techniques/">Techniques for WCAG {{ versionDecimal }}</a> document, as explained in <a href="#understanding-techniques-othertechs">Other Techniques</a> below. <em>(See also <a href="#understanding-techniques-informative">Techniques are Informative</a> above.)</em></p>
+			<p>There may be other ways to meet success criteria besides the sufficient techniques in W3C's <a href="../Techniques/">Techniques for WCAG {{ versionDecimal }}</a> document, as explained in <a href="#other-techniques">Other Techniques</a> below. <em>(See also <a href="#techniques-are-informative">Techniques are Informative</a> above.)</em></p>
 			<section>
 				<h3>Numbered Lists, "AND"</h3>
 				<p> The W3C-documented sufficient techniques are provided in a numbered list where each list item provides a technique or combination of techniques that can be used to meet the success criterion. Where there are multiple techniques on a numbered list item connected by "AND" then all of the techniques must be used to be sufficient. For example, <a href="info-and-relationships#techniques">Sufficient Techniques for 1.3.1</a> has: "G115: Using semantic elements to mark up structure AND H49: Using semantic markup to mark emphasized or special text (HTML)".</p>
@@ -87,7 +87,7 @@
 		<section>
 			<h2>Other Techniques</h2>
 			<p>In addition to the techniques in W3C's <a href="../Techniques/">Techniques for WCAG {{ versionDecimal }}</a> document, <em>there are other ways to meet WCAG {{ versionDecimal }} success criteria</em>. W3C's techniques are not comprehensive and may not cover newer technologies and situations.</p>
-			<p><em>web content does not have to use W3C's published techniques in order to conform to WCAG {{ versionDecimal }}. (See also <a href="understanding-techniques-informative">Techniques are Informative</a> above.)</em></p>
+			<p><em>web content does not have to use W3C's published techniques in order to conform to WCAG {{ versionDecimal }}. (See also <a href="#techniques-are-informative">Techniques are Informative</a> above.)</em></p>
 			<p>Content authors can develop different techniques. For example, an author could develop a technique for HTML5, <a href="https://www.w3.org/WAI/intro/aria">WAI-ARIA</a>, or other new technology. Other organizations may develop sets of techniques to meet WCAG {{ versionDecimal }} success criteria.</p>
 			<p>Any techniques can be sufficient if:</p>
 			<ul>


### PR DESCRIPTION
Fixes #4425.

This adds IDs to headings that aren't the first under their respective parent section, and relies on `@sindresorhus/slugify` to produce headings, with counters when duplicate labels exist. (This library is an existing dependency of Eleventy, so it does not increase `npm install` size.)

This updates _all_ generated IDs to use `slugify` instead of the previous logic that had been ported from the XSLT process. This means some subsection IDs may change; it also means some which were previously inaccessible due to duplicate IDs will be fixed. None of the standard level-2 headings should be impacted.

See [list of diffs for existing IDs](https://gist.github.com/kfranqueiro/871a382c9267b96155af87926ec6b632); any case where an appended number is the only change is fixing a duplicate (i.e. previously unreachable) ID.

I performed extra testing to check for headings that might've been overlooked by the selector I used here, but all of the first-child cases involve headings under sections which will already have IDs.