### PR TITLE
Fall2025 errata

### DIFF
--- a/errata/21.html
+++ b/errata/21.html
@@ -46,6 +46,31 @@
         <h3>Editorial Errata</h3>
         <ul>
           <li>
+            2025-10-15:
+            Rewording the normative preamble of Hover or Focus for clarity
+            ({% gh "#4469" %})
+          </li>
+          <li>
+            2025-10-15:
+            Changing occurrences of "e-mail" to "email"
+            ({% gh "#4385" %})
+          </li>          
+          <li>
+            2025-10-15:
+            Removing use of "must" in section 7 preamble
+            ({% gh "#4458" %})
+          </li>
+          <li>
+            2025-10-15:
+            Fixing the markup for the notes in the "abbreviation" definition
+            ({% gh "#4452" %})
+          </li>
+          <li>
+            2025-10-15:
+            Changing capitalized occurrences of "Web" to match the established lower-case style
+            ({% gh "#4461" %})
+          </li>          
+          <li>
             2025-07-07:
             Correcting the alphabetical order of two definitions
             ({% gh "6f733de" %})

--- a/errata/22.html
+++ b/errata/22.html
@@ -46,6 +46,31 @@
         <h3>Editorial Errata</h3>
         <ul>
           <li>
+            2025-10-15:
+            Rewording the normative preamble of Hover or Focus for clarity
+            ({% gh "#4469" %})
+          </li>
+          <li>
+            2025-10-15:
+            Changing occurrences of "e-mail" to "email"
+            ({% gh "#4385" %})
+          </li>          
+          <li>
+            2025-10-15:
+            Removing use of "must" in section 7 preamble
+            ({% gh "#4458" %})
+          </li>
+          <li>
+            2025-10-15:
+            Fixing the markup for the notes in the "abbreviation" definition
+            ({% gh "#4452" %})
+          </li>
+          <li>
+            2025-10-15:
+            Changing capitalized occurrences of "Web" to match the established lower-case style
+            ({% gh "#4461" %})
+          </li>
+          <li>
             2025-06-27:
             Correcting the alphabetical order of two definitions
             ({% gh "#4256" %})


### PR DESCRIPTION
Updates the errata documents for 2.2 and 2.1 to list the 5 new editorial changes held for the quarterly update.