### PR TITLE
F1 update - Updated procedure and clarified scope

### DIFF
--- a/techniques/failures/F1.html
+++ b/techniques/failures/F1.html
@@ -117,10 +117,16 @@
       <section class="procedure"><h3>Procedure</h3>
          <p>For content which uses CSS for positioning: </p>
          <ol>
-            <li>Remove the style information from the document or turn off use of
-                                    style sheets in the user agent.</li>
-            <li>Check that the reading order of the content is correct and the
-                                    meaning of the content is preserved.</li>
+            <li>Identify the content elements that use CSS for positioning.</li>
+            <li>Check that the reading order of the content is correct and the meaning of the content is preserved in relation to the surrounding page or context, using one of the following methods:
+                <ul>
+                  <li>Code inspection: review the HTML code to determine the logical reading sequence.</li>
+                  <li>Accessibility tree inspection: examine the accessibility tree to confirm the reading order.</li>
+                  <li>Assistive Technology test: use a screen reader to check how the content is read aloud.</li>
+                  <li>Visual test without CSS positioning: remove positioning styles and observe the visual reading sequence.</li>        
+                </ul>
+            </li>
+           
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>


### PR DESCRIPTION
Closes: https://github.com/w3c/wcag/issues/4215

With the goal of closing https://github.com/w3c/wcag/issues/4215 and prevent people from removing all styles, which can (and probably does) lead to invalid testing, I've clarified also the scope of the procedure. 

The key clarification is that the content in scope (which was not clear if it was the single item or the whole page) must be checked in relation to the surrounding page or context. Previously, it could be interpreted that only the “component” or "specific content" needed to be checked in isolation. The intent is to ensure that the reading sequence is correct within the full context of surrounding elements, not just internally within the component.

