### PR TITLE
Update "Fork & Edit on GitHub" links to point to precise file

### DIFF
--- a/_includes/help-improve.html
+++ b/_includes/help-improve.html
@@ -10,7 +10,7 @@
     <div class="button-group">
       <a href="mailto:public-agwg-comments@w3.org?subject=%5BUnderstanding%20and%20Techniques%20Feedback%5D"
         class="button"><span>Email</span></a>
-      <a href="https://github.com/w3c/wcag/issues/" class="button"><span>Fork &amp; Edit on GitHub</span></a>
+      <a href="https://github.com/w3c/wcag/edit/main/{{ page.inputPath | replace_first: "./", "" }}" class="button"><span>Fork &amp; Edit on GitHub</span></a>
       <a href="https://github.com/w3c/wcag/issues/new" class="button"><span>New GitHub Issue</span></a>
     </div>
   </div>


### PR DESCRIPTION
This resolves the only remaining issue of #3637 involving the "Fork & Edit on GitHub" link, which applies to all individual Technique and Understanding pages. This was always statically pointing to the repo's new issue URL, which was behavior carried over from the previous XSLT build system. Now that we're using Eleventy, this is trivial to implement consistently with the rest of the WAI website.

Fixes #3637.