### PR TITLE
Update footer design to match the WAI website's

### DIFF
--- a/xslt/base.xslt
+++ b/xslt/base.xslt
@@ -360,54 +360,35 @@
 	</xsl:template>
 
 	<xsl:template name="site-footer">
-    <footer class="w3c-global-footer wai-global-footer default-grid" aria-label="Site">
-      <div class="inner">
-        <div class="wai-global-footer__content">
-          <div class="wai-global-footer__subsite"><a href="https://www.w3.org/WAI/" lang="en" dir="auto" translate="no">W3C Web Accessibility Initiative (WAI)</a></div>
-          <div class="wai-global-footer__subsite-desc">Strategies, standards, resources to make the Web accessible to people with disabilities</div>
-          <div class="wai-global-footer__cta w3c-l-cluster w3c-l-cluster--vertical-align">
-            <ul class="w3c-clean-list" role="list">
-              <li class="w3c-with-icon--before w3c-with-icon--larger">
-                <img class="w3c-icon w3c-icon--larger" src="https://www.w3.org/WAI/assets/images/email.svg" width="30" height="30" alt="" aria-hidden="true">
-                <a href="https://www.w3.org/WAI/news/subscribe/">Get News in Email</a>
-              </li>
-              <li class="w3c-with-icon--before w3c-with-icon--larger">
-                <img class="w3c-icon w3c-icon--larger" src="https://www.w3.org/WAI/assets/images/social/linkedin.svg" width="30" height="30" alt="" aria-hidden="true">
-                <a href="https://www.linkedin.com/company/w3c-wai/" translate="no">LinkedIn</a>
-              </li>
-              <li class="w3c-with-icon--before w3c-with-icon--larger">
-                <img class="w3c-icon w3c-icon--larger" src="https://www.w3.org/assets/website-2021/svg/mastodon.svg" width="30" height="30" alt="" aria-hidden="true">
-                <a href="https://w3c.social/@wai" translate="no">Mastodon</a>
-              </li>
-              <li class="w3c-with-icon--before w3c-with-icon--larger">
-                <img class="w3c-icon w3c-icon--larger" src="https://www.w3.org/WAI/assets/images/social/youtube.svg" width="30" height="30" alt="" aria-hidden="true">
-                <a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlists/" translate="no">YouTube</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div class="w3c-global-footer__links">
-          <div class="w3c-l-cluster">
-            <ul class="w3c-clean-list" role="list">
-              <li><a href="https://www.w3.org/WAI/">Home</a></li>
-              <li><a href="https://www.w3.org/WAI/about/contacting/">Contact</a></li>
-              <li><a href="https://www.w3.org/WAI/sitemap/">Site map</a></li>
-              <li><a href="https://www.w3.org/WAI/about/support/">Support WAI</a></li>
-              <li><a href="https://www.w3.org/WAI/news/">News</a></li>
-              <li><a href="https://www.w3.org/WAI/about/accessibility-statement/">Accessibility statement</a></li>
-              <li><a href="https://www.w3.org/WAI/translations/">All Translations</a></li>
-              <li><a href="https://www.w3.org/WAI/roles/">Resources for roles</a></li>
-            </ul>
-          </div>
-        </div>
-        <p class="w3c-copyright" translate="no">Copyright © <xsl:value-of select="format-date(current-date(), '[Y]')"/> <a href="https://www.w3.org/">World Wide Web	Consortium</a>.<br>
-          <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-          <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
-          <a href="https://www.w3.org/policies/#trademarks">trademark</a> and
-          <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C Software License">permissive license</a>
-          rules apply unless otherwise noted. See <a href="https://www.w3.org/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
-      </div>
-    </footer>
+		<footer class="site-footer grid-4q" aria-label="Site">
+			<div class="q1-start q3-end about">
+				<div>
+					<p><a class="largelink" href="https://www.w3.org/WAI/" dir="auto" translate="no" lang="en">W3C Web Accessibility Initiative (WAI)</a></p>
+					<p>Strategies, standards, and supporting resources to make the Web accessible to people with disabilities.</p>
+				</div>
+				<div class="social" dir="auto" translate="no" lang="en">
+					<ul>
+						<li><a href="https://twitter.com/w3c_wai"><svg focusable="false" aria-hidden="true" class="icon-twitter " viewBox="0 0 32 32"><path d="M31.939 6.092c-1.18 0.519-2.44 0.872-3.767 1.033 1.352-0.815 2.392-2.099 2.884-3.631-1.268 0.74-2.673 1.279-4.169 1.579-1.195-1.279-2.897-2.079-4.788-2.079-3.623 0-6.56 2.937-6.56 6.556 0 0.52 0.060 1.020 0.169 1.499-5.453-0.257-10.287-2.876-13.521-6.835-0.569 0.963-0.888 2.081-0.888 3.3 0 2.28 1.16 4.284 2.917 5.461-1.076-0.035-2.088-0.331-2.971-0.821v0.081c0 3.18 2.257 5.832 5.261 6.436-0.551 0.148-1.132 0.228-1.728 0.228-0.419 0-0.82-0.040-1.221-0.115 0.841 2.604 3.26 4.503 6.139 4.556-2.24 1.759-5.079 2.807-8.136 2.807-0.52 0-1.039-0.031-1.56-0.089 2.919 1.859 6.357 2.945 10.076 2.945 12.072 0 18.665-9.995 18.665-18.648 0-0.279 0-0.56-0.020-0.84 1.281-0.919 2.4-2.080 3.28-3.397l-0.063-0.027z"></path></svg> Twitter</a></li>
+						<li><a href="https://www.w3.org/WAI/feed.xml"><svg focusable="false" aria-hidden="true" class="icon-rss " viewBox="0 0 32 32"><path d="M25.599 32c0-14.044-11.555-25.6-25.599-25.6v-6.4c17.553 0 32 14.447 32 32h-6.401zM4.388 23.22c2.419 0 4.391 1.972 4.391 4.393 0 2.417-1.98 4.387-4.401 4.387-2.417 0-4.377-1.965-4.377-4.387s1.967-4.392 4.388-4.393zM21.212 32h-6.22c0-8.225-6.767-14.993-14.992-14.993v-6.22c11.636 0 21.212 9.579 21.212 21.213z"></path></svg> Feed</a></li>
+						<li><a href="https://www.youtube.com/channel/UCU6ljj3m1fglIPjSjs2DpRA/playlistsv"><svg focusable="false" aria-hidden="true" class="icon-youtube "  viewBox="0 0 32 32"><path d="M31.327 8.273c-0.386-1.353-1.431-2.398-2.756-2.777l-0.028-0.007c-2.493-0.668-12.528-0.668-12.528-0.668s-10.009-0.013-12.528 0.668c-1.353 0.386-2.398 1.431-2.777 2.756l-0.007 0.028c-0.443 2.281-0.696 4.903-0.696 7.585 0 0.054 0 0.109 0 0.163l-0-0.008c-0 0.037-0 0.082-0 0.126 0 2.682 0.253 5.304 0.737 7.845l-0.041-0.26c0.386 1.353 1.431 2.398 2.756 2.777l0.028 0.007c2.491 0.669 12.528 0.669 12.528 0.669s10.008 0 12.528-0.669c1.353-0.386 2.398-1.431 2.777-2.756l0.007-0.028c0.425-2.233 0.668-4.803 0.668-7.429 0-0.099-0-0.198-0.001-0.297l0 0.015c0.001-0.092 0.001-0.201 0.001-0.31 0-2.626-0.243-5.196-0.708-7.687l0.040 0.258zM12.812 20.801v-9.591l8.352 4.803z"></path></svg> YouTube</a></li>
+						<li><a href="https://www.w3.org/WAI/news/subscribe/" class="button">Get News in Email</a></li>
+					</ul>
+				</div>
+				<div dir="auto" translate="no" lang="en">
+					<p>Copyright © <xsl:value-of select="format-date(current-date(), '[Y]')"/> World Wide Web Consortium (<a href="https://www.w3.org/">W3C</a><sup>®</sup>). See <a href="/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.</p>
+				</div>
+			</div>
+			<div dir="auto" translate="no" class="q4-start q4-end" lang="en">
+				<ul style="margin-bottom:0">
+					<li><a href="/WAI/about/contacting/">Contact WAI</a></li>
+					<li><a href="/WAI/sitemap/">Site Map</a></li>
+					<li><a href="/WAI/news/">News</a></li>
+					<li><a href="/WAI/about/accessibility-statement/">Accessibility Statement</a></li>
+					<li><a href="/WAI/translations/"> Translations</a></li>
+					<li><a href="/WAI/roles/">Resources for Roles</a></li>
+				</ul>
+			</div>
+		</footer>
 	</xsl:template>
 	
 	<xsl:template name="waiscript">


### PR DESCRIPTION
This applies the same footer design as on the WAI website.

Related to https://github.com/w3c/wai-website-theme/pull/163.