### PR TITLE
Configure cspell to ignore multi-line content within a containing `[lang]` element

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -59,7 +59,7 @@ languageSettings:
   - languageId: html
     ignoreRegExpList:
       # Non-English elements
-      - /<(\w+)[^>]+lang="(?!en)\w+"[^>]*>.*?<\/\1>/gi
+      - /<(\w+)[^>]+lang="(?!en)\w+"[^>]*>[\s\S]*?<\/\1\s*>/gi
       # Encoded citations
       - /\[\[[^\]]+\]\]/g
       # Other citations


### PR DESCRIPTION
Heya @kfranqueiro, here’s another whitespace request. 😅

In #4829, cspell gave me [“unknown word” failures for “_tou_” and “_shi_”](https://github.com/w3c/wcag/actions/runs/20857561983), so I resolved them by [adding a file-specific override](https://github.com/w3c/wcag/pull/4829/files#diff-911db262cf96b6fa444f9cf0fc8fe00952325cda6b66c53952ea15d552ef42adR58-R59).

A little further down in `cspell.yml`, I noticed a regex for ignoring any elements with the `lang` attribute — which is exactly where my unknown words had occurred in #4829. However, my `lang` content contained multiple lines, whereas the regex seems to be looking for single line matches.

Would it be okay to make this one more permissive so that I can remove the file-specific override?