### PR TITLE
Updated "A document collection" example since obsolete - SC 2.4.2

### DIFF
--- a/understanding/20/page-titled.html
+++ b/understanding/20/page-titled.html
@@ -96,15 +96,23 @@
          <dt>An HTML web page</dt>
          <dd>The descriptive title of an HTML web page is marked up with the &lt;title&gt; element so
                that it will be displayed in the title bar of the user agent.</dd>
-         <dt>A document collection</dt>
+         <dt>A guide on authoring practices</dt>
          <dd>
-            <p>The title of <a href="./">Understanding WCAG 2.2</a> is "Understanding WCAG 2.2".</p>
+            <p>The title of the landing page is "ARIA Authoring Practices Guide | APG | WAI | W3C"</p>
             <ul>
-               <li>The <a href="../Understanding/intro">Introduction to Understanding WCAG</a> page has the title "Introduction to Understanding WCAG".</li>
-               <li>Major sections of the document collection are pages titled "Understanding Guideline X" and "Understanding Success Criterion X."</li>
-               <li>Appendix A has the title "Glossary."</li>
-               <li>Appendix B has the title "Acknowledgements."</li>
-               <li>Appendix C has the title "References."</li>
+              <li>
+                <span>The patterns list page has the title "Patterns | APG | WAI | W3C"</span>
+                <ul>
+                  <li>
+                    <span>Specific patterns are pages titled "X Pattern | APG | WAI | W3C" (e.g., "Alert and Message Dialogs Pattern | APG | WAI | W3C")</span>
+                    <ul>
+                      <li>Specific examples for each pattern are pages titled "X Example | APG | WAI | W3C" (e.g., "Alert Dialog Example | APG | WAI | W3C")</li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li>Practices page has the title "Practices | APG | WAI | W3C"</li>
+              <li>Index page has the title "Index | APG | WAI | W3C"</li>
             </ul>
          </dd>
          <dt>A web application</dt>


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/3803

Description:
The current example does not accurately reflect the WCAG title structure and causes considerable confusion. Additionally, self-referential examples are difficult to maintain. For these reasons, I have replaced it with a static example.