### PR TITLE
Normalize `h1` text to permit leading, trailing, and wrapping whitespace

### DIFF
--- a/11ty/techniques.ts
+++ b/11ty/techniques.ts
@@ -366,7 +366,12 @@ export async function getTechniquesByTechnology(guidelines: FlatGuidelinesMap) {
     // Isolate h1 from each file before feeding into Cheerio to save ~300ms total
     const h1Match = content.match(/<h1[^>]*>([\s\S]+?)<\/h1>/);
     if (!h1Match || !h1Match[1]) throw new Error(`No h1 found in techniques/${path}`);
-    const $h1 = load(h1Match[1], null, false);
+
+    const normalizedH1 = h1Match[1]
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    const $h1 = load(normalizedH1, null, false);
 
     let title = $h1.text();
     let titleHtml = $h1.html();


### PR DESCRIPTION
While developing #4829, I discovered that [my `h1` text for the new page](https://github.com/w3c/wcag/blob/f71bb0c0860b612f25a7d71234f9112771166cf5/techniques/failures/F999.html#L11) wasn’t successfully retrieved by the build system because I’d hard-wrapped the lines like so:

```html
<h1>
  Failure of Success Criterion 1.3.1 due to visible ruby annotations that
  are not programmatically determinable
</h1>
```

@kfranqueiro, would it be alright to tweak the build system to permit wrapped heading text like this?