### PR TITLE
Build: Only replace title within head (avoid clobbering inline SVGs)

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -349,7 +349,7 @@ export class CustomLiquid extends Liquid {
         }
       }
     } else {
-      const $title = $("title");
+      const $title = $("head title");
 
       if (scope.isTechniques) {
         const isObsolete =


### PR DESCRIPTION
The build was naively assuming that `title` would only ever appear in `head`, which is no longer true if SVGs are inlined. This fixes the selector to only replace `title` within `head`.

Tested against #4573 to confirm it resolves the issue as encountered in that PR.

This does not cause any diffs in the build output on `main`.