### PR TITLE
Upgrade at-risk dependencies and remove a couple that are unnecessary

### DIFF
--- a/11ty/cp-cvs.ts
+++ b/11ty/cp-cvs.ts
@@ -1,9 +1,8 @@
 /** @fileoverview script to copy already-built output to CVS subfolders */
 
 import { glob } from "glob";
-import { mkdirp } from "mkdirp";
 
-import { copyFile, unlink } from "fs/promises";
+import { copyFile, mkdir, unlink } from "fs/promises";
 import { dirname, join } from "path";
 
 import { assertIsWcagVersion } from "./guidelines";
@@ -40,14 +39,14 @@ for (const [srcDir, destDir] of Object.entries(dirs)) {
   for (const path of indexPaths) {
     const srcPath = join(outputBase, srcDir, path);
     const destPath = join(wcagBase, destDir, path.replace(/index\.html$/, "Overview.html"));
-    await mkdirp(dirname(destPath));
+    await mkdir(dirname(destPath), { recursive: true });
     await copyFile(srcPath, destPath);
   }
 
   for (const path of nonIndexPaths) {
     const srcPath = join(outputBase, srcDir, path);
     const destPath = join(wcagBase, destDir, path);
-    await mkdirp(dirname(destPath));
+    await mkdir(dirname(destPath), { recursive: true });
     await copyFile(srcPath, destPath);
   }
 }
@@ -56,7 +55,7 @@ try {
   await copyFile(join(outputBase, "wcag.json"), join(wcagBase, "wcag.json"));
 } catch (error) {}
 
-await mkdirp(join(wcagBase, "errata"));
+await mkdir(join(wcagBase, "errata"), { recursive: true });
 await copyFile(
   join(outputBase, "errata", `${wcagVersion}.html`),
   join(wcagBase, "errata", "Overview.html")

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -1,8 +1,6 @@
 import compact from "lodash-es/compact";
-import { mkdirp } from "mkdirp";
-import { rimraf } from "rimraf";
 
-import { copyFile, writeFile } from "fs/promises";
+import { copyFile, mkdir, rm, writeFile } from "fs/promises";
 import { join } from "path";
 
 import { CustomLiquid } from "11ty/CustomLiquid";
@@ -208,7 +206,8 @@ export default async function (eleventyConfig: any) {
   eleventyConfig.on("eleventy.before", async ({ runMode }: EleventyEvent) => {
     // Clear the _site folder before builds intended for the W3C site,
     // to avoid inheriting dev-only files from previous runs
-    if (runMode === "build" && process.env.WCAG_MODE === "publication") await rimraf("_site");
+    if (runMode === "build" && process.env.WCAG_MODE === "publication")
+      await rm("_site", { recursive: true });
   });
 
   let hasDisplayedGuidance = false;
@@ -227,7 +226,7 @@ export default async function (eleventyConfig: any) {
     // Output guidelines/index.html and dependencies for PR runs (not for GH Pages or W3C site)
     const sha = process.env.COMMIT_REF; // Read environment variable exposed by Netlify
     if (sha && !process.env.WCAG_MODE) {
-      await mkdirp(join(dir.output, "guidelines"));
+      await mkdir(join(dir.output, "guidelines"), { recursive: true });
       await copyFile(
         join(dir.input, "guidelines", "guidelines.css"),
         join(dir.output, "guidelines", "guidelines.css")

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
         "highlight.js": "^11.11.1",
         "liquidjs": "^10.21.0",
         "lodash-es": "^4.17.21",
-        "mkdirp": "^3.0.1",
-        "rimraf": "^5.0.10",
         "tsx": "^4.20.3"
       },
       "devDependencies": {
@@ -180,9 +178,10 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2478,21 +2477,20 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.3.16",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.16.tgz",
-      "integrity": "sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.11.0"
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2815,9 +2813,10 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3006,25 +3005,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/moo": {
@@ -3117,6 +3103,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "2.0.0",
@@ -3361,20 +3353,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "highlight.js": "^11.11.1",
     "liquidjs": "^10.21.0",
     "lodash-es": "^4.17.21",
-    "mkdirp": "^3.0.1",
-    "rimraf": "^5.0.10",
     "tsx": "^4.20.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates `glob` and `js-yaml` to address vulnerabilities, and removes `mkdirp` and `rimraf` since the built-in node.js `mkdir` and `rm` APIs already support `{ recursive: true }`.