### PR TITLE
Tweak definition for "human language"

### DIFF
--- a/guidelines/terms/20/human-language.html
+++ b/guidelines/terms/20/human-language.html
@@ -1,7 +1,7 @@
 <dt><dfn id="dfn-human-language-s" data-lt="human languages|human language(s)">human language</dfn></dt>
 <dd>
    
-   <p>language that is spoken, written or signed (through visual or tactile means) to communicate
+   <p>natural or constructed language that is spoken, written or signed (through visual or tactile means) to communicate
       with humans
    </p>
    


### PR DESCRIPTION
Closes https://github.com/w3c/wcag/issues/2639 which raised a concern about the mismatch of terms in WCAG ("human language") and the i18n glossary ("natural language"). Keep the actual term as "human language" (as it's too pervasive in normative and non-normative documents to just change), while adding the mention of "natural" (as well as "constructed" - for instance, Esperanto) in the definition itself.