### PR TITLE
Print tip about restarting dev server for certain cases

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -23,4 +23,4 @@ understanding/*/seizures.html
 **/*-template.html
 
 # HTML files under img will be passthrough-copied
-**/img/*
+**/img/*.html

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -254,7 +254,8 @@ export default async function (eleventyConfig: any) {
     if (runMode === "build" && process.env.WCAG_MODE === "publication") await rimraf("_site");
   });
 
-  eleventyConfig.on("eleventy.after", async ({ dir }: EleventyEvent) => {
+  let hasDisplayedGuidance = false;
+  eleventyConfig.on("eleventy.after", async ({ dir, runMode }: EleventyEvent) => {
     // addPassthroughCopy can only map each file once,
     // but base.css needs to be copied to a 2nd destination
     await copyFile(
@@ -288,6 +289,13 @@ export default async function (eleventyConfig: any) {
       const { generateWcagJson } = await import("11ty/json");
       assertIsWcagVersion(version);
       await writeFile(`${dir.output}/wcag.json`, await generateWcagJson(version));
+    }
+
+    if (runMode === "serve" && !hasDisplayedGuidance) {
+      hasDisplayedGuidance = true;
+      console.log(
+        "If editing TypeScript files or adding new pages, press Enter to restart the dev server."
+      );
     }
   });
 

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -416,13 +416,11 @@ export default async function (eleventyConfig: any) {
   eleventyConfig.addShortcode("gh", (id: string) => {
     if (/^#\d+$/.test(id)) {
       const num = id.slice(1);
-      return `<a href="https://github.com/${GH_ORG}/${GH_REPO}/pull/${num}" aria-label="pull request ${num}">${id}</a>`
-    }
-    else if (/^[0-9a-f]{7,}$/.test(id)) {
+      return `<a href="https://github.com/${GH_ORG}/${GH_REPO}/pull/${num}" aria-label="pull request ${num}">${id}</a>`;
+    } else if (/^[0-9a-f]{7,}$/.test(id)) {
       const sha = id.slice(0, 7); // Truncate in case full SHA was passed
-      return `<a href="https://github.com/${GH_ORG}/${GH_REPO}/commit/${sha}" aria-label="commit ${sha}">${sha}</a>`
-    }
-    else throw new Error(`Invalid SHA or PR ID passed to gh tag: ${id}`);
+      return `<a href="https://github.com/${GH_ORG}/${GH_REPO}/commit/${sha}" aria-label="commit ${sha}">${sha}</a>`;
+    } else throw new Error(`Invalid SHA or PR ID passed to gh tag: ${id}`);
   });
 
   // Renders a section box (used for About this Technique and Guideline / SC)

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -294,7 +294,7 @@ export default async function (eleventyConfig: any) {
     if (runMode === "serve" && !hasDisplayedGuidance) {
       hasDisplayedGuidance = true;
       console.log(
-        "If editing TypeScript files or adding new pages, press Enter to restart the dev server."
+        "The dev server will restart on TypeScript changes. If you are adding new HTML pages, press Enter to restart it manually."
       );
     }
   });


### PR DESCRIPTION
This provides guidance within terminal output when running the dev server, to notify users that the server can be restarted, and should be for certain editing cases.

I originally added restart-on-enter in #4175 mainly for purposes of working with TypeScript in the build system, but it has come to light that this can be useful/necessary in cases such as adding new techniques files while the server is running. (Credit to Adam Page for reporting this.)

Other fixes in this PR:

- Fix formatting elsewhere in `eleventy.config.ts` (this has been bugging me for a while, but I didn't want to cram it into any bigger PRs and risk making them more confusing)
- Constrain `eleventyignore` line for `img` folders to only ignore `*.html`, so changes to images no longer require a dev server restart (this does not cause any build changes)