### PR TITLE
New Failure Technique for 1.4.13 Content on hover or focus when the pointer cannot be moved over the new popup content without that content closing

### DIFF
--- a/techniques/failures/F115.html
+++ b/techniques/failures/F115.html
@@ -14,7 +14,7 @@
      <h2>Examples</h2>
       <ul>
          <li><strong>Custom tooltip:</strong> When focussing an icon with a question mark that is placed after an input field, a popup window with an explanation of the expected input appears next to the icon. Moving the pointer away from the icon and over the popup automatically closes the popup content.</li>
-        <li><strong>Sub-menu:</strong> When the mouse pointer is moved over the entry in a horizonal menubar, a submenu appears. Moving the pointer away from the main menu item toward the submenu closes this submenu.</li>
+        <li><strong>Sub-menu:</strong> When the mouse pointer is moved over the entry in a menubar, a submenu appears. Moving the pointer away from the main menu item toward the submenu closes this submenu.</li>
       </ul>
    </section>
    <section id="tests"><h2>Tests</h2>


### PR DESCRIPTION
Attempt to create a new Failure for 1.4.13 Content on hover or focus to cover the situation when the pointer cannot be moved over the new popup content without that content closing.

One issue to check may be the situation where keyboard focussing causes a popup to appear and then the pointer (mouse) is used to make popup contents visible by changing the viewport section. I would expect that the same applies as when the content appears on pointer hover, but may have missed something here.