### PR TITLE
Captions: Adjust "that has a video player" to "with a video player"

### DIFF
--- a/understanding/understanding.11tydata.js
+++ b/understanding/understanding.11tydata.js
@@ -113,7 +113,7 @@ export default function (data) {
               "SM11",
               "SM12",
               "H95",
-              "Using any readily available media format that has a video player that supports closed captioning",
+              "Using any readily available media format with a video player that supports closed captioning",
             ],
             usingQuantity: "any",
           },
@@ -152,7 +152,7 @@ export default function (data) {
             using: [
               "SM11",
               "SM12",
-              "Using any readily available media format that has a video player that supports closed captioning",
+              "Using any readily available media format with a video player that supports closed captioning",
             ],
           },
         ],


### PR DESCRIPTION
This implements a suggestion from Mike in https://github.com/w3c/wcag/pull/4509#issuecomment-3172676113:

> I do think we should consider a tweak to the language, changing "that has" to 'with". The rationale is that in most circumstances, it is the author who supplies the video player

I could see arguing for or against this change, and am open to alternative suggestions, as there are potentially multiple ways to interpret the before/after versions to the point where they are either identical or quite different in meaning.

(Possible alternative: "for which there exists" may align more with the old text, but is even more verbose)

@netlify /understanding/captions-prerecorded