### PR TITLE
highlight.js: Add missing overrides, update version, and run at build time

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -153,6 +153,22 @@ export class CustomLiquid extends Liquid {
       // Add charset to pages that forgot it
       if (!$("meta[charset]").length) $('<meta charset="UTF-8">').prependTo("head");
 
+      const $missingHljsOverrides = $("pre code:not([class])");
+      if ($missingHljsOverrides.length) {
+        $missingHljsOverrides.each((_, el) => {
+          const code = $(el).html()!.replace(/\n/g, "\\n");
+          const excerpt = `${code.slice(0, 40)}${code.length > 40 ? "..." : ""}`;
+          console.log(
+            `${filepath} missing "language-*" or "no-highlight" class on <pre><code> starting with ${excerpt}`
+          );
+        });
+        if (process.env.ELEVENTY_RUN_MODE === "build") {
+          throw new Error(
+            "Please ensure all code blocks have a highlight.js class (language-* or no-highlight)."
+          );
+        }
+      }
+
       const prependedIncludes = ["header"];
       const appendedIncludes = ["wai-site-footer", "site-footer"];
 

--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -1,3 +1,4 @@
+import hljs from "highlight.js";
 import { Liquid, type Template } from "liquidjs";
 import type { LiquidOptions, RenderOptions } from "liquidjs/dist/liquid-options";
 import compact from "lodash-es/compact";
@@ -168,6 +169,15 @@ export class CustomLiquid extends Liquid {
           );
         }
       }
+
+      $("pre code[class*='language-']").each((_, el) => {
+        const $el = $(el);
+        // Unescape any HTML entities (which were originally needed for client-side highlight.js)
+        const code = $el.html()!.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+        const language = $el.attr("class")!.replace(/^.*language-(\S+).*$/, "$1");
+        $el.html(hljs.highlight(code, { language }).value);
+        $el.addClass("hljs");
+      });
 
       const prependedIncludes = ["header"];
       const appendedIncludes = ["wai-site-footer", "site-footer"];

--- a/_includes/waiscript.html
+++ b/_includes/waiscript.html
@@ -1,8 +1,5 @@
-{% if isTechniques %}{% assign hljsPath = "../" %}{% endif %}
-<link rel="stylesheet" href="{{ hljsPath }}a11y-light.css">
-<script src="{{ hljsPath }}highlight.min.js"></script>
+<link rel="stylesheet" href="{% if isTechniques %}../{% endif %}a11y-light.css">
 <script>
-  hljs.highlightAll();
-  var translationStrings = {}; /* fix WAI JS */
+  var translationStrings = {}; // prevent errors in WAI main.js t() calls
 </script>
 <script src="https://www.w3.org/WAI/assets/scripts/main.js"></script>

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -193,7 +193,6 @@ export default async function (eleventyConfig: any) {
   eleventyConfig.addPassthroughCopy({
     "css/base.css": "techniques/base.css",
     "css/a11y-light.css": "techniques/a11y-light.css",
-    "script/highlight.min.js": "techniques/highlight.min.js",
   });
 
   eleventyConfig.addPassthroughCopy("understanding/*.css");
@@ -224,10 +223,6 @@ export default async function (eleventyConfig: any) {
     await copyFile(
       join(dir.input, "css", "a11y-light.css"),
       join(dir.output, "understanding", "a11y-light.css")
-    );
-    await copyFile(
-      join(dir.input, "script", "highlight.min.js"),
-      join(dir.output, "understanding", "highlight.min.js")
     );
 
     // Output guidelines/index.html and dependencies for PR runs (not for GH Pages or W3C site)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cheerio": "^1.0.0",
         "glob": "^10.3.16",
         "gray-matter": "^4.0.3",
+        "highlight.js": "^11.11.1",
         "liquidjs": "^10.21.0",
         "lodash-es": "^4.17.21",
         "mkdirp": "^3.0.1",
@@ -2788,6 +2789,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cheerio": "^1.0.0",
     "glob": "^10.3.16",
     "gray-matter": "^4.0.3",
+    "highlight.js": "^11.11.1",
     "liquidjs": "^10.21.0",
     "lodash-es": "^4.17.21",
     "mkdirp": "^3.0.1",

--- a/script/highlight.min.js
+++ b/script/highlight.min.js
@@ -1,496 +1,628 @@
 /*!
-  Highlight.js v11.0.1 (git: 1cf31f015d)
-  (c) 2006-2021 Ivan Sagalaev and other contributors
+  Highlight.js v11.11.1 (git: 08cb242e7d)
+  (c) 2006-2025 Josh Goebel <hello@joshgoebel.com> and other contributors
   License: BSD-3-Clause
+  Languages: apache css java javascript php php-template python vbnet xml
  */
-  var hljs=function(){"use strict";var e={exports:{}};function t(e){
-    return e instanceof Map?e.clear=e.delete=e.set=()=>{
-    throw Error("map is read-only")}:e instanceof Set&&(e.add=e.clear=e.delete=()=>{
-    throw Error("set is read-only")
-    }),Object.freeze(e),Object.getOwnPropertyNames(e).forEach((n=>{var i=e[n]
-    ;"object"!=typeof i||Object.isFrozen(i)||t(i)})),e}
-    e.exports=t,e.exports.default=t;var n=e.exports;class i{constructor(e){
-    void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
-    ignoreMatch(){this.isMatchIgnored=!0}}function r(e){
-    return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
-    }function s(e,...t){const n=Object.create(null);for(const t in e)n[t]=e[t]
-    ;return t.forEach((e=>{for(const t in e)n[t]=e[t]})),n}const o=e=>!!e.kind
-    ;class a{constructor(e,t){
-    this.buffer="",this.classPrefix=t.classPrefix,e.walk(this)}addText(e){
-    this.buffer+=r(e)}openNode(e){if(!o(e))return;let t=e.kind
-    ;t=e.sublanguage?"language-"+t:((e,{prefix:t})=>{if(e.includes(".")){
-    const n=e.split(".")
-    ;return[`${t}${n.shift()}`,...n.map(((e,t)=>`${e}${"_".repeat(t+1)}`))].join(" ")
-    }return`${t}${e}`})(t,{prefix:this.classPrefix}),this.span(t)}closeNode(e){
-    o(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
-    this.buffer+=`<span class="${e}">`}}class l{constructor(){this.rootNode={
-    children:[]},this.stack=[this.rootNode]}get top(){
-    return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
-    this.top.children.push(e)}openNode(e){const t={kind:e,children:[]}
-    ;this.add(t),this.stack.push(t)}closeNode(){
-    if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
-    for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
-    walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,t){
-    return"string"==typeof t?e.addText(t):t.children&&(e.openNode(t),
-    t.children.forEach((t=>this._walk(e,t))),e.closeNode(t)),e}static _collapse(e){
-    "string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
-    l._collapse(e)})))}}class c extends l{constructor(e){super(),this.options=e}
-    addKeyword(e,t){""!==e&&(this.openNode(t),this.addText(e),this.closeNode())}
-    addText(e){""!==e&&this.add(e)}addSublanguage(e,t){const n=e.root
-    ;n.kind=t,n.sublanguage=!0,this.add(n)}toHTML(){
-    return new a(this,this.options).value()}finalize(){return!0}}function g(e){
-    return e?"string"==typeof e?e:e.source:null}function d(...e){
-    return e.map((e=>g(e))).join("")}function u(...e){return"("+((e=>{
-    const t=e[e.length-1]
-    ;return"object"==typeof t&&t.constructor===Object?(e.splice(e.length-1,1),t):{}
-    })(e).capture?"":"?:")+e.map((e=>g(e))).join("|")+")"}function h(e){
-    return RegExp(e.toString()+"|").exec("").length-1}
-    const f=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
-    ;function p(e,{joinWith:t}){let n=0;return e.map((e=>{n+=1;const t=n
-    ;let i=g(e),r="";for(;i.length>0;){const e=f.exec(i);if(!e){r+=i;break}
-    r+=i.substring(0,e.index),
-    i=i.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?r+="\\"+(Number(e[1])+t):(r+=e[0],
-    "("===e[0]&&n++)}return r})).map((e=>`(${e})`)).join(t)}
-    const b="[a-zA-Z]\\w*",m="[a-zA-Z_]\\w*",E="\\b\\d+(\\.\\d+)?",x="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",y="\\b(0b[01]+)",w={
-    begin:"\\\\[\\s\\S]",relevance:0},_={scope:"string",begin:"'",end:"'",
-    illegal:"\\n",contains:[w]},v={scope:"string",begin:'"',end:'"',illegal:"\\n",
-    contains:[w]},O=(e,t,n={})=>{const i=s({scope:"comment",begin:e,end:t,
-    contains:[]},n);i.contains.push({scope:"doctag",
-    begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
-    end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
-    ;const r=u("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
-    ;return i.contains.push({begin:d(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i
-    },k=O("//","$"),N=O("/\\*","\\*/"),S=O("#","$");var M=Object.freeze({
-    __proto__:null,MATCH_NOTHING_RE:/\b\B/,IDENT_RE:b,UNDERSCORE_IDENT_RE:m,
-    NUMBER_RE:E,C_NUMBER_RE:x,BINARY_NUMBER_RE:y,
-    RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
-    SHEBANG:(e={})=>{const t=/^#![ ]*\//
-    ;return e.binary&&(e.begin=d(t,/.*\b/,e.binary,/\b.*/)),s({scope:"meta",begin:t,
-    end:/$/,relevance:0,"on:begin":(e,t)=>{0!==e.index&&t.ignoreMatch()}},e)},
-    BACKSLASH_ESCAPE:w,APOS_STRING_MODE:_,QUOTE_STRING_MODE:v,PHRASAL_WORDS_MODE:{
-    begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
-    },COMMENT:O,C_LINE_COMMENT_MODE:k,C_BLOCK_COMMENT_MODE:N,HASH_COMMENT_MODE:S,
-    NUMBER_MODE:{scope:"number",begin:E,relevance:0},C_NUMBER_MODE:{scope:"number",
-    begin:x,relevance:0},BINARY_NUMBER_MODE:{scope:"number",begin:y,relevance:0},
-    REGEXP_MODE:{begin:/(?=\/[^/\n]*\/)/,contains:[{scope:"regexp",begin:/\//,
-    end:/\/[gimuy]*/,illegal:/\n/,contains:[w,{begin:/\[/,end:/\]/,relevance:0,
-    contains:[w]}]}]},TITLE_MODE:{scope:"title",begin:b,relevance:0},
-    UNDERSCORE_TITLE_MODE:{scope:"title",begin:m,relevance:0},METHOD_GUARD:{
-    begin:"\\.\\s*[a-zA-Z_]\\w*",relevance:0},END_SAME_AS_BEGIN:e=>Object.assign(e,{
-    "on:begin":(e,t)=>{t.data._beginMatch=e[1]},"on:end":(e,t)=>{
-    t.data._beginMatch!==e[1]&&t.ignoreMatch()}})});function R(e,t){
-    "."===e.input[e.index-1]&&t.ignoreMatch()}function j(e,t){
-    void 0!==e.className&&(e.scope=e.className,delete e.className)}function A(e,t){
-    t&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
-    e.__beforeBegin=R,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
-    void 0===e.relevance&&(e.relevance=0))}function I(e,t){
-    Array.isArray(e.illegal)&&(e.illegal=u(...e.illegal))}function B(e,t){
-    if(e.match){
-    if(e.begin||e.end)throw Error("begin & end are not supported with match")
-    ;e.begin=e.match,delete e.match}}function T(e,t){
-    void 0===e.relevance&&(e.relevance=1)}const L=(e,t)=>{if(!e.beforeMatch)return
-    ;if(e.starts)throw Error("beforeMatch cannot be used with starts")
-    ;const n=Object.assign({},e);Object.keys(e).forEach((t=>{delete e[t]
-    })),e.keywords=n.keywords,
-    e.begin=d(n.beforeMatch,d("(?=",n.begin,")")),e.starts={relevance:0,
-    contains:[Object.assign(n,{endsParent:!0})]},e.relevance=0,delete n.beforeMatch
-    },D=["of","and","for","in","not","or","if","then","parent","list","value"]
-    ;function P(e,t,n="keyword"){const i=Object.create(null)
-    ;return"string"==typeof e?r(n,e.split(" ")):Array.isArray(e)?r(n,e):Object.keys(e).forEach((n=>{
-    Object.assign(i,P(e[n],t,n))})),i;function r(e,n){
-    t&&(n=n.map((e=>e.toLowerCase()))),n.forEach((t=>{const n=t.split("|")
-    ;i[n[0]]=[e,C(n[0],n[1])]}))}}function C(e,t){
-    return t?Number(t):(e=>D.includes(e.toLowerCase()))(e)?0:1}const H={},$=e=>{
-    console.error(e)},U=(e,...t)=>{console.log("WARN: "+e,...t)},z=(e,t)=>{
-    H[`${e}/${t}`]||(console.log(`Deprecated as of ${e}. ${t}`),H[`${e}/${t}`]=!0)
-    },K=Error();function W(e,t,{key:n}){let i=0;const r=e[n],s={},o={}
-    ;for(let e=1;e<=t.length;e++)o[e+i]=r[e],s[e+i]=!0,i+=h(t[e-1])
-    ;e[n]=o,e[n]._emit=s,e[n]._multi=!0}function X(e){(e=>{
-    e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
-    delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
-    _wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
-    }),(e=>{if(Array.isArray(e.begin)){
-    if(e.skip||e.excludeBegin||e.returnBegin)throw $("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
-    K
-    ;if("object"!=typeof e.beginScope||null===e.beginScope)throw $("beginScope must be object"),
-    K;W(e,e.begin,{key:"beginScope"}),e.begin=p(e.begin,{joinWith:""})}})(e),(e=>{
-    if(Array.isArray(e.end)){
-    if(e.skip||e.excludeEnd||e.returnEnd)throw $("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
-    K
-    ;if("object"!=typeof e.endScope||null===e.endScope)throw $("endScope must be object"),
-    K;W(e,e.end,{key:"endScope"}),e.end=p(e.end,{joinWith:""})}})(e)}function G(e){
-    function t(t,n){return RegExp(g(t),"m"+(e.case_insensitive?"i":"")+(n?"g":""))}
-    class n{constructor(){
-    this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
-    addRule(e,t){
-    t.position=this.position++,this.matchIndexes[this.matchAt]=t,this.regexes.push([t,e]),
-    this.matchAt+=h(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
-    ;const e=this.regexes.map((e=>e[1]));this.matcherRe=t(p(e,{joinWith:"|"
-    }),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
-    ;const t=this.matcherRe.exec(e);if(!t)return null
-    ;const n=t.findIndex(((e,t)=>t>0&&void 0!==e)),i=this.matchIndexes[n]
-    ;return t.splice(0,n),Object.assign(t,i)}}class i{constructor(){
-    this.rules=[],this.multiRegexes=[],
-    this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
-    if(this.multiRegexes[e])return this.multiRegexes[e];const t=new n
-    ;return this.rules.slice(e).forEach((([e,n])=>t.addRule(e,n))),
-    t.compile(),this.multiRegexes[e]=t,t}resumingScanAtSamePosition(){
-    return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,t){
-    this.rules.push([e,t]),"begin"===t.type&&this.count++}exec(e){
-    const t=this.getMatcher(this.regexIndex);t.lastIndex=this.lastIndex
-    ;let n=t.exec(e)
-    ;if(this.resumingScanAtSamePosition())if(n&&n.index===this.lastIndex);else{
-    const t=this.getMatcher(0);t.lastIndex=this.lastIndex+1,n=t.exec(e)}
-    return n&&(this.regexIndex+=n.position+1,
-    this.regexIndex===this.count&&this.considerAll()),n}}
-    if(e.compilerExtensions||(e.compilerExtensions=[]),
-    e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
-    ;return e.classNameAliases=s(e.classNameAliases||{}),function n(r,o){const a=r
-    ;if(r.isCompiled)return a
-    ;[j,B,X,L].forEach((e=>e(r,o))),e.compilerExtensions.forEach((e=>e(r,o))),
-    r.__beforeBegin=null,[A,I,T].forEach((e=>e(r,o))),r.isCompiled=!0;let l=null
-    ;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
-    l=r.keywords.$pattern,
-    delete r.keywords.$pattern),l=l||/\w+/,r.keywords&&(r.keywords=P(r.keywords,e.case_insensitive)),
-    a.keywordPatternRe=t(l,!0),
-    o&&(r.begin||(r.begin=/\B|\b/),a.beginRe=t(r.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
-    r.end&&(a.endRe=t(r.end)),
-    a.terminatorEnd=g(r.end)||"",r.endsWithParent&&o.terminatorEnd&&(a.terminatorEnd+=(r.end?"|":"")+o.terminatorEnd)),
-    r.illegal&&(a.illegalRe=t(r.illegal)),
-    r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((t=>s(e,{
-    variants:null},t)))),e.cachedVariants?e.cachedVariants:Z(e)?s(e,{
-    starts:e.starts?s(e.starts):null
-    }):Object.isFrozen(e)?s(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{n(e,a)
-    })),r.starts&&n(r.starts,o),a.matcher=(e=>{const t=new i
-    ;return e.contains.forEach((e=>t.addRule(e.begin,{rule:e,type:"begin"
-    }))),e.terminatorEnd&&t.addRule(e.terminatorEnd,{type:"end"
-    }),e.illegal&&t.addRule(e.illegal,{type:"illegal"}),t})(a),a}(e)}function Z(e){
-    return!!e&&(e.endsWithParent||Z(e.starts))}const F=r,V=s,q=Symbol("nomatch")
-    ;var J=(e=>{const t=Object.create(null),r=Object.create(null),s=[];let o=!0
-    ;const a="Could not find the language '{}', did you forget to load/include a language module?",l={
-    disableAutodetect:!0,name:"Plain text",contains:[]};let g={
-    ignoreUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
-    languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
-    cssSelector:"pre code",languages:null,__emitter:c};function d(e){
-    return g.noHighlightRe.test(e)}function u(e,t,n,i){let r="",s=""
-    ;"object"==typeof t?(r=e,
-    n=t.ignoreIllegals,s=t.language,i=void 0):(z("10.7.0","highlight(lang, code, ...args) has been deprecated."),
-    z("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
-    s=e,r=t),void 0===n&&(n=!0);const o={code:r,language:s};w("before:highlight",o)
-    ;const a=o.result?o.result:h(o.language,o.code,n,i)
-    ;return a.code=o.code,w("after:highlight",a),a}function h(e,n,r,s){
-    const l=Object.create(null);function c(){if(!k.keywords)return void S.addText(M)
-    ;let e=0;k.keywordPatternRe.lastIndex=0;let t=k.keywordPatternRe.exec(M),n=""
-    ;for(;t;){n+=M.substring(e,t.index)
-    ;const r=_.case_insensitive?t[0].toLowerCase():t[0],s=(i=r,k.keywords[i]);if(s){
-    const[e,i]=s
-    ;if(S.addText(n),n="",l[r]=(l[r]||0)+1,l[r]<=7&&(R+=i),e.startsWith("_"))n+=t[0];else{
-    const n=_.classNameAliases[e]||e;S.addKeyword(t[0],n)}}else n+=t[0]
-    ;e=k.keywordPatternRe.lastIndex,t=k.keywordPatternRe.exec(M)}var i
-    ;n+=M.substr(e),S.addText(n)}function d(){null!=k.subLanguage?(()=>{
-    if(""===M)return;let e=null;if("string"==typeof k.subLanguage){
-    if(!t[k.subLanguage])return void S.addText(M)
-    ;e=h(k.subLanguage,M,!0,N[k.subLanguage]),N[k.subLanguage]=e._top
-    }else e=f(M,k.subLanguage.length?k.subLanguage:null)
-    ;k.relevance>0&&(R+=e.relevance),S.addSublanguage(e._emitter,e.language)
-    })():c(),M=""}function u(e,t){let n=1;for(;void 0!==t[n];){if(!e._emit[n]){n++
-    ;continue}const i=_.classNameAliases[e[n]]||e[n],r=t[n]
-    ;i?S.addKeyword(r,i):(M=r,c(),M=""),n++}}function p(e,t){
-    return e.scope&&"string"==typeof e.scope&&S.openNode(_.classNameAliases[e.scope]||e.scope),
-    e.beginScope&&(e.beginScope._wrap?(S.addKeyword(M,_.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
-    M=""):e.beginScope._multi&&(u(e.beginScope,t),M="")),k=Object.create(e,{parent:{
-    value:k}}),k}function b(e,t,n){let r=((e,t)=>{const n=e&&e.exec(t)
-    ;return n&&0===n.index})(e.endRe,n);if(r){if(e["on:end"]){const n=new i(e)
-    ;e["on:end"](t,n),n.isMatchIgnored&&(r=!1)}if(r){
-    for(;e.endsParent&&e.parent;)e=e.parent;return e}}
-    if(e.endsWithParent)return b(e.parent,t,n)}function m(e){
-    return 0===k.matcher.regexIndex?(M+=e[0],1):(I=!0,0)}function x(e){
-    const t=e[0],i=n.substr(e.index),r=b(k,e,i);if(!r)return q;const s=k
-    ;k.endScope&&k.endScope._wrap?(d(),
-    S.addKeyword(t,k.endScope._wrap)):k.endScope&&k.endScope._multi?(d(),
-    u(k.endScope,e)):s.skip?M+=t:(s.returnEnd||s.excludeEnd||(M+=t),
-    d(),s.excludeEnd&&(M=t));do{
-    k.scope&&!k.isMultiClass&&S.closeNode(),k.skip||k.subLanguage||(R+=k.relevance),
-    k=k.parent}while(k!==r.parent)
-    ;return r.starts&&p(r.starts,e),s.returnEnd?0:t.length}let y={};function w(t,s){
-    const a=s&&s[0];if(M+=t,null==a)return d(),0
-    ;if("begin"===y.type&&"end"===s.type&&y.index===s.index&&""===a){
-    if(M+=n.slice(s.index,s.index+1),!o){const t=Error(`0 width match regex (${e})`)
-    ;throw t.languageName=e,t.badRule=y.rule,t}return 1}
-    if(y=s,"begin"===s.type)return(e=>{
-    const t=e[0],n=e.rule,r=new i(n),s=[n.__beforeBegin,n["on:begin"]]
-    ;for(const n of s)if(n&&(n(e,r),r.isMatchIgnored))return m(t)
-    ;return n.skip?M+=t:(n.excludeBegin&&(M+=t),
-    d(),n.returnBegin||n.excludeBegin||(M=t)),p(n,e),n.returnBegin?0:t.length})(s)
-    ;if("illegal"===s.type&&!r){
-    const e=Error('Illegal lexeme "'+a+'" for mode "'+(k.scope||"<unnamed>")+'"')
-    ;throw e.mode=k,e}if("end"===s.type){const e=x(s);if(e!==q)return e}
-    if("illegal"===s.type&&""===a)return 1
-    ;if(A>1e5&&A>3*s.index)throw Error("potential infinite loop, way more iterations than matches")
-    ;return M+=a,a.length}const _=E(e)
-    ;if(!_)throw $(a.replace("{}",e)),Error('Unknown language: "'+e+'"')
-    ;const v=G(_);let O="",k=s||v;const N={},S=new g.__emitter(g);(()=>{const e=[]
-    ;for(let t=k;t!==_;t=t.parent)t.scope&&e.unshift(t.scope)
-    ;e.forEach((e=>S.openNode(e)))})();let M="",R=0,j=0,A=0,I=!1;try{
-    for(k.matcher.considerAll();;){
-    A++,I?I=!1:k.matcher.considerAll(),k.matcher.lastIndex=j
-    ;const e=k.matcher.exec(n);if(!e)break;const t=w(n.substring(j,e.index),e)
-    ;j=e.index+t}return w(n.substr(j)),S.closeAllNodes(),S.finalize(),O=S.toHTML(),{
-    language:e,value:O,relevance:R,illegal:!1,_emitter:S,_top:k}}catch(t){
-    if(t.message&&t.message.includes("Illegal"))return{language:e,value:F(n),
-    illegal:!0,relevance:0,_illegalBy:{message:t.message,index:j,
-    context:n.slice(j-100,j+100),mode:t.mode,resultSoFar:O},_emitter:S};if(o)return{
-    language:e,value:F(n),illegal:!1,relevance:0,errorRaised:t,_emitter:S,_top:k}
-    ;throw t}}function f(e,n){n=n||g.languages||Object.keys(t);const i=(e=>{
-    const t={value:F(e),illegal:!1,relevance:0,_top:l,_emitter:new g.__emitter(g)}
-    ;return t._emitter.addText(e),t})(e),r=n.filter(E).filter(y).map((t=>h(t,e,!1)))
-    ;r.unshift(i);const s=r.sort(((e,t)=>{
-    if(e.relevance!==t.relevance)return t.relevance-e.relevance
-    ;if(e.language&&t.language){if(E(e.language).supersetOf===t.language)return 1
-    ;if(E(t.language).supersetOf===e.language)return-1}return 0})),[o,a]=s,c=o
-    ;return c.secondBest=a,c}function p(e){let t=null;const n=(e=>{
-    let t=e.className+" ";t+=e.parentNode?e.parentNode.className:""
-    ;const n=g.languageDetectRe.exec(t);if(n){const t=E(n[1])
-    ;return t||(U(a.replace("{}",n[1])),
-    U("Falling back to no-highlight mode for this block.",e)),t?n[1]:"no-highlight"}
-    return t.split(/\s+/).find((e=>d(e)||E(e)))})(e);if(d(n))return
-    ;w("before:highlightElement",{el:e,language:n
-    }),!g.ignoreUnescapedHTML&&e.children.length>0&&(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
-    console.warn("https://github.com/highlightjs/highlight.js/issues/2886"),
-    console.warn(e)),t=e;const i=t.textContent,s=n?u(i,{language:n,ignoreIllegals:!0
-    }):f(i);e.innerHTML=s.value,((e,t,n)=>{const i=t&&r[t]||n
-    ;e.classList.add("hljs"),e.classList.add("language-"+i)
-    })(e,n,s.language),e.result={language:s.language,re:s.relevance,
-    relevance:s.relevance},s.secondBest&&(e.secondBest={
-    language:s.secondBest.language,relevance:s.secondBest.relevance
-    }),w("after:highlightElement",{el:e,result:s,text:i})}let b=!1;function m(){
-    "loading"!==document.readyState?document.querySelectorAll(g.cssSelector).forEach(p):b=!0
-    }function E(e){return e=(e||"").toLowerCase(),t[e]||t[r[e]]}
-    function x(e,{languageName:t}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
-    r[e.toLowerCase()]=t}))}function y(e){const t=E(e)
-    ;return t&&!t.disableAutodetect}function w(e,t){const n=e;s.forEach((e=>{
-    e[n]&&e[n](t)}))}
-    "undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",(()=>{
-    b&&m()}),!1),Object.assign(e,{highlight:u,highlightAuto:f,highlightAll:m,
-    highlightElement:p,
-    highlightBlock:e=>(z("10.7.0","highlightBlock will be removed entirely in v12.0"),
-    z("10.7.0","Please use highlightElement now."),p(e)),configure:e=>{g=V(g,e)},
-    initHighlighting:()=>{
-    m(),z("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
-    initHighlightingOnLoad:()=>{
-    m(),z("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
-    },registerLanguage:(n,i)=>{let r=null;try{r=i(e)}catch(e){
-    if($("Language definition for '{}' could not be registered.".replace("{}",n)),
-    !o)throw e;$(e),r=l}
-    r.name||(r.name=n),t[n]=r,r.rawDefinition=i.bind(null,e),r.aliases&&x(r.aliases,{
-    languageName:n})},unregisterLanguage:e=>{delete t[e]
-    ;for(const t of Object.keys(r))r[t]===e&&delete r[t]},
-    listLanguages:()=>Object.keys(t),getLanguage:E,registerAliases:x,
-    autoDetection:y,inherit:V,addPlugin:e=>{(e=>{
-    e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=t=>{
-    e["before:highlightBlock"](Object.assign({block:t.el},t))
-    }),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=t=>{
-    e["after:highlightBlock"](Object.assign({block:t.el},t))})})(e),s.push(e)}
-    }),e.debugMode=()=>{o=!1},e.safeMode=()=>{o=!0},e.versionString="11.0.1"
-    ;for(const e in M)"object"==typeof M[e]&&n(M[e]);return Object.assign(e,M),e
-    })({}),Y=Object.freeze({__proto__:null});const Q=J
-    ;for(const e of Object.keys(Y)){const t=e.replace("grmr_","")
-    ;Q.registerLanguage(t,Y[e])}return Q}()
-    ;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);hljs.registerLanguage("css",(()=>{"use strict"
-    ;const e=["a","abbr","address","article","aside","audio","b","blockquote","body","button","canvas","caption","cite","code","dd","del","details","dfn","div","dl","dt","em","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","html","i","iframe","img","input","ins","kbd","label","legend","li","main","mark","menu","nav","object","ol","p","q","quote","samp","section","span","strong","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","ul","var","video"],t=["any-hover","any-pointer","aspect-ratio","color","color-gamut","color-index","device-aspect-ratio","device-height","device-width","display-mode","forced-colors","grid","height","hover","inverted-colors","monochrome","orientation","overflow-block","overflow-inline","pointer","prefers-color-scheme","prefers-contrast","prefers-reduced-motion","prefers-reduced-transparency","resolution","scan","scripting","update","width","min-width","max-width","min-height","max-height"],i=["active","any-link","blank","checked","current","default","defined","dir","disabled","drop","empty","enabled","first","first-child","first-of-type","fullscreen","future","focus","focus-visible","focus-within","has","host","host-context","hover","indeterminate","in-range","invalid","is","lang","last-child","last-of-type","left","link","local-link","not","nth-child","nth-col","nth-last-child","nth-last-col","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","past","placeholder-shown","read-only","read-write","required","right","root","scope","target","target-within","user-invalid","valid","visited","where"],o=["after","backdrop","before","cue","cue-region","first-letter","first-line","grammar-error","marker","part","placeholder","selection","slotted","spelling-error"],r=["align-content","align-items","align-self","animation","animation-delay","animation-direction","animation-duration","animation-fill-mode","animation-iteration-count","animation-name","animation-play-state","animation-timing-function","auto","backface-visibility","background","background-attachment","background-clip","background-color","background-image","background-origin","background-position","background-repeat","background-size","border","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-style","border-bottom-width","border-collapse","border-color","border-image","border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width","border-left","border-left-color","border-left-style","border-left-width","border-radius","border-right","border-right-color","border-right-style","border-right-width","border-spacing","border-style","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-style","border-top-width","border-width","bottom","box-decoration-break","box-shadow","box-sizing","break-after","break-before","break-inside","caption-side","clear","clip","clip-path","color","column-count","column-fill","column-gap","column-rule","column-rule-color","column-rule-style","column-rule-width","column-span","column-width","columns","content","counter-increment","counter-reset","cursor","direction","display","empty-cells","filter","flex","flex-basis","flex-direction","flex-flow","flex-grow","flex-shrink","flex-wrap","float","font","font-display","font-family","font-feature-settings","font-kerning","font-language-override","font-size","font-size-adjust","font-smoothing","font-stretch","font-style","font-variant","font-variant-ligatures","font-variation-settings","font-weight","height","hyphens","icon","image-orientation","image-rendering","image-resolution","ime-mode","inherit","initial","justify-content","left","letter-spacing","line-height","list-style","list-style-image","list-style-position","list-style-type","margin","margin-bottom","margin-left","margin-right","margin-top","marks","mask","max-height","max-width","min-height","min-width","nav-down","nav-index","nav-left","nav-right","nav-up","none","normal","object-fit","object-position","opacity","order","orphans","outline","outline-color","outline-offset","outline-style","outline-width","overflow","overflow-wrap","overflow-x","overflow-y","padding","padding-bottom","padding-left","padding-right","padding-top","page-break-after","page-break-before","page-break-inside","perspective","perspective-origin","pointer-events","position","quotes","resize","right","src","tab-size","table-layout","text-align","text-align-last","text-decoration","text-decoration-color","text-decoration-line","text-decoration-style","text-indent","text-overflow","text-rendering","text-shadow","text-transform","text-underline-position","top","transform","transform-origin","transform-style","transition","transition-delay","transition-duration","transition-property","transition-timing-function","unicode-bidi","vertical-align","visibility","white-space","widows","width","word-break","word-spacing","word-wrap","z-index"].reverse()
-    ;return n=>{const a=(e=>({IMPORTANT:{scope:"meta",begin:"!important"},HEXCOLOR:{
-    scope:"number",begin:"#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})"},
-    ATTRIBUTE_SELECTOR_MODE:{scope:"selector-attr",begin:/\[/,end:/\]/,illegal:"$",
-    contains:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},CSS_NUMBER_MODE:{
-    scope:"number",
-    begin:e.NUMBER_RE+"(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
-    relevance:0}}))(n),l=[n.APOS_STRING_MODE,n.QUOTE_STRING_MODE];return{name:"CSS",
-    case_insensitive:!0,illegal:/[=|'\$]/,keywords:{keyframePosition:"from to"},
-    classNameAliases:{keyframePosition:"selector-tag"},
-    contains:[n.C_BLOCK_COMMENT_MODE,{begin:/-(webkit|moz|ms|o)-(?=[a-z])/
-    },a.CSS_NUMBER_MODE,{className:"selector-id",begin:/#[A-Za-z0-9_-]+/,relevance:0
-    },{className:"selector-class",begin:"\\.[a-zA-Z-][a-zA-Z0-9_-]*",relevance:0
-    },a.ATTRIBUTE_SELECTOR_MODE,{className:"selector-pseudo",variants:[{
-    begin:":("+i.join("|")+")"},{begin:"::("+o.join("|")+")"}]},{
-    className:"attribute",begin:"\\b("+r.join("|")+")\\b"},{begin:":",end:"[;}]",
-    contains:[a.HEXCOLOR,a.IMPORTANT,a.CSS_NUMBER_MODE,...l,{
-    begin:/(url|data-uri)\(/,end:/\)/,relevance:0,keywords:{built_in:"url data-uri"
-    },contains:[{className:"string",begin:/[^)]/,endsWithParent:!0,excludeEnd:!0}]
-    },{className:"built_in",begin:/[\w-]+(?=\()/}]},{
-    begin:(s=/@/,((...e)=>e.map((e=>(e=>e?"string"==typeof e?e:e.source:null)(e))).join(""))("(?=",s,")")),
-    end:"[{;]",relevance:0,illegal:/:/,contains:[{className:"keyword",
-    begin:/@-?\w[\w]*(-\w+)*/},{begin:/\s/,endsWithParent:!0,excludeEnd:!0,
-    relevance:0,keywords:{$pattern:/[a-z-]+/,keyword:"and or not only",
-    attribute:t.join(" ")},contains:[{begin:/[a-z-]+(?=:)/,className:"attribute"
-    },...l,a.CSS_NUMBER_MODE]}]},{className:"selector-tag",
-    begin:"\\b("+e.join("|")+")\\b"}]};var s}})());hljs.registerLanguage("xml",(()=>{"use strict";function e(e){
-    return e?"string"==typeof e?e:e.source:null}function n(e){return a("(?=",e,")")}
-    function a(...n){return n.map((n=>e(n))).join("")}function s(...n){
-    return"("+((e=>{const n=e[e.length-1]
-    ;return"object"==typeof n&&n.constructor===Object?(e.splice(e.length-1,1),n):{}
-    })(n).capture?"":"?:")+n.map((n=>e(n))).join("|")+")"}return e=>{
-    const t=a(/[A-Z_]/,a("(?:",/[A-Z0-9_.-]*:/,")?"),/[A-Z0-9_.-]*/),i={
-    className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},c={begin:/\s/,
-    contains:[{className:"keyword",begin:/#?[a-z_][a-z1-9_-]+/,illegal:/\n/}]
-    },r=e.inherit(c,{begin:/\(/,end:/\)/}),l=e.inherit(e.APOS_STRING_MODE,{
-    className:"string"}),g=e.inherit(e.QUOTE_STRING_MODE,{className:"string"}),m={
-    endsWithParent:!0,illegal:/</,relevance:0,contains:[{className:"attr",
-    begin:/[A-Za-z0-9._:-]+/,relevance:0},{begin:/=\s*/,relevance:0,contains:[{
-    className:"string",endsParent:!0,variants:[{begin:/"/,end:/"/,contains:[i]},{
-    begin:/'/,end:/'/,contains:[i]},{begin:/[^\s"'=<>`]+/}]}]}]};return{
-    name:"HTML, XML",
-    aliases:["html","xhtml","rss","atom","xjb","xsd","xsl","plist","wsf","svg"],
-    case_insensitive:!0,contains:[{className:"meta",begin:/<![a-z]/,end:/>/,
-    relevance:10,contains:[c,g,l,r,{begin:/\[/,end:/\]/,contains:[{className:"meta",
-    begin:/<![a-z]/,end:/>/,contains:[c,r,g,l]}]}]},e.COMMENT(/<!--/,/-->/,{
-    relevance:10}),{begin:/<!\[CDATA\[/,end:/\]\]>/,relevance:10},i,{
-    className:"meta",begin:/<\?xml/,end:/\?>/,relevance:10},{className:"tag",
-    begin:/<style(?=\s|>)/,end:/>/,keywords:{name:"style"},contains:[m],starts:{
-    end:/<\/style>/,returnEnd:!0,subLanguage:["css","xml"]}},{className:"tag",
-    begin:/<script(?=\s|>)/,end:/>/,keywords:{name:"script"},contains:[m],starts:{
-    end:/<\/script>/,returnEnd:!0,subLanguage:["javascript","handlebars","xml"]}},{
-    className:"tag",begin:/<>|<\/>/},{className:"tag",
-    begin:a(/</,n(a(t,s(/\/>/,/>/,/\s/)))),end:/\/?>/,contains:[{className:"name",
-    begin:t,relevance:0,starts:m}]},{className:"tag",begin:a(/<\//,n(a(t,/>/))),
-    contains:[{className:"name",begin:t,relevance:0},{begin:/>/,relevance:0,
-    endsParent:!0}]}]}}})());hljs.registerLanguage("markdown",(()=>{"use strict";function n(...n){
-    return n.map((n=>{return(e=n)?"string"==typeof e?e:e.source:null;var e
-    })).join("")}return e=>{const a={begin:/<\/?[A-Za-z_]/,end:">",
-    subLanguage:"xml",relevance:0},i={variants:[{begin:/\[.+?\]\[.*?\]/,relevance:0
-    },{begin:/\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/,
-    relevance:2},{begin:n(/\[.+?\]\(/,/[A-Za-z][A-Za-z0-9+.-]*/,/:\/\/.*?\)/),
-    relevance:2},{begin:/\[.+?\]\([./?&#].*?\)/,relevance:1},{
-    begin:/\[.+?\]\(.*?\)/,relevance:0}],returnBegin:!0,contains:[{
-    className:"string",relevance:0,begin:"\\[",end:"\\]",excludeBegin:!0,
-    returnEnd:!0},{className:"link",relevance:0,begin:"\\]\\(",end:"\\)",
-    excludeBegin:!0,excludeEnd:!0},{className:"symbol",relevance:0,begin:"\\]\\[",
-    end:"\\]",excludeBegin:!0,excludeEnd:!0}]},s={className:"strong",contains:[],
-    variants:[{begin:/_{2}/,end:/_{2}/},{begin:/\*{2}/,end:/\*{2}/}]},c={
-    className:"emphasis",contains:[],variants:[{begin:/\*(?!\*)/,end:/\*/},{
-    begin:/_(?!_)/,end:/_/,relevance:0}]};s.contains.push(c),c.contains.push(s)
-    ;let t=[a,i]
-    ;return s.contains=s.contains.concat(t),c.contains=c.contains.concat(t),
-    t=t.concat(s,c),{name:"Markdown",aliases:["md","mkdown","mkd"],contains:[{
-    className:"section",variants:[{begin:"^#{1,6}",end:"$",contains:t},{
-    begin:"(?=^.+?\\n[=-]{2,}$)",contains:[{begin:"^[=-]*$"},{begin:"^",end:"\\n",
-    contains:t}]}]},a,{className:"bullet",begin:"^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
-    end:"\\s+",excludeEnd:!0},s,c,{className:"quote",begin:"^>\\s+",contains:t,
-    end:"$"},{className:"code",variants:[{begin:"(`{3,})[^`](.|\\n)*?\\1`*[ ]*"},{
-    begin:"(~{3,})[^~](.|\\n)*?\\1~*[ ]*"},{begin:"```",end:"```+[ ]*$"},{
-    begin:"~~~",end:"~~~+[ ]*$"},{begin:"`.+?`"},{begin:"(?=^( {4}|\\t))",
-    contains:[{begin:"^( {4}|\\t)",end:"(\\n)$"}],relevance:0}]},{
-    begin:"^[-\\*]{3,}",end:"$"},i,{begin:/^\[[^\n]+\]:/,returnBegin:!0,contains:[{
-    className:"symbol",begin:/\[/,end:/\]/,excludeBegin:!0,excludeEnd:!0},{
-    className:"link",begin:/:\s*/,end:/$/,excludeBegin:!0}]}]}}})());hljs.registerLanguage("javascript",(()=>{"use strict"
-    ;const e="[A-Za-z$_][0-9A-Za-z$_]*",n=["as","in","of","if","for","while","finally","var","new","function","do","return","void","else","break","catch","instanceof","with","throw","case","default","try","switch","continue","typeof","delete","let","yield","const","class","debugger","async","await","static","import","from","export","extends"],a=["true","false","null","undefined","NaN","Infinity"],t=["Intl","DataView","Number","Math","Date","String","RegExp","Object","Function","Boolean","Error","Symbol","Set","Map","WeakSet","WeakMap","Proxy","Reflect","JSON","Promise","Float64Array","Int16Array","Int32Array","Int8Array","Uint16Array","Uint32Array","Float32Array","Array","Uint8Array","Uint8ClampedArray","ArrayBuffer","BigInt64Array","BigUint64Array","BigInt"],s=["EvalError","InternalError","RangeError","ReferenceError","SyntaxError","TypeError","URIError"],r=["setInterval","setTimeout","clearInterval","clearTimeout","require","exports","eval","isFinite","isNaN","parseFloat","parseInt","decodeURI","decodeURIComponent","encodeURI","encodeURIComponent","escape","unescape"],i=["arguments","this","super","console","window","document","localStorage","module","global"],c=[].concat(r,t,s)
-    ;function o(e){return l("(?=",e,")")}function l(...e){return e.map((e=>{
-    return(n=e)?"string"==typeof n?n:n.source:null;var n})).join("")}return b=>{
-    const g=e,d={begin:/<[A-Za-z0-9\\._:-]+/,end:/\/[A-Za-z0-9\\._:-]+>|\/>/,
-    isTrulyOpeningTag:(e,n)=>{const a=e[0].length+e.index,t=e.input[a]
-    ;"<"!==t?">"===t&&(((e,{after:n})=>{const a="</"+e[0].slice(1)
-    ;return-1!==e.input.indexOf(a,n)})(e,{after:a
-    })||n.ignoreMatch()):n.ignoreMatch()}},u={$pattern:e,keyword:n,literal:a,
-    built_in:c,"variable.language":i
-    },m="\\.([0-9](_?[0-9])*)",E="0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",y={
-    className:"number",variants:[{
-    begin:`(\\b(${E})((${m})|\\.)?|(${m}))[eE][+-]?([0-9](_?[0-9])*)\\b`},{
-    begin:`\\b(${E})\\b((${m})\\b|\\.)?|(${m})\\b`},{
-    begin:"\\b(0|[1-9](_?[0-9])*)n\\b"},{
-    begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b"},{
-    begin:"\\b0[bB][0-1](_?[0-1])*n?\\b"},{begin:"\\b0[oO][0-7](_?[0-7])*n?\\b"},{
-    begin:"\\b0[0-7]+n?\\b"}],relevance:0},_={className:"subst",begin:"\\$\\{",
-    end:"\\}",keywords:u,contains:[]},N={begin:"html`",end:"",starts:{end:"`",
-    returnEnd:!1,contains:[b.BACKSLASH_ESCAPE,_],subLanguage:"xml"}},f={
-    begin:"css`",end:"",starts:{end:"`",returnEnd:!1,
-    contains:[b.BACKSLASH_ESCAPE,_],subLanguage:"css"}},A={className:"string",
-    begin:"`",end:"`",contains:[b.BACKSLASH_ESCAPE,_]},v={className:"comment",
-    variants:[b.COMMENT(/\/\*\*(?!\/)/,"\\*/",{relevance:0,contains:[{
-    begin:"(?=@[A-Za-z]+)",relevance:0,contains:[{className:"doctag",
-    begin:"@[A-Za-z]+"},{className:"type",begin:"\\{",end:"\\}",excludeEnd:!0,
-    excludeBegin:!0,relevance:0},{className:"variable",begin:g+"(?=\\s*(-)|$)",
-    endsParent:!0,relevance:0},{begin:/(?=[^\n])\s/,relevance:0}]}]
-    }),b.C_BLOCK_COMMENT_MODE,b.C_LINE_COMMENT_MODE]
-    },p=[b.APOS_STRING_MODE,b.QUOTE_STRING_MODE,N,f,A,y,b.REGEXP_MODE]
-    ;_.contains=p.concat({begin:/\{/,end:/\}/,keywords:u,contains:["self"].concat(p)
-    });const h=[].concat(v,_.contains),S=h.concat([{begin:/\(/,end:/\)/,keywords:u,
-    contains:["self"].concat(h)}]),w={className:"params",begin:/\(/,end:/\)/,
-    excludeBegin:!0,excludeEnd:!0,keywords:u,contains:S},R={variants:[{
-    match:[/class/,/\s+/,g],scope:{1:"keyword",3:"title.class"}},{
-    match:[/extends/,/\s+/,l(g,"(",l(/\./,g),")*")],scope:{1:"keyword",
-    3:"title.class.inherited"}}]},O={relevance:0,
-    match:/\b[A-Z][a-z]+([A-Z][a-z]+)*/,className:"title.class",keywords:{
-    _:[...t,...s]}},I={variants:[{match:[/function/,/\s+/,g,/(?=\s*\()/]},{
-    match:[/function/,/\s*(?=\()/]}],className:{1:"keyword",3:"title.function"},
-    label:"func.def",contains:[w],illegal:/%/},T={
-    match:l(/\b/,(x=[...r,"super"],l("(?!",x.join("|"),")")),g,o(/\(/)),
-    className:"title.function",relevance:0};var x;const M={
-    begin:l(/\./,o(l(g,/(?![0-9A-Za-z$_(])/))),end:g,excludeBegin:!0,
-    keywords:"prototype",className:"property",relevance:0},k={
-    match:[/get|set/,/\s+/,g,/(?=\()/],className:{1:"keyword",3:"title.function"},
-    contains:[{begin:/\(\)/},w]
-    },C="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+b.UNDERSCORE_IDENT_RE+")\\s*=>",B={
-    match:[/const|var|let/,/\s+/,g,/\s*/,/=\s*/,o(C)],className:{1:"keyword",
-    3:"title.function"},contains:[w]};return{name:"Javascript",
-    aliases:["js","jsx","mjs","cjs"],keywords:u,exports:{PARAMS_CONTAINS:S},
-    illegal:/#(?![$_A-z])/,contains:[b.SHEBANG({label:"shebang",binary:"node",
-    relevance:5}),{label:"use_strict",className:"meta",relevance:10,
-    begin:/^\s*['"]use (strict|asm)['"]/
-    },b.APOS_STRING_MODE,b.QUOTE_STRING_MODE,N,f,A,v,y,O,{className:"attr",
-    begin:g+o(":"),relevance:0},B,{
-    begin:"("+b.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
-    keywords:"return throw case",relevance:0,contains:[v,b.REGEXP_MODE,{
-    className:"function",begin:C,returnBegin:!0,end:"\\s*=>",contains:[{
-    className:"params",variants:[{begin:b.UNDERSCORE_IDENT_RE,relevance:0},{
-    className:null,begin:/\(\s*\)/,skip:!0},{begin:/\(/,end:/\)/,excludeBegin:!0,
-    excludeEnd:!0,keywords:u,contains:S}]}]},{begin:/,/,relevance:0},{match:/\s+/,
-    relevance:0},{variants:[{begin:"<>",end:"</>"},{begin:d.begin,
-    "on:begin":d.isTrulyOpeningTag,end:d.end}],subLanguage:"xml",contains:[{
-    begin:d.begin,end:d.end,skip:!0,contains:["self"]}]}]},I,{
-    beginKeywords:"while if switch catch for"},{
-    begin:"\\b(?!function)"+b.UNDERSCORE_IDENT_RE+"\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
-    returnBegin:!0,label:"func.def",contains:[w,b.inherit(b.TITLE_MODE,{begin:g,
-    className:"title.function"})]},{match:/\.\.\./,relevance:0},M,{match:"\\$"+g,
-    relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
-    contains:[w]},T,{relevance:0,match:/\b[A-Z][A-Z_]+\b/,
-    className:"variable.constant"},R,k,{match:/\$[(.]/}]}}})());hljs.registerLanguage("php",(()=>{"use strict";return e=>{const r={
-    className:"variable",
-    begin:"\\$+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?![A-Za-z0-9])(?![$])"},t={
-    className:"meta",variants:[{begin:/<\?php/,relevance:10},{begin:/<\?[=]?/},{
-    begin:/\?>/}]},a={className:"subst",variants:[{begin:/\$\w+/},{begin:/\{\$/,
-    end:/\}/}]},n=e.inherit(e.APOS_STRING_MODE,{illegal:null
-    }),i=e.inherit(e.QUOTE_STRING_MODE,{illegal:null,
-    contains:e.QUOTE_STRING_MODE.contains.concat(a)}),o=e.END_SAME_AS_BEGIN({
-    begin:/<<<[ \t]*(\w+)\n/,end:/[ \t]*(\w+)\b/,
-    contains:e.QUOTE_STRING_MODE.contains.concat(a)}),l={className:"string",
-    contains:[e.BACKSLASH_ESCAPE,t],variants:[e.inherit(n,{begin:"b'",end:"'"
-    }),e.inherit(i,{begin:'b"',end:'"'}),i,n,o]},s={className:"number",variants:[{
-    begin:"\\b0b[01]+(?:_[01]+)*\\b"},{begin:"\\b0o[0-7]+(?:_[0-7]+)*\\b"},{
-    begin:"\\b0x[\\da-f]+(?:_[\\da-f]+)*\\b"},{
-    begin:"(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:e[+-]?\\d+)?"
-    }],relevance:0},c={
-    keyword:"__CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__ __NAMESPACE__ __TRAIT__ die echo exit include include_once print require require_once array abstract and as binary bool boolean break callable case catch class clone const continue declare default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile enum eval extends final finally float for foreach from global goto if implements instanceof insteadof int integer interface isset iterable list match|0 mixed new object or private protected public real return string switch throw trait try unset use var void while xor yield",
-    literal:"false null true",
-    built_in:"Error|0 AppendIterator ArgumentCountError ArithmeticError ArrayIterator ArrayObject AssertionError BadFunctionCallException BadMethodCallException CachingIterator CallbackFilterIterator CompileError Countable DirectoryIterator DivisionByZeroError DomainException EmptyIterator ErrorException Exception FilesystemIterator FilterIterator GlobIterator InfiniteIterator InvalidArgumentException IteratorIterator LengthException LimitIterator LogicException MultipleIterator NoRewindIterator OutOfBoundsException OutOfRangeException OuterIterator OverflowException ParentIterator ParseError RangeException RecursiveArrayIterator RecursiveCachingIterator RecursiveCallbackFilterIterator RecursiveDirectoryIterator RecursiveFilterIterator RecursiveIterator RecursiveIteratorIterator RecursiveRegexIterator RecursiveTreeIterator RegexIterator RuntimeException SeekableIterator SplDoublyLinkedList SplFileInfo SplFileObject SplFixedArray SplHeap SplMaxHeap SplMinHeap SplObjectStorage SplObserver SplObserver SplPriorityQueue SplQueue SplStack SplSubject SplSubject SplTempFileObject TypeError UnderflowException UnexpectedValueException UnhandledMatchError ArrayAccess Closure Generator Iterator IteratorAggregate Serializable Stringable Throwable Traversable WeakReference WeakMap Directory __PHP_Incomplete_Class parent php_user_filter self static stdClass"
-    };return{case_insensitive:!0,keywords:c,
-    contains:[e.HASH_COMMENT_MODE,e.COMMENT("//","$",{contains:[t]
-    }),e.COMMENT("/\\*","\\*/",{contains:[{className:"doctag",begin:"@[A-Za-z]+"}]
-    }),e.COMMENT("__halt_compiler.+?;",!1,{endsWithParent:!0,
-    keywords:"__halt_compiler"}),t,{className:"keyword",begin:/\$this\b/},r,{
-    begin:/(::|->)+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/},{className:"function",
-    relevance:0,beginKeywords:"fn function",end:/[;{]/,excludeEnd:!0,
-    illegal:"[$%\\[]",contains:[{beginKeywords:"use"},e.UNDERSCORE_TITLE_MODE,{
-    begin:"=>",endsParent:!0},{className:"params",begin:"\\(",end:"\\)",
-    excludeBegin:!0,excludeEnd:!0,keywords:c,
-    contains:["self",r,e.C_BLOCK_COMMENT_MODE,l,s]}]},{className:"class",variants:[{
-    beginKeywords:"enum",illegal:/[($"]/},{beginKeywords:"class interface trait",
-    illegal:/[:($"]/}],relevance:0,end:/\{/,excludeEnd:!0,contains:[{
-    beginKeywords:"extends implements"},e.UNDERSCORE_TITLE_MODE]},{
-    beginKeywords:"namespace",relevance:0,end:";",illegal:/[.']/,
-    contains:[e.UNDERSCORE_TITLE_MODE]},{beginKeywords:"use",relevance:0,end:";",
-    contains:[e.UNDERSCORE_TITLE_MODE]},l,s]}}})());hljs.registerLanguage("php-template",(()=>{"use strict";return n=>({
-    name:"PHP template",subLanguage:"xml",contains:[{begin:/<\?(php|=)?/,end:/\?>/,
-    subLanguage:"php",contains:[{begin:"/\\*",end:"\\*/",skip:!0},{begin:'b"',
-    end:'"',skip:!0},{begin:"b'",end:"'",skip:!0},n.inherit(n.APOS_STRING_MODE,{
-    illegal:null,className:null,contains:null,skip:!0
-    }),n.inherit(n.QUOTE_STRING_MODE,{illegal:null,className:null,contains:null,
-    skip:!0})]}]})})());
+var hljs=function(){"use strict";function e(t){
+return t instanceof Map?t.clear=t.delete=t.set=()=>{
+throw Error("map is read-only")}:t instanceof Set&&(t.add=t.clear=t.delete=()=>{
+throw Error("set is read-only")
+}),Object.freeze(t),Object.getOwnPropertyNames(t).forEach((n=>{
+const i=t[n],s=typeof i;"object"!==s&&"function"!==s||Object.isFrozen(i)||e(i)
+})),t}class t{constructor(e){
+void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
+ignoreMatch(){this.isMatchIgnored=!0}}function n(e){
+return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
+}function i(e,...t){const n=Object.create(null);for(const t in e)n[t]=e[t]
+;return t.forEach((e=>{for(const t in e)n[t]=e[t]})),n}const s=e=>!!e.scope
+;class r{constructor(e,t){
+this.buffer="",this.classPrefix=t.classPrefix,e.walk(this)}addText(e){
+this.buffer+=n(e)}openNode(e){if(!s(e))return;const t=((e,{prefix:t})=>{
+if(e.startsWith("language:"))return e.replace("language:","language-")
+;if(e.includes(".")){const n=e.split(".")
+;return[`${t}${n.shift()}`,...n.map(((e,t)=>`${e}${"_".repeat(t+1)}`))].join(" ")
+}return`${t}${e}`})(e.scope,{prefix:this.classPrefix});this.span(t)}
+closeNode(e){s(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
+this.buffer+=`<span class="${e}">`}}const o=(e={})=>{const t={children:[]}
+;return Object.assign(t,e),t};class a{constructor(){
+this.rootNode=o(),this.stack=[this.rootNode]}get top(){
+return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
+this.top.children.push(e)}openNode(e){const t=o({scope:e})
+;this.add(t),this.stack.push(t)}closeNode(){
+if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
+for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
+walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,t){
+return"string"==typeof t?e.addText(t):t.children&&(e.openNode(t),
+t.children.forEach((t=>this._walk(e,t))),e.closeNode(t)),e}static _collapse(e){
+"string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
+a._collapse(e)})))}}class c extends a{constructor(e){super(),this.options=e}
+addText(e){""!==e&&this.add(e)}startScope(e){this.openNode(e)}endScope(){
+this.closeNode()}__addSublanguage(e,t){const n=e.root
+;t&&(n.scope="language:"+t),this.add(n)}toHTML(){
+return new r(this,this.options).value()}finalize(){
+return this.closeAllNodes(),!0}}function l(e){
+return e?"string"==typeof e?e:e.source:null}function g(e){return h("(?=",e,")")}
+function u(e){return h("(?:",e,")*")}function d(e){return h("(?:",e,")?")}
+function h(...e){return e.map((e=>l(e))).join("")}function f(...e){const t=(e=>{
+const t=e[e.length-1]
+;return"object"==typeof t&&t.constructor===Object?(e.splice(e.length-1,1),t):{}
+})(e);return"("+(t.capture?"":"?:")+e.map((e=>l(e))).join("|")+")"}
+function p(e){return RegExp(e.toString()+"|").exec("").length-1}
+const b=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
+;function m(e,{joinWith:t}){let n=0;return e.map((e=>{n+=1;const t=n
+;let i=l(e),s="";for(;i.length>0;){const e=b.exec(i);if(!e){s+=i;break}
+s+=i.substring(0,e.index),
+i=i.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?s+="\\"+(Number(e[1])+t):(s+=e[0],
+"("===e[0]&&n++)}return s})).map((e=>`(${e})`)).join(t)}
+const E="[a-zA-Z]\\w*",x="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",_="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",w="\\b(0b[01]+)",O={
+begin:"\\\\[\\s\\S]",relevance:0},v={scope:"string",begin:"'",end:"'",
+illegal:"\\n",contains:[O]},k={scope:"string",begin:'"',end:'"',illegal:"\\n",
+contains:[O]},N=(e,t,n={})=>{const s=i({scope:"comment",begin:e,end:t,
+contains:[]},n);s.contains.push({scope:"doctag",
+begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
+end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
+;const r=f("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
+;return s.contains.push({begin:h(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),s
+},S=N("//","$"),M=N("/\\*","\\*/"),R=N("#","$");var j=Object.freeze({
+__proto__:null,APOS_STRING_MODE:v,BACKSLASH_ESCAPE:O,BINARY_NUMBER_MODE:{
+scope:"number",begin:w,relevance:0},BINARY_NUMBER_RE:w,COMMENT:N,
+C_BLOCK_COMMENT_MODE:M,C_LINE_COMMENT_MODE:S,C_NUMBER_MODE:{scope:"number",
+begin:_,relevance:0},C_NUMBER_RE:_,END_SAME_AS_BEGIN:e=>Object.assign(e,{
+"on:begin":(e,t)=>{t.data._beginMatch=e[1]},"on:end":(e,t)=>{
+t.data._beginMatch!==e[1]&&t.ignoreMatch()}}),HASH_COMMENT_MODE:R,IDENT_RE:E,
+MATCH_NOTHING_RE:/\b\B/,METHOD_GUARD:{begin:"\\.\\s*"+x,relevance:0},
+NUMBER_MODE:{scope:"number",begin:y,relevance:0},NUMBER_RE:y,
+PHRASAL_WORDS_MODE:{
+begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+},QUOTE_STRING_MODE:k,REGEXP_MODE:{scope:"regexp",begin:/\/(?=[^/\n]*\/)/,
+end:/\/[gimuy]*/,contains:[O,{begin:/\[/,end:/\]/,relevance:0,contains:[O]}]},
+RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
+SHEBANG:(e={})=>{const t=/^#![ ]*\//
+;return e.binary&&(e.begin=h(t,/.*\b/,e.binary,/\b.*/)),i({scope:"meta",begin:t,
+end:/$/,relevance:0,"on:begin":(e,t)=>{0!==e.index&&t.ignoreMatch()}},e)},
+TITLE_MODE:{scope:"title",begin:E,relevance:0},UNDERSCORE_IDENT_RE:x,
+UNDERSCORE_TITLE_MODE:{scope:"title",begin:x,relevance:0}});function A(e,t){
+"."===e.input[e.index-1]&&t.ignoreMatch()}function I(e,t){
+void 0!==e.className&&(e.scope=e.className,delete e.className)}function T(e,t){
+t&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
+e.__beforeBegin=A,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
+void 0===e.relevance&&(e.relevance=0))}function L(e,t){
+Array.isArray(e.illegal)&&(e.illegal=f(...e.illegal))}function B(e,t){
+if(e.match){
+if(e.begin||e.end)throw Error("begin & end are not supported with match")
+;e.begin=e.match,delete e.match}}function P(e,t){
+void 0===e.relevance&&(e.relevance=1)}const D=(e,t)=>{if(!e.beforeMatch)return
+;if(e.starts)throw Error("beforeMatch cannot be used with starts")
+;const n=Object.assign({},e);Object.keys(e).forEach((t=>{delete e[t]
+})),e.keywords=n.keywords,e.begin=h(n.beforeMatch,g(n.begin)),e.starts={
+relevance:0,contains:[Object.assign(n,{endsParent:!0})]
+},e.relevance=0,delete n.beforeMatch
+},H=["of","and","for","in","not","or","if","then","parent","list","value"]
+;function C(e,t,n="keyword"){const i=Object.create(null)
+;return"string"==typeof e?s(n,e.split(" ")):Array.isArray(e)?s(n,e):Object.keys(e).forEach((n=>{
+Object.assign(i,C(e[n],t,n))})),i;function s(e,n){
+t&&(n=n.map((e=>e.toLowerCase()))),n.forEach((t=>{const n=t.split("|")
+;i[n[0]]=[e,$(n[0],n[1])]}))}}function $(e,t){
+return t?Number(t):(e=>H.includes(e.toLowerCase()))(e)?0:1}const U={},z=e=>{
+console.error(e)},W=(e,...t)=>{console.log("WARN: "+e,...t)},X=(e,t)=>{
+U[`${e}/${t}`]||(console.log(`Deprecated as of ${e}. ${t}`),U[`${e}/${t}`]=!0)
+},G=Error();function K(e,t,{key:n}){let i=0;const s=e[n],r={},o={}
+;for(let e=1;e<=t.length;e++)o[e+i]=s[e],r[e+i]=!0,i+=p(t[e-1])
+;e[n]=o,e[n]._emit=r,e[n]._multi=!0}function F(e){(e=>{
+e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
+delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
+_wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
+}),(e=>{if(Array.isArray(e.begin)){
+if(e.skip||e.excludeBegin||e.returnBegin)throw z("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
+G
+;if("object"!=typeof e.beginScope||null===e.beginScope)throw z("beginScope must be object"),
+G;K(e,e.begin,{key:"beginScope"}),e.begin=m(e.begin,{joinWith:""})}})(e),(e=>{
+if(Array.isArray(e.end)){
+if(e.skip||e.excludeEnd||e.returnEnd)throw z("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
+G
+;if("object"!=typeof e.endScope||null===e.endScope)throw z("endScope must be object"),
+G;K(e,e.end,{key:"endScope"}),e.end=m(e.end,{joinWith:""})}})(e)}function Z(e){
+function t(t,n){
+return RegExp(l(t),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(n?"g":""))
+}class n{constructor(){
+this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
+addRule(e,t){
+t.position=this.position++,this.matchIndexes[this.matchAt]=t,this.regexes.push([t,e]),
+this.matchAt+=p(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
+;const e=this.regexes.map((e=>e[1]));this.matcherRe=t(m(e,{joinWith:"|"
+}),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
+;const t=this.matcherRe.exec(e);if(!t)return null
+;const n=t.findIndex(((e,t)=>t>0&&void 0!==e)),i=this.matchIndexes[n]
+;return t.splice(0,n),Object.assign(t,i)}}class s{constructor(){
+this.rules=[],this.multiRegexes=[],
+this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
+if(this.multiRegexes[e])return this.multiRegexes[e];const t=new n
+;return this.rules.slice(e).forEach((([e,n])=>t.addRule(e,n))),
+t.compile(),this.multiRegexes[e]=t,t}resumingScanAtSamePosition(){
+return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,t){
+this.rules.push([e,t]),"begin"===t.type&&this.count++}exec(e){
+const t=this.getMatcher(this.regexIndex);t.lastIndex=this.lastIndex
+;let n=t.exec(e)
+;if(this.resumingScanAtSamePosition())if(n&&n.index===this.lastIndex);else{
+const t=this.getMatcher(0);t.lastIndex=this.lastIndex+1,n=t.exec(e)}
+return n&&(this.regexIndex+=n.position+1,
+this.regexIndex===this.count&&this.considerAll()),n}}
+if(e.compilerExtensions||(e.compilerExtensions=[]),
+e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
+;return e.classNameAliases=i(e.classNameAliases||{}),function n(r,o){const a=r
+;if(r.isCompiled)return a
+;[I,B,F,D].forEach((e=>e(r,o))),e.compilerExtensions.forEach((e=>e(r,o))),
+r.__beforeBegin=null,[T,L,P].forEach((e=>e(r,o))),r.isCompiled=!0;let c=null
+;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
+c=r.keywords.$pattern,
+delete r.keywords.$pattern),c=c||/\w+/,r.keywords&&(r.keywords=C(r.keywords,e.case_insensitive)),
+a.keywordPatternRe=t(c,!0),
+o&&(r.begin||(r.begin=/\B|\b/),a.beginRe=t(a.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
+r.end&&(a.endRe=t(a.end)),
+a.terminatorEnd=l(a.end)||"",r.endsWithParent&&o.terminatorEnd&&(a.terminatorEnd+=(r.end?"|":"")+o.terminatorEnd)),
+r.illegal&&(a.illegalRe=t(r.illegal)),
+r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((t=>i(e,{
+variants:null},t)))),e.cachedVariants?e.cachedVariants:V(e)?i(e,{
+starts:e.starts?i(e.starts):null
+}):Object.isFrozen(e)?i(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{n(e,a)
+})),r.starts&&n(r.starts,o),a.matcher=(e=>{const t=new s
+;return e.contains.forEach((e=>t.addRule(e.begin,{rule:e,type:"begin"
+}))),e.terminatorEnd&&t.addRule(e.terminatorEnd,{type:"end"
+}),e.illegal&&t.addRule(e.illegal,{type:"illegal"}),t})(a),a}(e)}function V(e){
+return!!e&&(e.endsWithParent||V(e.starts))}class q extends Error{
+constructor(e,t){super(e),this.name="HTMLInjectionError",this.html=t}}
+const J=n,Y=i,Q=Symbol("nomatch"),ee=n=>{
+const i=Object.create(null),s=Object.create(null),r=[];let o=!0
+;const a="Could not find the language '{}', did you forget to load/include a language module?",l={
+disableAutodetect:!0,name:"Plain text",contains:[]};let p={
+ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
+languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
+cssSelector:"pre code",languages:null,__emitter:c};function b(e){
+return p.noHighlightRe.test(e)}function m(e,t,n){let i="",s=""
+;"object"==typeof t?(i=e,
+n=t.ignoreIllegals,s=t.language):(X("10.7.0","highlight(lang, code, ...args) has been deprecated."),
+X("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
+s=e,i=t),void 0===n&&(n=!0);const r={code:i,language:s};N("before:highlight",r)
+;const o=r.result?r.result:E(r.language,r.code,n)
+;return o.code=r.code,N("after:highlight",o),o}function E(e,n,s,r){
+const c=Object.create(null);function l(){if(!N.keywords)return void M.addText(R)
+;let e=0;N.keywordPatternRe.lastIndex=0;let t=N.keywordPatternRe.exec(R),n=""
+;for(;t;){n+=R.substring(e,t.index)
+;const s=w.case_insensitive?t[0].toLowerCase():t[0],r=(i=s,N.keywords[i]);if(r){
+const[e,i]=r
+;if(M.addText(n),n="",c[s]=(c[s]||0)+1,c[s]<=7&&(j+=i),e.startsWith("_"))n+=t[0];else{
+const n=w.classNameAliases[e]||e;u(t[0],n)}}else n+=t[0]
+;e=N.keywordPatternRe.lastIndex,t=N.keywordPatternRe.exec(R)}var i
+;n+=R.substring(e),M.addText(n)}function g(){null!=N.subLanguage?(()=>{
+if(""===R)return;let e=null;if("string"==typeof N.subLanguage){
+if(!i[N.subLanguage])return void M.addText(R)
+;e=E(N.subLanguage,R,!0,S[N.subLanguage]),S[N.subLanguage]=e._top
+}else e=x(R,N.subLanguage.length?N.subLanguage:null)
+;N.relevance>0&&(j+=e.relevance),M.__addSublanguage(e._emitter,e.language)
+})():l(),R=""}function u(e,t){
+""!==e&&(M.startScope(t),M.addText(e),M.endScope())}function d(e,t){let n=1
+;const i=t.length-1;for(;n<=i;){if(!e._emit[n]){n++;continue}
+const i=w.classNameAliases[e[n]]||e[n],s=t[n];i?u(s,i):(R=s,l(),R=""),n++}}
+function h(e,t){
+return e.scope&&"string"==typeof e.scope&&M.openNode(w.classNameAliases[e.scope]||e.scope),
+e.beginScope&&(e.beginScope._wrap?(u(R,w.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
+R=""):e.beginScope._multi&&(d(e.beginScope,t),R="")),N=Object.create(e,{parent:{
+value:N}}),N}function f(e,n,i){let s=((e,t)=>{const n=e&&e.exec(t)
+;return n&&0===n.index})(e.endRe,i);if(s){if(e["on:end"]){const i=new t(e)
+;e["on:end"](n,i),i.isMatchIgnored&&(s=!1)}if(s){
+for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+if(e.endsWithParent)return f(e.parent,n,i)}function b(e){
+return 0===N.matcher.regexIndex?(R+=e[0],1):(T=!0,0)}function m(e){
+const t=e[0],i=n.substring(e.index),s=f(N,e,i);if(!s)return Q;const r=N
+;N.endScope&&N.endScope._wrap?(g(),
+u(t,N.endScope._wrap)):N.endScope&&N.endScope._multi?(g(),
+d(N.endScope,e)):r.skip?R+=t:(r.returnEnd||r.excludeEnd||(R+=t),
+g(),r.excludeEnd&&(R=t));do{
+N.scope&&M.closeNode(),N.skip||N.subLanguage||(j+=N.relevance),N=N.parent
+}while(N!==s.parent);return s.starts&&h(s.starts,e),r.returnEnd?0:t.length}
+let y={};function _(i,r){const a=r&&r[0];if(R+=i,null==a)return g(),0
+;if("begin"===y.type&&"end"===r.type&&y.index===r.index&&""===a){
+if(R+=n.slice(r.index,r.index+1),!o){const t=Error(`0 width match regex (${e})`)
+;throw t.languageName=e,t.badRule=y.rule,t}return 1}
+if(y=r,"begin"===r.type)return(e=>{
+const n=e[0],i=e.rule,s=new t(i),r=[i.__beforeBegin,i["on:begin"]]
+;for(const t of r)if(t&&(t(e,s),s.isMatchIgnored))return b(n)
+;return i.skip?R+=n:(i.excludeBegin&&(R+=n),
+g(),i.returnBegin||i.excludeBegin||(R=n)),h(i,e),i.returnBegin?0:n.length})(r)
+;if("illegal"===r.type&&!s){
+const e=Error('Illegal lexeme "'+a+'" for mode "'+(N.scope||"<unnamed>")+'"')
+;throw e.mode=N,e}if("end"===r.type){const e=m(r);if(e!==Q)return e}
+if("illegal"===r.type&&""===a)return R+="\n",1
+;if(I>1e5&&I>3*r.index)throw Error("potential infinite loop, way more iterations than matches")
+;return R+=a,a.length}const w=O(e)
+;if(!w)throw z(a.replace("{}",e)),Error('Unknown language: "'+e+'"')
+;const v=Z(w);let k="",N=r||v;const S={},M=new p.__emitter(p);(()=>{const e=[]
+;for(let t=N;t!==w;t=t.parent)t.scope&&e.unshift(t.scope)
+;e.forEach((e=>M.openNode(e)))})();let R="",j=0,A=0,I=0,T=!1;try{
+if(w.__emitTokens)w.__emitTokens(n,M);else{for(N.matcher.considerAll();;){
+I++,T?T=!1:N.matcher.considerAll(),N.matcher.lastIndex=A
+;const e=N.matcher.exec(n);if(!e)break;const t=_(n.substring(A,e.index),e)
+;A=e.index+t}_(n.substring(A))}return M.finalize(),k=M.toHTML(),{language:e,
+value:k,relevance:j,illegal:!1,_emitter:M,_top:N}}catch(t){
+if(t.message&&t.message.includes("Illegal"))return{language:e,value:J(n),
+illegal:!0,relevance:0,_illegalBy:{message:t.message,index:A,
+context:n.slice(A-100,A+100),mode:t.mode,resultSoFar:k},_emitter:M};if(o)return{
+language:e,value:J(n),illegal:!1,relevance:0,errorRaised:t,_emitter:M,_top:N}
+;throw t}}function x(e,t){t=t||p.languages||Object.keys(i);const n=(e=>{
+const t={value:J(e),illegal:!1,relevance:0,_top:l,_emitter:new p.__emitter(p)}
+;return t._emitter.addText(e),t})(e),s=t.filter(O).filter(k).map((t=>E(t,e,!1)))
+;s.unshift(n);const r=s.sort(((e,t)=>{
+if(e.relevance!==t.relevance)return t.relevance-e.relevance
+;if(e.language&&t.language){if(O(e.language).supersetOf===t.language)return 1
+;if(O(t.language).supersetOf===e.language)return-1}return 0})),[o,a]=r,c=o
+;return c.secondBest=a,c}function y(e){let t=null;const n=(e=>{
+let t=e.className+" ";t+=e.parentNode?e.parentNode.className:""
+;const n=p.languageDetectRe.exec(t);if(n){const t=O(n[1])
+;return t||(W(a.replace("{}",n[1])),
+W("Falling back to no-highlight mode for this block.",e)),t?n[1]:"no-highlight"}
+return t.split(/\s+/).find((e=>b(e)||O(e)))})(e);if(b(n))return
+;if(N("before:highlightElement",{el:e,language:n
+}),e.dataset.highlighted)return void console.log("Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",e)
+;if(e.children.length>0&&(p.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
+console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
+console.warn("The element with unescaped HTML:"),
+console.warn(e)),p.throwUnescapedHTML))throw new q("One of your code blocks includes unescaped HTML.",e.innerHTML)
+;t=e;const i=t.textContent,r=n?m(i,{language:n,ignoreIllegals:!0}):x(i)
+;e.innerHTML=r.value,e.dataset.highlighted="yes",((e,t,n)=>{const i=t&&s[t]||n
+;e.classList.add("hljs"),e.classList.add("language-"+i)
+})(e,n,r.language),e.result={language:r.language,re:r.relevance,
+relevance:r.relevance},r.secondBest&&(e.secondBest={
+language:r.secondBest.language,relevance:r.secondBest.relevance
+}),N("after:highlightElement",{el:e,result:r,text:i})}let _=!1;function w(){
+if("loading"===document.readyState)return _||window.addEventListener("DOMContentLoaded",(()=>{
+w()}),!1),void(_=!0);document.querySelectorAll(p.cssSelector).forEach(y)}
+function O(e){return e=(e||"").toLowerCase(),i[e]||i[s[e]]}
+function v(e,{languageName:t}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+s[e.toLowerCase()]=t}))}function k(e){const t=O(e)
+;return t&&!t.disableAutodetect}function N(e,t){const n=e;r.forEach((e=>{
+e[n]&&e[n](t)}))}Object.assign(n,{highlight:m,highlightAuto:x,highlightAll:w,
+highlightElement:y,
+highlightBlock:e=>(X("10.7.0","highlightBlock will be removed entirely in v12.0"),
+X("10.7.0","Please use highlightElement now."),y(e)),configure:e=>{p=Y(p,e)},
+initHighlighting:()=>{
+w(),X("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
+initHighlightingOnLoad:()=>{
+w(),X("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
+},registerLanguage:(e,t)=>{let s=null;try{s=t(n)}catch(t){
+if(z("Language definition for '{}' could not be registered.".replace("{}",e)),
+!o)throw t;z(t),s=l}
+s.name||(s.name=e),i[e]=s,s.rawDefinition=t.bind(null,n),s.aliases&&v(s.aliases,{
+languageName:e})},unregisterLanguage:e=>{delete i[e]
+;for(const t of Object.keys(s))s[t]===e&&delete s[t]},
+listLanguages:()=>Object.keys(i),getLanguage:O,registerAliases:v,
+autoDetection:k,inherit:Y,addPlugin:e=>{(e=>{
+e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=t=>{
+e["before:highlightBlock"](Object.assign({block:t.el},t))
+}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=t=>{
+e["after:highlightBlock"](Object.assign({block:t.el},t))})})(e),r.push(e)},
+removePlugin:e=>{const t=r.indexOf(e);-1!==t&&r.splice(t,1)}}),n.debugMode=()=>{
+o=!1},n.safeMode=()=>{o=!0},n.versionString="11.11.1",n.regex={concat:h,
+lookahead:g,either:f,optional:d,anyNumberOfTimes:u}
+;for(const t in j)"object"==typeof j[t]&&e(j[t]);return Object.assign(n,j),n
+},te=ee({});return te.newInstance=()=>ee({}),te}()
+;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);/*! `apache` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{const n={className:"number",
+begin:/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(:\d{1,5})?/};return{
+name:"Apache config",aliases:["apacheconf"],case_insensitive:!0,
+contains:[e.HASH_COMMENT_MODE,{className:"section",begin:/<\/?/,end:/>/,
+contains:[n,{className:"number",begin:/:\d{1,5}/
+},e.inherit(e.QUOTE_STRING_MODE,{relevance:0})]},{className:"attribute",
+begin:/\w+/,relevance:0,keywords:{
+_:["order","deny","allow","setenv","rewriterule","rewriteengine","rewritecond","documentroot","sethandler","errordocument","loadmodule","options","header","listen","serverroot","servername"]
+},starts:{end:/$/,relevance:0,keywords:{literal:"on off all deny allow"},
+contains:[{scope:"punctuation",match:/\\\n/},{className:"meta",begin:/\s\[/,
+end:/\]$/},{className:"variable",begin:/[\$%]\{/,end:/\}/,contains:["self",{
+className:"number",begin:/[$%]\d+/}]},n,{className:"number",begin:/\b\d+/
+},e.QUOTE_STRING_MODE]}}],illegal:/\S/}}})();hljs.registerLanguage("apache",e)
+})();/*! `css` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict"
+;const e=["a","abbr","address","article","aside","audio","b","blockquote","body","button","canvas","caption","cite","code","dd","del","details","dfn","div","dl","dt","em","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","html","i","iframe","img","input","ins","kbd","label","legend","li","main","mark","menu","nav","object","ol","optgroup","option","p","picture","q","quote","samp","section","select","source","span","strong","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","ul","var","video","defs","g","marker","mask","pattern","svg","switch","symbol","feBlend","feColorMatrix","feComponentTransfer","feComposite","feConvolveMatrix","feDiffuseLighting","feDisplacementMap","feFlood","feGaussianBlur","feImage","feMerge","feMorphology","feOffset","feSpecularLighting","feTile","feTurbulence","linearGradient","radialGradient","stop","circle","ellipse","image","line","path","polygon","polyline","rect","text","use","textPath","tspan","foreignObject","clipPath"],i=["any-hover","any-pointer","aspect-ratio","color","color-gamut","color-index","device-aspect-ratio","device-height","device-width","display-mode","forced-colors","grid","height","hover","inverted-colors","monochrome","orientation","overflow-block","overflow-inline","pointer","prefers-color-scheme","prefers-contrast","prefers-reduced-motion","prefers-reduced-transparency","resolution","scan","scripting","update","width","min-width","max-width","min-height","max-height"].sort().reverse(),t=["active","any-link","blank","checked","current","default","defined","dir","disabled","drop","empty","enabled","first","first-child","first-of-type","fullscreen","future","focus","focus-visible","focus-within","has","host","host-context","hover","indeterminate","in-range","invalid","is","lang","last-child","last-of-type","left","link","local-link","not","nth-child","nth-col","nth-last-child","nth-last-col","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","past","placeholder-shown","read-only","read-write","required","right","root","scope","target","target-within","user-invalid","valid","visited","where"].sort().reverse(),o=["after","backdrop","before","cue","cue-region","first-letter","first-line","grammar-error","marker","part","placeholder","selection","slotted","spelling-error"].sort().reverse(),r=["accent-color","align-content","align-items","align-self","alignment-baseline","all","anchor-name","animation","animation-composition","animation-delay","animation-direction","animation-duration","animation-fill-mode","animation-iteration-count","animation-name","animation-play-state","animation-range","animation-range-end","animation-range-start","animation-timeline","animation-timing-function","appearance","aspect-ratio","backdrop-filter","backface-visibility","background","background-attachment","background-blend-mode","background-clip","background-color","background-image","background-origin","background-position","background-position-x","background-position-y","background-repeat","background-size","baseline-shift","block-size","border","border-block","border-block-color","border-block-end","border-block-end-color","border-block-end-style","border-block-end-width","border-block-start","border-block-start-color","border-block-start-style","border-block-start-width","border-block-style","border-block-width","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-style","border-bottom-width","border-collapse","border-color","border-end-end-radius","border-end-start-radius","border-image","border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width","border-inline","border-inline-color","border-inline-end","border-inline-end-color","border-inline-end-style","border-inline-end-width","border-inline-start","border-inline-start-color","border-inline-start-style","border-inline-start-width","border-inline-style","border-inline-width","border-left","border-left-color","border-left-style","border-left-width","border-radius","border-right","border-right-color","border-right-style","border-right-width","border-spacing","border-start-end-radius","border-start-start-radius","border-style","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-style","border-top-width","border-width","bottom","box-align","box-decoration-break","box-direction","box-flex","box-flex-group","box-lines","box-ordinal-group","box-orient","box-pack","box-shadow","box-sizing","break-after","break-before","break-inside","caption-side","caret-color","clear","clip","clip-path","clip-rule","color","color-interpolation","color-interpolation-filters","color-profile","color-rendering","color-scheme","column-count","column-fill","column-gap","column-rule","column-rule-color","column-rule-style","column-rule-width","column-span","column-width","columns","contain","contain-intrinsic-block-size","contain-intrinsic-height","contain-intrinsic-inline-size","contain-intrinsic-size","contain-intrinsic-width","container","container-name","container-type","content","content-visibility","counter-increment","counter-reset","counter-set","cue","cue-after","cue-before","cursor","cx","cy","direction","display","dominant-baseline","empty-cells","enable-background","field-sizing","fill","fill-opacity","fill-rule","filter","flex","flex-basis","flex-direction","flex-flow","flex-grow","flex-shrink","flex-wrap","float","flood-color","flood-opacity","flow","font","font-display","font-family","font-feature-settings","font-kerning","font-language-override","font-optical-sizing","font-palette","font-size","font-size-adjust","font-smooth","font-smoothing","font-stretch","font-style","font-synthesis","font-synthesis-position","font-synthesis-small-caps","font-synthesis-style","font-synthesis-weight","font-variant","font-variant-alternates","font-variant-caps","font-variant-east-asian","font-variant-emoji","font-variant-ligatures","font-variant-numeric","font-variant-position","font-variation-settings","font-weight","forced-color-adjust","gap","glyph-orientation-horizontal","glyph-orientation-vertical","grid","grid-area","grid-auto-columns","grid-auto-flow","grid-auto-rows","grid-column","grid-column-end","grid-column-start","grid-gap","grid-row","grid-row-end","grid-row-start","grid-template","grid-template-areas","grid-template-columns","grid-template-rows","hanging-punctuation","height","hyphenate-character","hyphenate-limit-chars","hyphens","icon","image-orientation","image-rendering","image-resolution","ime-mode","initial-letter","initial-letter-align","inline-size","inset","inset-area","inset-block","inset-block-end","inset-block-start","inset-inline","inset-inline-end","inset-inline-start","isolation","justify-content","justify-items","justify-self","kerning","left","letter-spacing","lighting-color","line-break","line-height","line-height-step","list-style","list-style-image","list-style-position","list-style-type","margin","margin-block","margin-block-end","margin-block-start","margin-bottom","margin-inline","margin-inline-end","margin-inline-start","margin-left","margin-right","margin-top","margin-trim","marker","marker-end","marker-mid","marker-start","marks","mask","mask-border","mask-border-mode","mask-border-outset","mask-border-repeat","mask-border-slice","mask-border-source","mask-border-width","mask-clip","mask-composite","mask-image","mask-mode","mask-origin","mask-position","mask-repeat","mask-size","mask-type","masonry-auto-flow","math-depth","math-shift","math-style","max-block-size","max-height","max-inline-size","max-width","min-block-size","min-height","min-inline-size","min-width","mix-blend-mode","nav-down","nav-index","nav-left","nav-right","nav-up","none","normal","object-fit","object-position","offset","offset-anchor","offset-distance","offset-path","offset-position","offset-rotate","opacity","order","orphans","outline","outline-color","outline-offset","outline-style","outline-width","overflow","overflow-anchor","overflow-block","overflow-clip-margin","overflow-inline","overflow-wrap","overflow-x","overflow-y","overlay","overscroll-behavior","overscroll-behavior-block","overscroll-behavior-inline","overscroll-behavior-x","overscroll-behavior-y","padding","padding-block","padding-block-end","padding-block-start","padding-bottom","padding-inline","padding-inline-end","padding-inline-start","padding-left","padding-right","padding-top","page","page-break-after","page-break-before","page-break-inside","paint-order","pause","pause-after","pause-before","perspective","perspective-origin","place-content","place-items","place-self","pointer-events","position","position-anchor","position-visibility","print-color-adjust","quotes","r","resize","rest","rest-after","rest-before","right","rotate","row-gap","ruby-align","ruby-position","scale","scroll-behavior","scroll-margin","scroll-margin-block","scroll-margin-block-end","scroll-margin-block-start","scroll-margin-bottom","scroll-margin-inline","scroll-margin-inline-end","scroll-margin-inline-start","scroll-margin-left","scroll-margin-right","scroll-margin-top","scroll-padding","scroll-padding-block","scroll-padding-block-end","scroll-padding-block-start","scroll-padding-bottom","scroll-padding-inline","scroll-padding-inline-end","scroll-padding-inline-start","scroll-padding-left","scroll-padding-right","scroll-padding-top","scroll-snap-align","scroll-snap-stop","scroll-snap-type","scroll-timeline","scroll-timeline-axis","scroll-timeline-name","scrollbar-color","scrollbar-gutter","scrollbar-width","shape-image-threshold","shape-margin","shape-outside","shape-rendering","speak","speak-as","src","stop-color","stop-opacity","stroke","stroke-dasharray","stroke-dashoffset","stroke-linecap","stroke-linejoin","stroke-miterlimit","stroke-opacity","stroke-width","tab-size","table-layout","text-align","text-align-all","text-align-last","text-anchor","text-combine-upright","text-decoration","text-decoration-color","text-decoration-line","text-decoration-skip","text-decoration-skip-ink","text-decoration-style","text-decoration-thickness","text-emphasis","text-emphasis-color","text-emphasis-position","text-emphasis-style","text-indent","text-justify","text-orientation","text-overflow","text-rendering","text-shadow","text-size-adjust","text-transform","text-underline-offset","text-underline-position","text-wrap","text-wrap-mode","text-wrap-style","timeline-scope","top","touch-action","transform","transform-box","transform-origin","transform-style","transition","transition-behavior","transition-delay","transition-duration","transition-property","transition-timing-function","translate","unicode-bidi","user-modify","user-select","vector-effect","vertical-align","view-timeline","view-timeline-axis","view-timeline-inset","view-timeline-name","view-transition-name","visibility","voice-balance","voice-duration","voice-family","voice-pitch","voice-range","voice-rate","voice-stress","voice-volume","white-space","white-space-collapse","widows","width","will-change","word-break","word-spacing","word-wrap","writing-mode","x","y","z-index","zoom"].sort().reverse()
+;return n=>{const a=n.regex,l=(e=>({IMPORTANT:{scope:"meta",begin:"!important"},
+BLOCK_COMMENT:e.C_BLOCK_COMMENT_MODE,HEXCOLOR:{scope:"number",
+begin:/#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/},FUNCTION_DISPATCH:{
+className:"built_in",begin:/[\w-]+(?=\()/},ATTRIBUTE_SELECTOR_MODE:{
+scope:"selector-attr",begin:/\[/,end:/\]/,illegal:"$",
+contains:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},CSS_NUMBER_MODE:{
+scope:"number",
+begin:e.NUMBER_RE+"(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+relevance:0},CSS_VARIABLE:{className:"attr",begin:/--[A-Za-z_][A-Za-z0-9_-]*/}
+}))(n),s=[n.APOS_STRING_MODE,n.QUOTE_STRING_MODE];return{name:"CSS",
+case_insensitive:!0,illegal:/[=|'\$]/,keywords:{keyframePosition:"from to"},
+classNameAliases:{keyframePosition:"selector-tag"},contains:[l.BLOCK_COMMENT,{
+begin:/-(webkit|moz|ms|o)-(?=[a-z])/},l.CSS_NUMBER_MODE,{
+className:"selector-id",begin:/#[A-Za-z0-9_-]+/,relevance:0},{
+className:"selector-class",begin:"\\.[a-zA-Z-][a-zA-Z0-9_-]*",relevance:0
+},l.ATTRIBUTE_SELECTOR_MODE,{className:"selector-pseudo",variants:[{
+begin:":("+t.join("|")+")"},{begin:":(:)?("+o.join("|")+")"}]},l.CSS_VARIABLE,{
+className:"attribute",begin:"\\b("+r.join("|")+")\\b"},{begin:/:/,end:/[;}{]/,
+contains:[l.BLOCK_COMMENT,l.HEXCOLOR,l.IMPORTANT,l.CSS_NUMBER_MODE,...s,{
+begin:/(url|data-uri)\(/,end:/\)/,relevance:0,keywords:{built_in:"url data-uri"
+},contains:[...s,{className:"string",begin:/[^)]/,endsWithParent:!0,
+excludeEnd:!0}]},l.FUNCTION_DISPATCH]},{begin:a.lookahead(/@/),end:"[{;]",
+relevance:0,illegal:/:/,contains:[{className:"keyword",begin:/@-?\w[\w]*(-\w+)*/
+},{begin:/\s/,endsWithParent:!0,excludeEnd:!0,relevance:0,keywords:{
+$pattern:/[a-z-]+/,keyword:"and or not only",attribute:i.join(" ")},contains:[{
+begin:/[a-z-]+(?=:)/,className:"attribute"},...s,l.CSS_NUMBER_MODE]}]},{
+className:"selector-tag",begin:"\\b("+e.join("|")+")\\b"}]}}})()
+;hljs.registerLanguage("css",e)})();/*! `java` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict"
+;var e="[0-9](_*[0-9])*",a=`\\.(${e})`,n="[0-9a-fA-F](_*[0-9a-fA-F])*",s={
+className:"number",variants:[{
+begin:`(\\b(${e})((${a})|\\.)?|(${a}))[eE][+-]?(${e})[fFdD]?\\b`},{
+begin:`\\b(${e})((${a})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{begin:`(${a})[fFdD]?\\b`
+},{begin:`\\b(${e})[fFdD]\\b`},{
+begin:`\\b0[xX]((${n})\\.?|(${n})?\\.(${n}))[pP][+-]?(${e})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${n})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};function t(e,a,n){return-1===n?"":e.replace(a,(s=>t(e,a,n-1)))}
+return e=>{
+const a=e.regex,n="[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",i=n+t("(?:<"+n+"~~~(?:\\s*,\\s*"+n+"~~~)*>)?",/~~~/g,2),r={
+keyword:["synchronized","abstract","private","var","static","if","const ","for","while","strictfp","finally","protected","import","native","final","void","enum","else","break","transient","catch","instanceof","volatile","case","assert","package","default","public","try","switch","continue","throws","protected","public","private","module","requires","exports","do","sealed","yield","permits","goto","when"],
+literal:["false","true","null"],
+type:["char","boolean","long","float","int","byte","short","double"],
+built_in:["super","this"]},l={className:"meta",begin:"@"+n,contains:[{
+begin:/\(/,end:/\)/,contains:["self"]}]},c={className:"params",begin:/\(/,
+end:/\)/,keywords:r,relevance:0,contains:[e.C_BLOCK_COMMENT_MODE],endsParent:!0}
+;return{name:"Java",aliases:["jsp"],keywords:r,illegal:/<\/|#/,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{begin:/\w+@/,
+relevance:0},{className:"doctag",begin:"@[A-Za-z]+"}]}),{
+begin:/import java\.[a-z]+\./,keywords:"import",relevance:2
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{begin:/"""/,end:/"""/,
+className:"string",contains:[e.BACKSLASH_ESCAPE]
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{
+match:[/\b(?:class|interface|enum|extends|implements|new)/,/\s+/,n],className:{
+1:"keyword",3:"title.class"}},{match:/non-sealed/,scope:"keyword"},{
+begin:[a.concat(/(?!else)/,n),/\s+/,n,/\s+/,/=(?!=)/],className:{1:"type",
+3:"variable",5:"operator"}},{begin:[/record/,/\s+/,n],className:{1:"keyword",
+3:"title.class"},contains:[c,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"new throw return else",relevance:0},{
+begin:["(?:"+i+"\\s+)",e.UNDERSCORE_IDENT_RE,/\s*(?=\()/],className:{
+2:"title.function"},keywords:r,contains:[{className:"params",begin:/\(/,
+end:/\)/,keywords:r,relevance:0,
+contains:[l,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,s,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},s,l]}}})()
+;hljs.registerLanguage("java",e)})();/*! `javascript` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict"
+;const e="[A-Za-z$_][0-9A-Za-z$_]*",n=["as","in","of","if","for","while","finally","var","new","function","do","return","void","else","break","catch","instanceof","with","throw","case","default","try","switch","continue","typeof","delete","let","yield","const","class","debugger","async","await","static","import","from","export","extends","using"],a=["true","false","null","undefined","NaN","Infinity"],t=["Object","Function","Boolean","Symbol","Math","Date","Number","BigInt","String","RegExp","Array","Float32Array","Float64Array","Int8Array","Uint8Array","Uint8ClampedArray","Int16Array","Int32Array","Uint16Array","Uint32Array","BigInt64Array","BigUint64Array","Set","Map","WeakSet","WeakMap","ArrayBuffer","SharedArrayBuffer","Atomics","DataView","JSON","Promise","Generator","GeneratorFunction","AsyncFunction","Reflect","Proxy","Intl","WebAssembly"],s=["Error","EvalError","InternalError","RangeError","ReferenceError","SyntaxError","TypeError","URIError"],r=["setInterval","setTimeout","clearInterval","clearTimeout","require","exports","eval","isFinite","isNaN","parseFloat","parseInt","decodeURI","decodeURIComponent","encodeURI","encodeURIComponent","escape","unescape"],c=["arguments","this","super","console","window","document","localStorage","sessionStorage","module","global"],i=[].concat(r,t,s)
+;return o=>{const l=o.regex,d=e,b={begin:/<[A-Za-z0-9\\._:-]+/,
+end:/\/[A-Za-z0-9\\._:-]+>|\/>/,isTrulyOpeningTag:(e,n)=>{
+const a=e[0].length+e.index,t=e.input[a]
+;if("<"===t||","===t)return void n.ignoreMatch();let s
+;">"===t&&(((e,{after:n})=>{const a="</"+e[0].slice(1)
+;return-1!==e.input.indexOf(a,n)})(e,{after:a})||n.ignoreMatch())
+;const r=e.input.substring(a)
+;((s=r.match(/^\s*=/))||(s=r.match(/^\s+extends\s+/))&&0===s.index)&&n.ignoreMatch()
+}},g={$pattern:e,keyword:n,literal:a,built_in:i,"variable.language":c
+},u="[0-9](_?[0-9])*",m=`\\.(${u})`,E="0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",A={
+className:"number",variants:[{
+begin:`(\\b(${E})((${m})|\\.)?|(${m}))[eE][+-]?(${u})\\b`},{
+begin:`\\b(${E})\\b((${m})\\b|\\.)?|(${m})\\b`},{
+begin:"\\b(0|[1-9](_?[0-9])*)n\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b"},{
+begin:"\\b0[bB][0-1](_?[0-1])*n?\\b"},{begin:"\\b0[oO][0-7](_?[0-7])*n?\\b"},{
+begin:"\\b0[0-7]+n?\\b"}],relevance:0},y={className:"subst",begin:"\\$\\{",
+end:"\\}",keywords:g,contains:[]},h={begin:".?html`",end:"",starts:{end:"`",
+returnEnd:!1,contains:[o.BACKSLASH_ESCAPE,y],subLanguage:"xml"}},_={
+begin:".?css`",end:"",starts:{end:"`",returnEnd:!1,
+contains:[o.BACKSLASH_ESCAPE,y],subLanguage:"css"}},N={begin:".?gql`",end:"",
+starts:{end:"`",returnEnd:!1,contains:[o.BACKSLASH_ESCAPE,y],
+subLanguage:"graphql"}},f={className:"string",begin:"`",end:"`",
+contains:[o.BACKSLASH_ESCAPE,y]},p={className:"comment",
+variants:[o.COMMENT(/\/\*\*(?!\/)/,"\\*/",{relevance:0,contains:[{
+begin:"(?=@[A-Za-z]+)",relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"},{className:"type",begin:"\\{",end:"\\}",excludeEnd:!0,
+excludeBegin:!0,relevance:0},{className:"variable",begin:d+"(?=\\s*(-)|$)",
+endsParent:!0,relevance:0},{begin:/(?=[^\n])\s/,relevance:0}]}]
+}),o.C_BLOCK_COMMENT_MODE,o.C_LINE_COMMENT_MODE]
+},v=[o.APOS_STRING_MODE,o.QUOTE_STRING_MODE,h,_,N,f,{match:/\$\d+/},A]
+;y.contains=v.concat({begin:/\{/,end:/\}/,keywords:g,contains:["self"].concat(v)
+});const S=[].concat(p,y.contains),w=S.concat([{begin:/(\s*)\(/,end:/\)/,
+keywords:g,contains:["self"].concat(S)}]),R={className:"params",begin:/(\s*)\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:g,contains:w},O={variants:[{
+match:[/class/,/\s+/,d,/\s+/,/extends/,/\s+/,l.concat(d,"(",l.concat(/\./,d),")*")],
+scope:{1:"keyword",3:"title.class",5:"keyword",7:"title.class.inherited"}},{
+match:[/class/,/\s+/,d],scope:{1:"keyword",3:"title.class"}}]},k={relevance:0,
+match:l.either(/\bJSON/,/\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,/\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,/\b[A-Z]{2,}[a-z]+([A-Z][a-z]+|\d)*([A-Z][a-z]*)*/),
+className:"title.class",keywords:{_:[...t,...s]}},I={variants:[{
+match:[/function/,/\s+/,d,/(?=\s*\()/]},{match:[/function/,/\s*(?=\()/]}],
+className:{1:"keyword",3:"title.function"},label:"func.def",contains:[R],
+illegal:/%/},x={
+match:l.concat(/\b/,(T=[...r,"super","import"].map((e=>e+"\\s*\\(")),
+l.concat("(?!",T.join("|"),")")),d,l.lookahead(/\s*\(/)),
+className:"title.function",relevance:0};var T;const C={
+begin:l.concat(/\./,l.lookahead(l.concat(d,/(?![0-9A-Za-z$_(])/))),end:d,
+excludeBegin:!0,keywords:"prototype",className:"property",relevance:0},M={
+match:[/get|set/,/\s+/,d,/(?=\()/],className:{1:"keyword",3:"title.function"},
+contains:[{begin:/\(\)/},R]
+},B="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+o.UNDERSCORE_IDENT_RE+")\\s*=>",$={
+match:[/const|var|let/,/\s+/,d,/\s*/,/=\s*/,/(async\s*)?/,l.lookahead(B)],
+keywords:"async",className:{1:"keyword",3:"title.function"},contains:[R]}
+;return{name:"JavaScript",aliases:["js","jsx","mjs","cjs"],keywords:g,exports:{
+PARAMS_CONTAINS:w,CLASS_REFERENCE:k},illegal:/#(?![$_A-z])/,
+contains:[o.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
+label:"use_strict",className:"meta",relevance:10,
+begin:/^\s*['"]use (strict|asm)['"]/
+},o.APOS_STRING_MODE,o.QUOTE_STRING_MODE,h,_,N,f,p,{match:/\$\d+/},A,k,{
+scope:"attr",match:d+l.lookahead(":"),relevance:0},$,{
+begin:"("+o.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
+keywords:"return throw case",relevance:0,contains:[p,o.REGEXP_MODE,{
+className:"function",begin:B,returnBegin:!0,end:"\\s*=>",contains:[{
+className:"params",variants:[{begin:o.UNDERSCORE_IDENT_RE,relevance:0},{
+className:null,begin:/\(\s*\)/,skip:!0},{begin:/(\s*)\(/,end:/\)/,
+excludeBegin:!0,excludeEnd:!0,keywords:g,contains:w}]}]},{begin:/,/,relevance:0
+},{match:/\s+/,relevance:0},{variants:[{begin:"<>",end:"</>"},{
+match:/<[A-Za-z0-9\\._:-]+\s*\/>/},{begin:b.begin,
+"on:begin":b.isTrulyOpeningTag,end:b.end}],subLanguage:"xml",contains:[{
+begin:b.begin,end:b.end,skip:!0,contains:["self"]}]}]},I,{
+beginKeywords:"while if switch catch for"},{
+begin:"\\b(?!function)"+o.UNDERSCORE_IDENT_RE+"\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
+returnBegin:!0,label:"func.def",contains:[R,o.inherit(o.TITLE_MODE,{begin:d,
+className:"title.function"})]},{match:/\.\.\./,relevance:0},C,{match:"\\$"+d,
+relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
+contains:[R]},x,{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},O,M,{match:/\$[(.]/}]}}})()
+;hljs.registerLanguage("javascript",e)})();/*! `php` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{
+const t=e.regex,a=/(?![A-Za-z0-9])(?![$])/,r=t.concat(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,a),n=t.concat(/(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,a),o=t.concat(/[A-Z]+/,a),c={
+scope:"variable",match:"\\$+"+r},i={scope:"subst",variants:[{begin:/\$\w+/},{
+begin:/\{\$/,end:/\}/}]},s=e.inherit(e.APOS_STRING_MODE,{illegal:null
+}),l="[ \t\n]",d={scope:"string",variants:[e.inherit(e.QUOTE_STRING_MODE,{
+illegal:null,contains:e.QUOTE_STRING_MODE.contains.concat(i)}),s,{
+begin:/<<<[ \t]*(?:(\w+)|"(\w+)")\n/,end:/[ \t]*(\w+)\b/,
+contains:e.QUOTE_STRING_MODE.contains.concat(i),"on:begin":(e,t)=>{
+t.data._beginMatch=e[1]||e[2]},"on:end":(e,t)=>{
+t.data._beginMatch!==e[1]&&t.ignoreMatch()}},e.END_SAME_AS_BEGIN({
+begin:/<<<[ \t]*'(\w+)'\n/,end:/[ \t]*(\w+)\b/})]},_={scope:"number",variants:[{
+begin:"\\b0[bB][01]+(?:_[01]+)*\\b"},{begin:"\\b0[oO][0-7]+(?:_[0-7]+)*\\b"},{
+begin:"\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b"},{
+begin:"(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?"
+}],relevance:0
+},p=["false","null","true"],b=["__CLASS__","__DIR__","__FILE__","__FUNCTION__","__COMPILER_HALT_OFFSET__","__LINE__","__METHOD__","__NAMESPACE__","__TRAIT__","die","echo","exit","include","include_once","print","require","require_once","array","abstract","and","as","binary","bool","boolean","break","callable","case","catch","class","clone","const","continue","declare","default","do","double","else","elseif","empty","enddeclare","endfor","endforeach","endif","endswitch","endwhile","enum","eval","extends","final","finally","float","for","foreach","from","global","goto","if","implements","instanceof","insteadof","int","integer","interface","isset","iterable","list","match|0","mixed","new","never","object","or","private","protected","public","readonly","real","return","string","switch","throw","trait","try","unset","use","var","void","while","xor","yield"],E=["Error|0","AppendIterator","ArgumentCountError","ArithmeticError","ArrayIterator","ArrayObject","AssertionError","BadFunctionCallException","BadMethodCallException","CachingIterator","CallbackFilterIterator","CompileError","Countable","DirectoryIterator","DivisionByZeroError","DomainException","EmptyIterator","ErrorException","Exception","FilesystemIterator","FilterIterator","GlobIterator","InfiniteIterator","InvalidArgumentException","IteratorIterator","LengthException","LimitIterator","LogicException","MultipleIterator","NoRewindIterator","OutOfBoundsException","OutOfRangeException","OuterIterator","OverflowException","ParentIterator","ParseError","RangeException","RecursiveArrayIterator","RecursiveCachingIterator","RecursiveCallbackFilterIterator","RecursiveDirectoryIterator","RecursiveFilterIterator","RecursiveIterator","RecursiveIteratorIterator","RecursiveRegexIterator","RecursiveTreeIterator","RegexIterator","RuntimeException","SeekableIterator","SplDoublyLinkedList","SplFileInfo","SplFileObject","SplFixedArray","SplHeap","SplMaxHeap","SplMinHeap","SplObjectStorage","SplObserver","SplPriorityQueue","SplQueue","SplStack","SplSubject","SplTempFileObject","TypeError","UnderflowException","UnexpectedValueException","UnhandledMatchError","ArrayAccess","BackedEnum","Closure","Fiber","Generator","Iterator","IteratorAggregate","Serializable","Stringable","Throwable","Traversable","UnitEnum","WeakReference","WeakMap","Directory","__PHP_Incomplete_Class","parent","php_user_filter","self","static","stdClass"],u={
+keyword:b,literal:(e=>{const t=[];return e.forEach((e=>{
+t.push(e),e.toLowerCase()===e?t.push(e.toUpperCase()):t.push(e.toLowerCase())
+})),t})(p),built_in:E},g=e=>e.map((e=>e.replace(/\|\d+$/,""))),h={variants:[{
+match:[/new/,t.concat(l,"+"),t.concat("(?!",g(E).join("\\b|"),"\\b)"),n],scope:{
+1:"keyword",4:"title.class"}}]},m=t.concat(r,"\\b(?!\\()"),I={variants:[{
+match:[t.concat(/::/,t.lookahead(/(?!class\b)/)),m],scope:{2:"variable.constant"
+}},{match:[/::/,/class/],scope:{2:"variable.language"}},{
+match:[n,t.concat(/::/,t.lookahead(/(?!class\b)/)),m],scope:{1:"title.class",
+3:"variable.constant"}},{match:[n,t.concat("::",t.lookahead(/(?!class\b)/))],
+scope:{1:"title.class"}},{match:[n,/::/,/class/],scope:{1:"title.class",
+3:"variable.language"}}]},f={scope:"attr",
+match:t.concat(r,t.lookahead(":"),t.lookahead(/(?!::)/))},v={relevance:0,
+begin:/\(/,end:/\)/,keywords:u,contains:[f,c,I,e.C_BLOCK_COMMENT_MODE,d,_,h]
+},O={relevance:0,
+match:[/\b/,t.concat("(?!fn\\b|function\\b|",g(b).join("\\b|"),"|",g(E).join("\\b|"),"\\b)"),r,t.concat(l,"*"),t.lookahead(/(?=\()/)],
+scope:{3:"title.function.invoke"},contains:[v]};v.contains.push(O)
+;const y=[f,I,e.C_BLOCK_COMMENT_MODE,d,_,h],w={
+begin:t.concat(/#\[\s*\\?/,t.either(n,o)),beginScope:"meta",end:/]/,
+endScope:"meta",keywords:{literal:p,keyword:["new","array"]},contains:[{
+begin:/\[/,end:/]/,keywords:{literal:p,keyword:["new","array"]},
+contains:["self",...y]},...y,{scope:"meta",variants:[{match:n},{match:o}]}]}
+;return{case_insensitive:!1,keywords:u,
+contains:[w,e.HASH_COMMENT_MODE,e.COMMENT("//","$"),e.COMMENT("/\\*","\\*/",{
+contains:[{scope:"doctag",match:"@[A-Za-z]+"}]}),{match:/__halt_compiler\(\);/,
+keywords:"__halt_compiler",starts:{scope:"comment",end:e.MATCH_NOTHING_RE,
+contains:[{match:/\?>/,scope:"meta",endsParent:!0}]}},{scope:"meta",variants:[{
+begin:/<\?php/,relevance:10},{begin:/<\?=/},{begin:/<\?/,relevance:.1},{
+begin:/\?>/}]},{scope:"variable.language",match:/\$this\b/},c,O,I,{
+match:[/const/,/\s/,r],scope:{1:"keyword",3:"variable.constant"}},h,{
+scope:"function",relevance:0,beginKeywords:"fn function",end:/[;{]/,
+excludeEnd:!0,illegal:"[$%\\[]",contains:[{beginKeywords:"use"
+},e.UNDERSCORE_TITLE_MODE,{begin:"=>",endsParent:!0},{scope:"params",
+begin:"\\(",end:"\\)",excludeBegin:!0,excludeEnd:!0,keywords:u,
+contains:["self",w,c,I,e.C_BLOCK_COMMENT_MODE,d,_]}]},{scope:"class",variants:[{
+beginKeywords:"enum",illegal:/[($"]/},{beginKeywords:"class interface trait",
+illegal:/[:($"]/}],relevance:0,end:/\{/,excludeEnd:!0,contains:[{
+beginKeywords:"extends implements"},e.UNDERSCORE_TITLE_MODE]},{
+beginKeywords:"namespace",relevance:0,end:";",illegal:/[.']/,
+contains:[e.inherit(e.UNDERSCORE_TITLE_MODE,{scope:"title.class"})]},{
+beginKeywords:"use",relevance:0,end:";",contains:[{
+match:/\b(as|const|function)\b/,scope:"keyword"},e.UNDERSCORE_TITLE_MODE]},d,_]}
+}})();hljs.registerLanguage("php",e)})();/*! `php-template` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var n=(()=>{"use strict";return n=>({name:"PHP template",
+subLanguage:"xml",contains:[{begin:/<\?(php|=)?/,end:/\?>/,subLanguage:"php",
+contains:[{begin:"/\\*",end:"\\*/",skip:!0},{begin:'b"',end:'"',skip:!0},{
+begin:"b'",end:"'",skip:!0},n.inherit(n.APOS_STRING_MODE,{illegal:null,
+className:null,contains:null,skip:!0}),n.inherit(n.QUOTE_STRING_MODE,{
+illegal:null,className:null,contains:null,skip:!0})]}]})})()
+;hljs.registerLanguage("php-template",n)})();/*! `python` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{
+const n=e.regex,a=/[\p{XID_Start}_]\p{XID_Continue}*/u,s=["and","as","assert","async","await","break","case","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","match","nonlocal|10","not","or","pass","raise","return","try","while","with","yield"],t={
+$pattern:/[A-Za-z]\w+|__\w+__/,keyword:s,
+built_in:["__import__","abs","all","any","ascii","bin","bool","breakpoint","bytearray","bytes","callable","chr","classmethod","compile","complex","delattr","dict","dir","divmod","enumerate","eval","exec","filter","float","format","frozenset","getattr","globals","hasattr","hash","help","hex","id","input","int","isinstance","issubclass","iter","len","list","locals","map","max","memoryview","min","next","object","oct","open","ord","pow","print","property","range","repr","reversed","round","set","setattr","slice","sorted","staticmethod","str","sum","super","tuple","type","vars","zip"],
+literal:["__debug__","Ellipsis","False","None","NotImplemented","True"],
+type:["Any","Callable","Coroutine","Dict","List","Literal","Generic","Optional","Sequence","Set","Tuple","Type","Union"]
+},i={className:"meta",begin:/^(>>>|\.\.\.) /},r={className:"subst",begin:/\{/,
+end:/\}/,keywords:t,illegal:/#/},l={begin:/\{\{/,relevance:0},o={
+className:"string",contains:[e.BACKSLASH_ESCAPE],variants:[{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,i],relevance:10},{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,end:/"""/,
+contains:[e.BACKSLASH_ESCAPE,i],relevance:10},{
+begin:/([fF][rR]|[rR][fF]|[fF])'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,i,l,r]},{begin:/([fF][rR]|[rR][fF]|[fF])"""/,
+end:/"""/,contains:[e.BACKSLASH_ESCAPE,i,l,r]},{begin:/([uU]|[rR])'/,end:/'/,
+relevance:10},{begin:/([uU]|[rR])"/,end:/"/,relevance:10},{
+begin:/([bB]|[bB][rR]|[rR][bB])'/,end:/'/},{begin:/([bB]|[bB][rR]|[rR][bB])"/,
+end:/"/},{begin:/([fF][rR]|[rR][fF]|[fF])'/,end:/'/,
+contains:[e.BACKSLASH_ESCAPE,l,r]},{begin:/([fF][rR]|[rR][fF]|[fF])"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,l,r]},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},b="[0-9](_?[0-9])*",c=`(\\b(${b}))?\\.(${b})|\\b(${b})\\.`,d="\\b|"+s.join("|"),g={
+className:"number",relevance:0,variants:[{
+begin:`(\\b(${b})|(${c}))[eE][+-]?(${b})[jJ]?(?=${d})`},{begin:`(${c})[jJ]?`},{
+begin:`\\b([1-9](_?[0-9])*|0+(_?0)*)[lLjJ]?(?=${d})`},{
+begin:`\\b0[bB](_?[01])+[lL]?(?=${d})`},{begin:`\\b0[oO](_?[0-7])+[lL]?(?=${d})`
+},{begin:`\\b0[xX](_?[0-9a-fA-F])+[lL]?(?=${d})`},{begin:`\\b(${b})[jJ](?=${d})`
+}]},p={className:"comment",begin:n.lookahead(/# type:/),end:/$/,keywords:t,
+contains:[{begin:/# type:/},{begin:/#/,end:/\b\B/,endsWithParent:!0}]},m={
+className:"params",variants:[{className:"",begin:/\(\s*\)/,skip:!0},{begin:/\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:t,
+contains:["self",i,g,o,e.HASH_COMMENT_MODE]}]};return r.contains=[o,g,i],{
+name:"Python",aliases:["py","gyp","ipython"],unicodeRegex:!0,keywords:t,
+illegal:/(<\/|\?)|=>/,contains:[i,g,{scope:"variable.language",match:/\bself\b/
+},{beginKeywords:"if",relevance:0},{match:/\bor\b/,scope:"keyword"
+},o,p,e.HASH_COMMENT_MODE,{match:[/\bdef/,/\s+/,a],scope:{1:"keyword",
+3:"title.function"},contains:[m]},{variants:[{
+match:[/\bclass/,/\s+/,a,/\s*/,/\(\s*/,a,/\s*\)/]},{match:[/\bclass/,/\s+/,a]}],
+scope:{1:"keyword",3:"title.class",6:"title.class.inherited"}},{
+className:"meta",begin:/^[\t ]*@/,end:/(?=#)|$/,contains:[g,m,o]}]}}})()
+;hljs.registerLanguage("python",e)})();/*! `vbnet` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{
+const n=e.regex,t=/\d{1,2}\/\d{1,2}\/\d{4}/,a=/\d{4}-\d{1,2}-\d{1,2}/,i=/(\d|1[012])(:\d+){0,2} *(AM|PM)/,s=/\d{1,2}(:\d{1,2}){1,2}/,r={
+className:"literal",variants:[{begin:n.concat(/# */,n.either(a,t),/ *#/)},{
+begin:n.concat(/# */,s,/ *#/)},{begin:n.concat(/# */,i,/ *#/)},{
+begin:n.concat(/# */,n.either(a,t),/ +/,n.either(i,s),/ *#/)}]
+},l=e.COMMENT(/'''/,/$/,{contains:[{className:"doctag",begin:/<\/?/,end:/>/}]
+}),o=e.COMMENT(null,/$/,{variants:[{begin:/'/},{begin:/([\t ]|^)REM(?=\s)/}]})
+;return{name:"Visual Basic .NET",aliases:["vb"],case_insensitive:!0,
+classNameAliases:{label:"symbol"},keywords:{
+keyword:"addhandler alias aggregate ansi as async assembly auto binary by byref byval call case catch class compare const continue custom declare default delegate dim distinct do each equals else elseif end enum erase error event exit explicit finally for friend from function get global goto group handles if implements imports in inherits interface into iterator join key let lib loop me mid module mustinherit mustoverride mybase myclass namespace narrowing new next notinheritable notoverridable of off on operator option optional order overloads overridable overrides paramarray partial preserve private property protected public raiseevent readonly redim removehandler resume return select set shadows shared skip static step stop structure strict sub synclock take text then throw to try unicode until using when where while widening with withevents writeonly yield",
+built_in:"addressof and andalso await directcast gettype getxmlnamespace is isfalse isnot istrue like mod nameof new not or orelse trycast typeof xor cbool cbyte cchar cdate cdbl cdec cint clng cobj csbyte cshort csng cstr cuint culng cushort",
+type:"boolean byte char date decimal double integer long object sbyte short single string uinteger ulong ushort",
+literal:"true false nothing"},
+illegal:"//|\\{|\\}|endif|gosub|variant|wend|^\\$ ",contains:[{
+className:"string",begin:/"(""|[^/n])"C\b/},{className:"string",begin:/"/,
+end:/"/,illegal:/\n/,contains:[{begin:/""/}]},r,{className:"number",relevance:0,
+variants:[{begin:/\b\d[\d_]*((\.[\d_]+(E[+-]?[\d_]+)?)|(E[+-]?[\d_]+))[RFD@!#]?/
+},{begin:/\b\d[\d_]*((U?[SIL])|[%&])?/},{begin:/&H[\dA-F_]+((U?[SIL])|[%&])?/},{
+begin:/&O[0-7_]+((U?[SIL])|[%&])?/},{begin:/&B[01_]+((U?[SIL])|[%&])?/}]},{
+className:"label",begin:/^\w+:/},l,o,{className:"meta",
+begin:/[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
+end:/$/,keywords:{
+keyword:"const disable else elseif enable end externalsource if region then"},
+contains:[o]}]}}})();hljs.registerLanguage("vbnet",e)})();/*! `xml` grammar compiled for Highlight.js 11.11.1 */
+(()=>{var e=(()=>{"use strict";return e=>{
+const a=e.regex,n=a.concat(/[\p{L}_]/u,a.optional(/[\p{L}0-9_.-]*:/u),/[\p{L}0-9_.-]*/u),s={
+className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},t={begin:/\s/,
+contains:[{className:"keyword",begin:/#?[a-z_][a-z1-9_-]+/,illegal:/\n/}]
+},i=e.inherit(t,{begin:/\(/,end:/\)/}),c=e.inherit(e.APOS_STRING_MODE,{
+className:"string"}),l=e.inherit(e.QUOTE_STRING_MODE,{className:"string"}),r={
+endsWithParent:!0,illegal:/</,relevance:0,contains:[{className:"attr",
+begin:/[\p{L}0-9._:-]+/u,relevance:0},{begin:/=\s*/,relevance:0,contains:[{
+className:"string",endsParent:!0,variants:[{begin:/"/,end:/"/,contains:[s]},{
+begin:/'/,end:/'/,contains:[s]},{begin:/[^\s"'=<>`]+/}]}]}]};return{
+name:"HTML, XML",
+aliases:["html","xhtml","rss","atom","xjb","xsd","xsl","plist","wsf","svg"],
+case_insensitive:!0,unicodeRegex:!0,contains:[{className:"meta",begin:/<![a-z]/,
+end:/>/,relevance:10,contains:[t,l,c,i,{begin:/\[/,end:/\]/,contains:[{
+className:"meta",begin:/<![a-z]/,end:/>/,contains:[t,i,l,c]}]}]
+},e.COMMENT(/<!--/,/-->/,{relevance:10}),{begin:/<!\[CDATA\[/,end:/\]\]>/,
+relevance:10},s,{className:"meta",end:/\?>/,variants:[{begin:/<\?xml/,
+relevance:10,contains:[l]},{begin:/<\?[a-z][a-z0-9]+/}]},{className:"tag",
+begin:/<style(?=\s|>)/,end:/>/,keywords:{name:"style"},contains:[r],starts:{
+end:/<\/style>/,returnEnd:!0,subLanguage:["css","xml"]}},{className:"tag",
+begin:/<script(?=\s|>)/,end:/>/,keywords:{name:"script"},contains:[r],starts:{
+end:/<\/script>/,returnEnd:!0,subLanguage:["javascript","handlebars","xml"]}},{
+className:"tag",begin:/<>|<\/>/},{className:"tag",
+begin:a.concat(/</,a.lookahead(a.concat(n,a.either(/\/>/,/>/,/\s/)))),
+end:/\/?>/,contains:[{className:"name",begin:n,relevance:0,starts:r}]},{
+className:"tag",begin:a.concat(/<\//,a.lookahead(a.concat(n,/>/))),contains:[{
+className:"name",begin:n,relevance:0},{begin:/>/,relevance:0,endsParent:!0}]}]}}
+})();hljs.registerLanguage("xml",e)})();

--- a/techniques/aria/ARIA24.html
+++ b/techniques/aria/ARIA24.html
@@ -79,7 +79,7 @@
 			</section>
          	<section>
             <h5><strong>- Do... -</strong></h5>
-            <pre xml:space="preserve"><code>&lt;p&gt;
+            <pre><code class="language-html">&lt;p&gt;
   &lt;span class=&quot;icon icon-star-bg&quot; role=&quot;img&quot; aria-label=&quot;Favorite&quot;&gt;&lt;/span&gt;
 &lt;/p&gt;</code></pre>
          	</section>

--- a/techniques/client-side-script/SCR37.html
+++ b/techniques/client-side-script/SCR37.html
@@ -22,7 +22,7 @@ obsoleteSince: 20
             <p>The triggering element is a button and the script is triggered from the onclick event. This sends the appropriate events to the operating system so that assistive technology is aware of the change in the DOM. </p>
             <p>In this example, the Submit and Reset buttons inside the dialog simply hide the <code>div</code>. </p>
          
-         <pre><code>...
+         <pre><code class="language-html">...
 &lt;button onclick="TogglePopup(event,true)"
   name="pop0001"&gt;Options&lt;/button&gt;
 
@@ -46,7 +46,7 @@ obsoleteSince: 20
          
             <p>The <code>div</code>, heading and <code>form</code> elements are styled with CSS to look like a dialog. </p>
          
-         <pre><code>...
+         <pre><code class="language-css">...
 a { color:blue; }
 a.clickPopup img { border:none; width:0; }
 
@@ -63,7 +63,7 @@ div.popover h3 { margin:0; padding:0.1em 0.5em; background-color:navy; color:whi
          
             <p>The script toggles the display of the popup <code>div</code>, showing it and hiding it. </p>
          
-         <pre><code>...
+         <pre><code class="language-javascript">...
 function TogglePopup(evt,show) {
   HarmonizeEvent(evt);
   var src = evt.target;

--- a/techniques/css/C15.html
+++ b/techniques/css/C15.html
@@ -48,7 +48,7 @@
 				<h3>Highlighting elements that receive focus</h3>
 				<p>In this example, the :focus pseudo-class is used to change the style applied to input fields when they receive focus by changing the background color.</p>
          
-<pre xml:space="preserve"><code class="language-">&lt;!doctype html&gt;
+<pre><code class="language-html">&lt;!doctype html&gt;
 &lt;html lang="en"&gt;
   &lt;head&gt;
     &lt;style&gt;

--- a/techniques/css/C43.html
+++ b/techniques/css/C43.html
@@ -30,7 +30,7 @@
           <p>This example demonstrates a technique to un-obscure content underneath a fixed-position banner. To prevent the page becoming unusable at smaller screen sizes, the banner becomes un-fixed. To observe the <code>scroll-padding</code> effect you will need to use a viewport over 800px wide.</p>
         </aside>
 				<p>Working example: <a href="../../working-examples/css-padding-focus-not-obscured/">Using CSS <code>scroll-padding</code> to un-obscure content</a>.</p>
-<pre xml:space="preserve"><code>&lt;!doctype html&gt;
+<pre><code class="language-html">&lt;!doctype html&gt;
 &lt;html lang="en"&gt;
 &lt;head&gt;
   &lt;meta charset="utf-8"&gt;

--- a/techniques/css/C45.html
+++ b/techniques/css/C45.html
@@ -36,7 +36,7 @@
         <p>By default, in all modern browsers, this button does not show any focus indication when activated using a mouse/pointer. Browsers show their default focus outline/indication when a user sets focus on the button using <kbd>Tab</kbd>.</p>
         <p>In order to make this focus indication more prominent, we use the <code>:focus-visible</code> pseudo-class selector to define a more intentional and pronounced focus style.</p>
 				<p>Working example: <a href="../../working-examples/css-focus-visible/">Using CSS <code>:focus-visible</code> to provide keyboard focus indication</a>.</p>
-<pre><code>&lt;!DOCTYPE html&gt;
+<pre><code class="language-html">&lt;!DOCTYPE html&gt;
 &lt;html lang="en"&gt;
 &lt;head&gt;
   &lt;meta charset="utf-8"&gt;

--- a/techniques/css/C8.html
+++ b/techniques/css/C8.html
@@ -27,7 +27,7 @@
 
 			<section id="the-css">
 			<h4>The CSS</h4>
-<pre><code>h2 {
+<pre><code class="language-css">h2 {
   letter-spacing: 1em;
 }</code></pre>
 </section>

--- a/techniques/failures/F111.html
+++ b/techniques/failures/F111.html
@@ -30,7 +30,7 @@
       <section class="example">
 				<h3>A text input with a visible label, but without an accessible name</h3>
 				<p>The text input is preceded by a visible text label "Enter name", but the text is not marked up as a <code>&lt;label&gt;</code> for the input, and there is no alternative way (e.g., <code>aria-label</code>) to provide the input with an accessible name at all.</p>
-				<pre><code>
+				<pre><code class="language-html">
 					&lt;p&gt;Enter name&lt;/p&gt;
 					&lt;input type="text"&gt;
         </code></pre>
@@ -39,7 +39,7 @@
 			<section class="example">
 				<h3>A text input with a visible label and aria-labelledby pointing to a non-existent id</h3>
 				<p>The text input is preceded by a visible text label "Enter name". The text's container has an <code>id</code> of <code>nameEntry</code>, but the input has an <code>aria-labelledby</code> referencing a non-existent <code>name-entry</code> <code>id</code>. As a result, the input lacks an accessible name altogether.</p>
-				<pre><code>
+				<pre><code class="language-html">
 					&lt;p id="nameEntry"&gt;Enter name&lt;/p&gt;
 					&lt;input type="text" aria-labelledby="name-entry" &gt;
         </code></pre>

--- a/techniques/failures/F71.html
+++ b/techniques/failures/F71.html
@@ -12,14 +12,14 @@
          
             <p>The following word looks, in browsers with appropriate font support, like the English word "cook", yet is composed of the string <code>U+03f2 U+043E U+03BF U+006B</code>, only one of which is a letter from the Western alphabet. This word will not be processed meaningfully, and a text alternative is not provided.</p>
          
-         <pre xml:space="preserve"><code>ϲоοk</code></pre>
+         <pre>ϲоοk</pre>
       </section>
       <section class="example">
          <h3>Character entities</h3>
          
             <p>The following example, like its predecessor, will look like the English word "cook" when rendered in browsers with appropriate font support. In this case, the characters are implemented with character entities, but the word will still not be processed meaningfully, and a text alternative is not provided.</p>
          
-         <pre xml:space="preserve"><code>&amp;#x03F2;&amp;#x043E;&amp;#x03BF;&amp;#x006B;</code></pre>
+         <pre><code class="language-html">&amp;#x03F2;&amp;#x043E;&amp;#x03BF;&amp;#x006B;</code></pre>
          
             <p>Working Example: "ϲоοk"</p>
          

--- a/techniques/general/G224.html
+++ b/techniques/general/G224.html
@@ -24,7 +24,7 @@
       <section class="example">
         <p>A website conveys information in a nested list format. The understandability of the list hierarchy is supported by the indentation of the list content. While it is important for the individual list item text to reflow, the list hierarchy would suffer if flattened so that all content would fit within a 320 CSS pixel wide viewport.</p>  
         <p>The following example list contains additional nested lists to provide more context for each of the parent list item's text. To maintain the visual hierarchy, the indentation of each list level remains present, but modified once an author defined CSS breakpoint is met. Additional styles are set for different breakpoints to mitigate against the potential for content to extend beyond a 320px wide viewport, while accounting for visual spacing against the borders of the viewport, to attempt to make the content not feel cramped. At the smallest breakpoint, the content of list items receive a minimum width to mitigate against potentially "squished" content lists with many nested levels. At this breakpoint, each nested list level can be horizontally scrolled into view, and once a nested list is visible within the viewport, only vertical scrolling will be necessary to read the content of the nested list's items.</p>
-<pre><code>
+<pre><code class="language-html">
 &lt;div class="example">
 	&lt;ul>
 		&lt;li>
@@ -56,7 +56,7 @@
 	&lt;/ul>
 &lt;/div>
 </code></pre>
-<pre><code>
+<pre><code class="language-css">
 *, *::before, *::after {
     box-sizing: border-box;
 }
@@ -92,7 +92,7 @@ body, html {
         <p>As a user zooms in the web page, the CSS of the indentation can be adjusted to maintain this necessary structure, while also allowing more text to be visible on a single line.</p>
 
         <p>The following represents a Python code example. The indentation of each line of text is necessary to create a group of statements that are executed as a block.</p>
-<pre><code>
+<pre><code class="language-python">
 def complex_function(x):
     if x > 0:
         for i in range(x):
@@ -114,7 +114,7 @@ def complex_function(x):
         print("x is not a positive number")
 </code></pre>
         <p>The following code example demonstrates the use of indentation to convey the nesting of elements in an HTML document:</p>
-<pre><code>
+<pre><code class="language-html">
 &lt;html lang=en>
 	&lt;head>...&lt;/head>
 	&lt;body>
@@ -125,7 +125,7 @@ def complex_function(x):
 &lt;/html>
 </code></pre>     
         <p>The indentation of code blocks like these could be adjusted at different viewport sizes, via a CSS Media Query.</p>
-<pre><code>
+<pre><code class="language-css">
 @media screen and ( min-width: 320px ) {
 	pre {
 		tab-size: 8px;

--- a/techniques/general/G91.html
+++ b/techniques/general/G91.html
@@ -23,7 +23,7 @@
 		<h2>Examples</h2>
 		<section class="example">
 			<h3>Describing the purpose of a link in <abbr title="HyperText Markup Language">HTML</abbr> in the text content of the <code>a</code> element</h3>
-<pre xml:space="preserve"><code class="language-">&lt;a href="routes.html"&gt;Current routes at Boulders Climbing Gym&lt;/a&gt;</code></pre>
+<pre><code class="language-html">&lt;a href="routes.html"&gt;Current routes at Boulders Climbing Gym&lt;/a&gt;</code></pre>
 		</section>
 	</section>
 	<section id="tests">

--- a/techniques/html/H35.html
+++ b/techniques/html/H35.html
@@ -16,7 +16,7 @@ obsoleteSince: 20
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>An applet to play the tic-tac-toe game. </h3>
-         <pre><code>&lt;applet code="tictactoe.class" width="250" height="250" alt="tic-tac-toe game"&gt;
+         <pre><code class="language-html">&lt;applet code="tictactoe.class" width="250" height="250" alt="tic-tac-toe game"&gt;
    tic-tac-toe game
 &lt;/applet&gt;</code></pre>
       </section>

--- a/techniques/html/H4.html
+++ b/techniques/html/H4.html
@@ -34,7 +34,7 @@ obsoleteSince: 20
                   <code>tabindex</code> attributes of the input fields are used to specify a tab
                 order that navigates column by column.</p>
          
-         <pre><code>&lt;form action="#" method="post"&gt;
+         <pre><code class="language-html">&lt;form action="#" method="post"&gt;
  &lt;table summary="the first column contains the search criteria 
   of the groom, the second column the search criteria of 
   of the bride"&gt;
@@ -89,7 +89,7 @@ obsoleteSince: 20
                 a different number for each element. Then it is easy to rearrange those elements or
                 add new elements and maintain a logical tab order.</p>
          
-         <pre><code>&lt;a href="xxx" tabindex = "1"&gt;First link in list&lt;/a&gt;
+         <pre><code class="language-html">&lt;a href="xxx" tabindex = "1"&gt;First link in list&lt;/a&gt;
 &lt;a href="xxx" tabindex = "1"&gt;Second link in list&lt;/a&gt;
 &lt;a href="xxx" tabindex = "1"&gt;Link that was added long 
   after the original list was created&lt;/a&gt;

--- a/techniques/html/H45.html
+++ b/techniques/html/H45.html
@@ -18,11 +18,11 @@ obsoleteSince: 20
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>Using longdesc to refer to a long description contained on a separate resource.</h3>
-         <pre><code>&lt;p&gt;&lt;img src="chart.gif" alt="a complex chart" longdesc="chartdesc.html"/&gt;&lt;/p&gt;</code></pre>
+         <pre><code class="language-html">&lt;p&gt;&lt;img src="chart.gif" alt="a complex chart" longdesc="chartdesc.html"/&gt;&lt;/p&gt;</code></pre>
       </section>
       <section class="example">
          <h3>Using longdesc to refer to a long description within the same page.</h3>
-         <pre><code>&lt;img longdesc="thispage.html#desc" alt="Line graph of the number of subscribers" src="http://www.company/images/graph.png"&gt;
+         <pre><code class="language-html">&lt;img longdesc="thispage.html#desc" alt="Line graph of the number of subscribers" src="http://www.company/images/graph.png"&gt;
 &lt;div id="desc"&gt;
 &lt;h3&gt;Long Description: Line graph of the number of subscribers&lt;/h3&gt;
 &lt;!-- Full Description of Graph --&gt;

--- a/techniques/html/H46.html
+++ b/techniques/html/H46.html
@@ -21,7 +21,7 @@ obsoleteSince: 20
          <h3>
 							     <code>noembed</code> is provided inside an <code>embed</code>
 						   </h3>
-         <pre><code>&lt;embed src="../movies/history_of_rome.mov"
+         <pre><code class="language-html">&lt;embed src="../movies/history_of_rome.mov"
   height="60" width="144" autostart="false"&gt;
   &lt;noembed&gt;
     &lt;a href="../transcripts/transcript_history_rome.htm"&gt;Transcript of "The history of Rome"&lt;/a&gt;
@@ -32,7 +32,7 @@ obsoleteSince: 20
          <h3>
 							     <code>noembed</code> is provided beside an <code>embed</code>
 						   </h3>
-         <pre><code>&lt;embed src="moviename.swf" width="100" height="80"
+         <pre><code class="language-html">&lt;embed src="moviename.swf" width="100" height="80"
   pluginspage="http://example.com/shockwave/download/" /&gt;
 &lt;noembed&gt;
   &lt;img alt="Still from Movie" src="moviename.gif" 

--- a/techniques/html/H56.html
+++ b/techniques/html/H56.html
@@ -33,7 +33,7 @@
                <p>the title is "YTIVITCA NOITAZILANOITANRETNI, w3c" in hebrew.</p>
                <p>The following markup will produce the expected result:</p>
          
-<pre><code>&lt;p&gt;The title says "&lt;span lang="he" dir="rtl"&gt;פעילות הבינאום, W3C&lt;/span&gt;" in Hebrew.&lt;/p&gt;</code></pre>
+<pre><code class="language-html">&lt;p&gt;The title says "&lt;span lang="he" dir="rtl"&gt;פעילות הבינאום, W3C&lt;/span&gt;" in Hebrew.&lt;/p&gt;</code></pre>
       </section>
    </section>
    <section id="tests">

--- a/techniques/html/H58.html
+++ b/techniques/html/H58.html
@@ -28,12 +28,12 @@
       <section class="example">
          <h3>The use of the <code>lang</code> attribute to define a quote written in German</h3>
 
-<pre xml:space="preserve"><code class="language-html">&lt;blockquote lang="de"&gt;
+<pre lang="de"><code class="language-html">&lt;blockquote lang="de"&gt;
   &lt;p&gt;
-    <span lang="de">Da dachte der Herr daran, ihn aus dem Futter zu schaffen,
+    Da dachte der Herr daran, ihn aus dem Futter zu schaffen,
     aber der Esel merkte, daß kein guter Wind wehte, lief fort
     und machte sich auf den Weg nach Bremen: dort, meinte er,
-    könnte er ja Stadtmusikant werden.</span>
+    könnte er ja Stadtmusikant werden.
   &lt;/p&gt;
 &lt;/blockquote&gt;</code></pre>
       </section>

--- a/techniques/html/H59.html
+++ b/techniques/html/H59.html
@@ -38,7 +38,7 @@ obsoleteSince: 20
             <p>A web page for Chapter 2 of an on-line book might contain the following links
                 within the <code>head</code> section.</p>
          
-<pre><code>&lt;link rel="prev" href="Chapter01.html" title="01. Why Volunteer?"&gt;
+<pre><code class="language-html">&lt;link rel="prev" href="Chapter01.html" title="01. Why Volunteer?"&gt;
 &lt;link rel="next" href="Chapter03.html" title="03. Who Volunteers?" /&gt;</code></pre>
       </section>
    </section>

--- a/techniques/html/H60.html
+++ b/techniques/html/H60.html
@@ -15,7 +15,7 @@ obsoleteSince: 20
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>The WCAG 2 Glossary.</h3>
-         <pre><code>&lt;link rel="glossary" href="https://www.w3.org/TR/WCAG20/#glossary"&gt;</code></pre>
+         <pre><code class="language-html">&lt;link rel="glossary" href="https://www.w3.org/TR/WCAG20/#glossary"&gt;</code></pre>
       </section>
    </section><section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>

--- a/techniques/html/H62.html
+++ b/techniques/html/H62.html
@@ -43,11 +43,11 @@
          <h3>Ruby annotation for Japanese</h3>
          <p>The following is an example in Japanese. For Japanese, the Ruby is used to give the reading of Han characters (Kanji). the Ruby parenthesis element <code>rp</code> is used for user agents that do not support Ruby annotations to indicate that the text in the <code>rt</code> element provides the pronunciation information. The pronunciation information is rendered in parentheses immediately following the base text. (User agents that support Ruby do not show the parentheses.)</p>
 
-<pre xml:space="preserve"><code class="language-html">&lt;p&gt;
+<pre lang="ja"><code class="language-html">&lt;p&gt;
   &lt;ruby&gt;
-    &lt;rb&gt;<span lang="ja">慶應大学</span>&lt;/rb&gt;
+    &lt;rb&gt;慶應大学&lt;/rb&gt;
     &lt;rp&gt;(&lt;/rp&gt;
-    &lt;rt&gt;<span lang="ja">けいおうだいがく</span>&lt;/rt&gt;
+    &lt;rt&gt;けいおうだいがく&lt;/rt&gt;
     &lt;rp&gt;)&lt;/rp&gt;
   &lt;/ruby&gt;
 &lt;/p&gt;</code></pre>

--- a/techniques/html/H70.html
+++ b/techniques/html/H70.html
@@ -33,7 +33,7 @@ obsoleteSince: 20
                 source parameter of main.html and the title attribute, "Main News Content" which
                 identifies its function.</p>
          
-         <pre><code>&lt;frameset cols="20%, *"&gt;
+         <pre><code class="language-html">&lt;frameset cols="20%, *"&gt;
   &lt;frame src="navigation.html" name="navbar" title="Navigation Bar" /&gt;
   &lt;frame src="main.html" name="maincontent" title="Main News Content" /&gt;
   &lt;noframes&gt;

--- a/techniques/html/H73.html
+++ b/techniques/html/H73.html
@@ -36,7 +36,7 @@ obsoleteSince: 20
             <p>This example shows a bus schedule. The route number and direction are included in
                 the <code>summary</code> along with information on how to use the schedule.</p>
          
-         <pre><code>&lt;table summary="Schedule for Route 7 going downtown. Service begins 
+         <pre><code class="language-html">&lt;table summary="Schedule for Route 7 going downtown. Service begins 
 at 4:00 AM and ends at midnight. Intersections are listed in the top row. 
 Find the intersection closest to your starting point or destination, then read 
 down that column to find out what time the bus leaves that intersection."&gt;
@@ -65,7 +65,7 @@ down that column to find out what time the bus leaves that intersection."&gt;
                 Screen readers read the <code>caption</code>, followed by the
               <code>summary</code>.</p>
          
-         <pre><code>&lt;table summary="Intersections are listed in row 1. 
+         <pre><code class="language-html">&lt;table summary="Intersections are listed in row 1. 
 Find the intersection closest to your starting point 
 or destination, then read down that column to find 
 out what time the bus leaves that intersection.  

--- a/techniques/pdf/PDF1.html
+++ b/techniques/pdf/PDF1.html
@@ -82,11 +82,11 @@
 				<section class="example">
 					<h3>Adding a text alternative to an image in a PDF document using an <code>/Alt</code> entry</h3>
 					<p>The <code>/Alt</code> property used on an image of mountains with a moon and trees typically would be used like this (typically accomplished by an authoring tool):</p>
-<pre xml:space="preserve"><code>/Figure &lt;&lt;/Alt (Sketch of Mountains with moon rising over trees)&gt;&gt;</code></pre>
+<pre><code class="no-highlight">/Figure &lt;&lt;/Alt (Sketch of Mountains with moon rising over trees)&gt;&gt;</code></pre>
 					<p>The image might also be represented by a tag with a different name. A different name might be used because the tag name is written in a language other than English or because a specific tool uses a different name for some other reason. In this situation, it is also necessary that the <code>RoleMap</code> contained within the <code>StructTreeRoot</code> for the PDF document contain an entry which explicitly maps the name of the tag used for the image with the standard structure type used in PDF documents (in this case, Figure). If the RoleMap contains only an entry mapping Shape tags to Figure tags, the <code>rolemap</code> information would appear as follows:</p>
-<pre xml:space="preserve"><code>/RoleMap &lt;&lt; /Shape /Figure &gt;&gt;</code></pre>
+<pre><code class="no-highlight">/RoleMap &lt;&lt; /Shape /Figure &gt;&gt;</code></pre>
 					<p>In this case, the usage of the <code>/Alt</code> entry as follows would also be correct:</p>
-<pre xml:space="preserve"><code>/Shape &lt;&lt;/Alt (Crater Lake in the summer, with the blue sky, clouds and
+<pre><code class="no-highlight">/Shape &lt;&lt;/Alt (Crater Lake in the summer, with the blue sky, clouds and
  crater walls perfectly reflected in the lake) &gt;&gt;</code></pre>
 					<p>Note that the <code>/Alt</code> entry in property lists can be combined with other entries.</p>
 				</section>

--- a/techniques/pdf/PDF10.html
+++ b/techniques/pdf/PDF10.html
@@ -69,7 +69,7 @@
             <p>The following code fragment illustrates the use of the TU entry to
     						provide a tooltip (or programmatically associated text label) for a
     						form field. This is typically accomplished by an authoring tool. </p>
-            <pre xml:space="preserve"><code>&lt;&lt; /AP -dict-                                                   
+            <pre><code class="no-highlight">&lt;&lt; /AP -dict-                                                   
    /DA /Helv  0 Tf 0 g
    /DR -dict-
    /F 0x4

--- a/techniques/pdf/PDF11.html
+++ b/techniques/pdf/PDF11.html
@@ -116,14 +116,14 @@
     						the association between content items and link annotations, providing
     						functionality comparable to <abbr title="HyperText Markup Language">HTML</abbr> hypertext links.</p>
         <p>In HTML, the following example produces text containing a hypertext link: </p>
-            <pre xml:space="preserve"><code class="language-html">&lt;p&gt;Here is some text &lt;a href="https://www.w3.org/WAI/"&gt;with a link&lt;/a&gt; inside.&lt;/p&gt;</code></pre>
+            <pre><code class="language-html">&lt;p&gt;Here is some text &lt;a href="https://www.w3.org/WAI/"&gt;with a link&lt;/a&gt; inside.&lt;/p&gt;</code></pre>
             <p>In PDF the page must be painted first and then a link annotation
     						placed over the area where the object action will occur. </p>
             <p>The following code fragment shows PDF equivalent to the HTML above;
     						it uses link text displayed in blue and underlined. A second code fragment
     						follows, indicating the associated logical structure hierarchy. This
     						is typically accomplished by an authoring tool. </p>
-            <pre xml:space="preserve"><code>/P &lt;&lt;/MCID 0&gt;&gt;                                                %Marked Content Sequence 0 (paragraph)
+            <pre><code class="no-highlight">/P &lt;&lt;/MCID 0&gt;&gt;                                                %Marked Content Sequence 0 (paragraph)
   BDC                                                          %Begin marked content sequence
    BT                                                          %Begin text object
     /F1 11.04 Tf                                               %set text font and size
@@ -168,7 +168,7 @@
             <p> The following code fragment is an excerpt from the logical structure
     						that establishes the association between the content items and the
     						link annotation: </p>
-            <pre xml:space="preserve"><code> 11 0 obj                                              %Object ID 11, generation   0, obj keyword
+            <pre><code class="no-highlight"> 11 0 obj                                              %Object ID 11, generation   0, obj keyword
   &lt;&lt;/K[1                                               %immediate child of the structure tree root
    &lt;&lt;
     /Obj 26 0 R                                        %reference to Object 26

--- a/techniques/pdf/PDF12.html
+++ b/techniques/pdf/PDF12.html
@@ -177,7 +177,7 @@
     <section class="example">
       <h3>Adding a checkbox in a PDF document using the <code>/Btn</code> field type</h3>   
       <p>The following code fragment illustrates code that is typical for a simple check box field such as shown in Examples 1 and 2. This is typically accomplished by an authoring tool.</p>
-            <pre xml:space="preserve"><code>1 0 obj
+            <pre><code class="no-highlight">1 0 obj
   &lt;&lt; /FT /Btn     % Role
      /TU Retiree  % Name
      /V /Yes      % Value

--- a/techniques/pdf/PDF13.html
+++ b/techniques/pdf/PDF13.html
@@ -65,14 +65,14 @@
 		<section class="example">
 			<h3>Adding alternate link text in a PDF document using the <code>/Alt</code> entry</h3>
 			<p>The following code fragment illustrates code that is typical for alternative text for a link. This is typically accomplished by an authoring tool.</p>
-            <pre xml:space="preserve"><code>32 0 obj
+            <pre><code class="no-highlight">32 0 obj
 &lt;&lt;
   /S/URI                                       %Action type (required), must be URI for a URI action
   /URI(http://www.boston.com/business/technology/)  %Uniform resource identifier(required), the URI to be resolved
 &gt;&gt;
 endobj</code></pre>
       <p>The following illustrates how to specify alternate text for the URL in the above link:</p>
-            <pre xml:space="preserve"><code>11 0 obj
+            <pre><code class="no-highlight">11 0 obj
 &lt;&lt;
   /Alt(Boston Globe technology page)    %Alternate text entry
   /K [ 1                                                      

--- a/techniques/pdf/PDF16.html
+++ b/techniques/pdf/PDF16.html
@@ -46,7 +46,7 @@
 				<h3>Specifying the default document language in a PDF document using a <code>/Lang</code> entry</h3>
         <p>The natural language used for text in a document is determined in a hierarchical fashion, based on whether an optional <code>/Lang</code> entry is present in any of several possible locations. At the highest level, the document's default language may be specified by a <code>/Lang</code> entry in the document catalog.</p>
             <p>The following code fragment illustrates code that is typical for using the <code>/Lang</code> entry in the document catalog for a document's default language (in this case English). (This is typically accomplished by an authoring tool.)</p>
-            <pre xml:space="preserve"><code>1 0 obj
+            <pre><code class="no-highlight">1 0 obj
    &lt;&lt; /Type /Catalog
       ...
       /Lang (en)

--- a/techniques/pdf/PDF17.html
+++ b/techniques/pdf/PDF17.html
@@ -77,7 +77,7 @@
 				<p>The following code fragment illustrates code that is typical for specifying multiple page numbering schemes in a document.</p>
 				<p>The example below is for a document with pages labeled: i, ii, iii, iv, 1, 2, 3, A-8, A-9, ...</p>
 				<p>This numbering scheme requires 3 page-label dictionaries (for lowercase Roman, Arabic, and prefixed numbers) </p>
-            <pre xml:space="preserve"><code>1 0 obj
+            <pre><code class="no-highlight">1 0 obj
     &lt;&lt; /Type /Catalog
        /PageLabels &lt;&lt; /Nums [ 0 &lt;&lt; /S /r &gt;&gt;  % lowercase Roman numerals
                               4 &lt;&lt; /S /D &gt;&gt;  % Arabic numerals

--- a/techniques/pdf/PDF18.html
+++ b/techniques/pdf/PDF18.html
@@ -58,7 +58,7 @@
       <section class="example">
 				<h3>A <code>/Title</code> entry in the document information dictionary of a PDF document</h3>
 				<p>The following code fragment illustrates code that is typical for providing a <code>/Title</code> entry in a document information dictionary that contains a document title.</p>
-				<pre xml:space="preserve"><code>1 0 obj   
+				<pre><code class="no-highlight">1 0 obj   
   &lt;&lt; /Title (Applying Guerrilla Tactics to Usability Testing by People with Disabilities)    
     /Author (Mary Smith) 
     /CreationDate (D:19970915110347-08'00')    

--- a/techniques/pdf/PDF19.html
+++ b/techniques/pdf/PDF19.html
@@ -74,7 +74,7 @@
           <li>Structure elements of any type, through a <code>/Lang</code> entry in the structure element dictionary.</li>
 				</ul>
         <p>The following code fragment illustrates code that is typical for using the <code>/Lang</code> entry to override the default document language by specifying a marked-content sequence within a page's content stream:</p>
-            <pre xml:space="preserve"><code>/P % Start of marked-content sequence
+            <pre><code class="no-highlight">/P % Start of marked-content sequence
    BDC
       (See you later, or in Spanish you would say, ) Tj
       /Span &lt;&lt; /Lang (es-MX) &gt;&gt;% Start of nested marked-content sequence
@@ -84,7 +84,7 @@
    EMC% End of marked-content sequence</code></pre>
       
 	 <p>The following code fragment illustrates code that is typical for using the <code>/Lang</code> entry in the structure element dictionary. In this case, the <code>/Lang</code> entry applies to the marked-content sequence having an MCID (marked-content identifier) value of 0 within the indicated page's content stream.</p>
-            <pre xml:space="preserve"><code>1 0 obj% Structure element
+            <pre><code class="no-highlight">1 0 obj% Structure element
   &lt;&lt; /Type /StructElem
     /S /Span% Structure type
     /P /P% Parent in structure hierarchy

--- a/techniques/pdf/PDF2.html
+++ b/techniques/pdf/PDF2.html
@@ -76,7 +76,7 @@
 			<section class="example">
 				<h3>Creating bookmarks with the outline hierarchy</h3> 
 				<p>The following code fragment illustrates part of an outline hierarchy used to create bookmarks This is typically accomplished by an authoring tool.</p>
-<pre xml:space="preserve"><code>121 0 obj
+<pre><code class="no-highlight">121 0 obj
   &lt;&lt; /Type /Outlines
     /First 22 0 R
     /Last 29 0 R

--- a/techniques/pdf/PDF20.html
+++ b/techniques/pdf/PDF20.html
@@ -77,7 +77,7 @@
       <section class="example">
          <h3>Marking up a table using table structure elements</h3>
 				 <p>The following code fragment illustrates code that is typical for a simple table (header row and data row) such as shown in Examples 1-3:</p>
-            <pre xml:space="preserve"><code>95 0 obj                %Structure element for a table
+            <pre><code class="no-highlight">95 0 obj                %Structure element for a table
  &lt;&lt; 
   /A 39 0 R
   /K[96 0 R 101 0 R 106 0 R 111 0 R]

--- a/techniques/pdf/PDF23.html
+++ b/techniques/pdf/PDF23.html
@@ -66,7 +66,7 @@
 			<section class="example">
         <h3>Adding a text field in a PDF document using the <code>/Tx</code> field type</h3>
         <p>The following code fragment illustrates code that is typical for a simple text field such as shown in Examples 1 and 2. This is typically accomplished by an authoring tool. </p>
-            <pre xml:space="preserve"><code>&lt;&lt; /AP -dict-                                                   
+            <pre><code class="no-highlight">&lt;&lt; /AP -dict-                                                   
    /DA /Helv  0 Tf 0 g
    /DR -dict-
    /F 0x4

--- a/techniques/pdf/PDF4.html
+++ b/techniques/pdf/PDF4.html
@@ -39,10 +39,10 @@
 				
 				<section id="artifact">
 					<h4>/Artifact</h4>
-            <pre xml:space="preserve"><code>BMC  ...  EMC</code></pre>
+            <pre><code class="no-highlight">BMC  ...  EMC</code></pre>
             <p>or</p>
             <h4>/Artifact propertyList</h4>
-            <pre xml:space="preserve"><code>BDC  ...  EMC</code></pre>
+            <pre><code class="no-highlight">BDC  ...  EMC</code></pre>
             <p>The first is used to identify a generic artifact; the second is used for artifacts that have an associated property list. Note, to aid in text reflow, artifacts should be defined with property lists whenever possible. Artifacts lacking a specified bounding box are likely to be discarded during reflow.</p>
             <p>Property list entries for artifacts include <code>Type</code>, <code>BBox</code>, <code>Attached</code>, and <code>Subtype</code>.</p>
 					</section>

--- a/techniques/pdf/PDF5.html
+++ b/techniques/pdf/PDF5.html
@@ -42,7 +42,7 @@
 				<section class="example">
 					<h3>Adding a required text field in a PDF form using the /Tx field type and Ff flag</h3>
           <p>The following code fragment illustrates code that is typical for the object definitions for a typical text field. Note that the text field is required, using the Ff flag. This is typically accomplished by an authoring tool.</p>
-<pre xml:space="preserve"><code>&lt;&lt; /AP -dict-                                                   
+<pre><code class="no-highlight">&lt;&lt; /AP -dict-                                                   
    /DA /Helv  0 Tf 0 g
    /DR -dict-
    /F 0x4

--- a/techniques/pdf/PDF6.html
+++ b/techniques/pdf/PDF6.html
@@ -87,7 +87,7 @@
       <section class="example">
 				<h3>Marking up a table using table structure elements</h3> 
 				<p>The following code fragment illustrates code that is typical for a simple table (header row and data row):</p>
-<pre xml:space="preserve"><code>95 0 obj                %Structure element for a table
+<pre><code class="no-highlight">95 0 obj                %Structure element for a table
   &lt;&lt; 
     /A 39 0 R
     /K[96 0 R 101 0 R 106 0 R 111 0 R]

--- a/techniques/pdf/PDF8.html
+++ b/techniques/pdf/PDF8.html
@@ -49,7 +49,7 @@
 				<h3>Using a <code>/Span</code> structure element with an <span>/E</span> entry to define an abbreviation</h3>
 				<p>The following code fragment illustrates code that is typical for using the <code>/Span</code> structure element to define an abbreviation.</p>
 				<p>This example uses the sentence "Sugar is commonly sold in 5 lb bags." The abbreviation "lb" is tagged as a <code>/Span</code> structure element with an <code>/E</code> entry (typically accomplished by an authoring tool).</p>
-<pre xml:space="preserve"><code>1 0 obj                                  % structure element
+<pre><code class="no-highlight">1 0 obj                                  % structure element
   &lt;&lt; /Type /StructElemen
            /S /Span                      % element type
            /P ...                        % Parent in structure hierarchy
@@ -66,7 +66,7 @@ endobj</code></pre>
 				<p>As noted in the Description, the <code>/E</code> entry is valid with any structure element.</p>
 				<p>The following code fragment illustrates code that is typical for using an <code>/E</code> entry to define an abbreviation.</p>
 				<p>A table that contains columns for each month uses abbreviations as the values of column headers. The expansion for each abbreviation is provided as the <code>/E</code> entry of the <code>/TH</code> structure element (typically accomplished by an authoring tool).</p>
-<pre xml:space="preserve"><code>1 0 obj                                  % structure element
+<pre><code class="no-highlight">1 0 obj                                  % structure element
   &lt;&lt; /Type /StructElemen
           /S /TH                        % element type
           /P ...                        % Parent in structure hierarchy

--- a/techniques/pdf/PDF9.html
+++ b/techniques/pdf/PDF9.html
@@ -72,7 +72,7 @@
 						<h3>Marking up headings using /H<em>n</em> elements</h3>
             <p>Headings within PDF documents can be marked up using /H<em>n</em> elements in the structure tree, where <em>n</em> is numeral 1 through 6 (for example /H1, /H2, etc.). </p>
             <p>The following code fragment illustrates code that is typical for using the /H<em>n</em> elements to mark content. Note that /H1 has been role-mapped to /Head1 in this example. This is typically accomplished by an authoring tool.</p>
-            <pre xml:space="preserve"><code>0 obj% Document catalog
+            <pre><code class="no-highlight">0 obj% Document catalog
   &lt;&lt; /Type /Catalog
      /Pages 100 0 R                  % Page tree
      /StructTreeRoot 300 0 R         % Structure tree root
@@ -122,7 +122,7 @@ endobj
 endobj
 ...</code></pre>
             <p>Within marked content containers, headings can be marked up using /Head<em>n</em> elements as follows for a first-level heading in a PDF document:</p>
-<pre xml:space="preserve"><code>BT		 		% Start of text object
+<pre><code class="no-highlight">BT		 		% Start of text object
   /Head1 &lt;&lt;/MCID 0 &gt;&gt;   	% Start of marked-content sequence
      BDC
         ...

--- a/understanding/20/language-of-parts.html
+++ b/understanding/20/language-of-parts.html
@@ -134,7 +134,7 @@
          <h3>The element's content and attribute values are in different languages</h3>
          <p>This example assumes that the page's default content is in English. The link's <code>title</code> attribute is in English, but the nested <code>span</code> element that contains the word <span lang="es">Español</span> has a <code>lang="es"</code> attribute.</p>
 
-         <p><code>&lt;a title="Spanish" href="qa-html-language-declarations-es.html"&gt;&lt;span lang="es"&gt;Español&lt;/span&gt;&lt;/a&gt;</code></p>
+         <pre><code class="language-html">&lt;a title="Spanish" href="qa-html-language-declarations-es.html"&gt;&lt;span lang="es"&gt;Español&lt;/span&gt;&lt;/a&gt;</code></pre>
    </section>
 
    <section id="resources">

--- a/understanding/conformance.html
+++ b/understanding/conformance.html
@@ -233,7 +233,7 @@
 
      <p>Here is a claim which has been enhanced with schema.org metadata:</p>
 
-     <pre><code>
+     <pre><code class="language-html">
 &lt;div typeof="WebPage" vocab="http://schema.org/">
     &lt;p property="accessibilitySummary">On 23 March 2009, all content available on
        the server at &lt;a 


### PR DESCRIPTION
Changes in this PR:

- Adds `language-*` or `no-highlight` classes to code elements inside pre elements where they were missing, to provide stability across highlight.js upgrades in the event of changes to auto-detection logic
  - This intentionally does not go through the trouble/noise of adding syntax highlighting to obsolete Flash and Silverlight techniques
- Adds a build-time check which logs in dev / fails in CI if any code blocks have no class specified
  - Example of message logged for each missing class found:
    `./techniques/css/C45.html missing "language-*" or "no-highlight" class on <pre><code> starting with &lt;!DOCTYPE html&gt;\n&lt;html lang="en...`
  - Example of message printed when build fails (for CI, in addition to the above message):
    ```
    [11ty] 1. Having trouble rendering liquid template ./techniques/css/C45.html (via TemplateContentRenderError)
    [11ty] 2. Please ensure all code blocks have a highlight.js class (language-* or no-highlight).
    ```
- Updates to use the latest version of highlight.js
- Switches to invoking `highlight.js` at build time and including it as an npm dependency
  - This means no more `highlight.min.js` bundle taking up more space in the repo on each update
  - This also means syntax highlighting no longer involves running client-side JS on every visit to every page, better optimizing for sustainability

Before switching from client-side to build-time, I verified (using the script I'd posted in #4611) that updating the bundle does not cause any syntax highlighting changes, other than adding it for the previously-missing languages.

I also performed screenshot diffs and have verified that the only changes caused by the update are fixes to syntax highlighting (primarily in terms of recognized CSS property names).

I performed screenshot diffs again after switching to build-time highlight.js, and there were only two diffs, in examples that specifically intended to include `<span lang="...">` elements inside of `<pre><code>`. These have been adjusted to apply `lang` to the `pre` tag instead.

**Note:** The failure on the Check PR files check is an extremely rare false positive because I had updated it to consider `script` normative, but technically only `script/wcag.js` is involved in TR space; `script/highlight.min.js` is not. This should never be an issue again, since I'm removing `highlight.min.js`.