### PR TITLE
Build: Support entire content of technique h1 being wrapped

### DIFF
--- a/11ty/techniques.ts
+++ b/11ty/techniques.ts
@@ -399,7 +399,7 @@ export async function getTechniquesByTechnology(guidelines: FlatGuidelinesMap) {
       technology,
       title,
       titleHtml,
-      truncatedTitle: title.replace(/\s*\n[\s\S]*\n\s*/, " … "),
+      truncatedTitle: title.trim().replace(/\s*\n[\s\S]*\n\s*/, " … "),
     });
   }
 


### PR DESCRIPTION
This fixes the issue reported in #4831 while avoiding regressions to existing link text truncation logic.

(This does cause some whitespace changes in output, but they are not noticeable in the rendered HTML.)