### PR TITLE
check-files workflow: Count script/ as TR-side changes

### DIFF
--- a/.github/workflows/check-files.yaml
+++ b/.github/workflows/check-files.yaml
@@ -37,8 +37,8 @@ jobs:
           fi
       - name: Check for isolation of changes to TR space or informative docs
         run: |
-          if test $(git diff origin/${{ github.base_ref }} --numstat | grep -c '\sguidelines/') -gt 0 &&
-          test $(git diff origin/${{ github.base_ref }} --numstat | grep -vc '\sguidelines/') -gt 0; then
+          if test $(git diff origin/${{ github.base_ref }} --numstat | egrep -c '\sguidelines/|\sscript/') -gt 0 &&
+          test $(git diff origin/${{ github.base_ref }} --numstat | egrep -vc '\sguidelines/|\sscript/') -gt 0; then
             echo "::notice title=Mixed TR and informative docs changes::Please submit changes to TR space separately from changes to informative docs."
             echo "CHECK_FAILED=1" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
This fixes a bug in the "isolation of changes to TR space or informative docs" check, which only considered `guidelines` to be TR space, disregarding `scripts` where `wcag.js` is stored.

Testing with the branch for #4590...

Old commands:

```
$ git diff main --numstat | grep -c '\sguidelines'
1
$ git diff main --numstat | grep -vc '\sguidelines'
1
```

New commands:

```
$ git diff main --numstat | egrep -c '\sguidelines/|\sscript/'
2
$ git diff main --numstat | egrep -vc '\sguidelines/|\sscript/'
0
```

(The check fails when the number is nonzero on both sides.)