### PR TITLE
Add link to revision history in each page's footer

### DIFF
--- a/_includes/wai-site-footer.html
+++ b/_includes/wai-site-footer.html
@@ -1,6 +1,11 @@
 <footer id="wai-site-footer" class="page-footer default-grid" aria-label="Page">
   <div class="inner" style="grid-column: 2 / 8">
-    <p><strong>Date:</strong> Updated {{ page.date | date_to_long_string }}.</p>
+    <p>
+      <strong>Date:</strong> Updated {{ page.date | date_to_long_string }}.
+      {%- unless skipHistory %}
+      <a href="https://github.com/w3c/wcag/commits/main/{{ page.inputPath | replace_first: "./", "" }}">View this page's revision history.</a>
+      {%- endunless -%}
+    </p>
     <p><strong>Developed by</strong>
       <a href="https://www.w3.org/groups/wg/ag/participants">Accessibility Guidelines Working Group (AG WG) Participants</a>
       (Co-Chairs: Alastair Campbell, Rachael Bradley Montgomery. W3C Staff Contact:

--- a/techniques/changelog.html
+++ b/techniques/changelog.html
@@ -1,3 +1,6 @@
+---
+skipHistory: true
+---
 <!DOCTYPE html>
 <html lang="en">
 

--- a/techniques/index.html
+++ b/techniques/index.html
@@ -1,3 +1,6 @@
+---
+skipHistory: true
+---
 <!DOCTYPE html>
 <html lang="en">
 	<head>

--- a/understanding/index.html
+++ b/understanding/index.html
@@ -1,3 +1,6 @@
+---
+skipHistory: true
+---
 <!DOCTYPE html>
 <html lang="en">
 	<head>


### PR DESCRIPTION
Refs #4003.

This adds a link to the revision history in GitHub for each page, after the last-updated date in its footer.

This intentionally avoids adding this link for the index pages and the Techniques change log page, as those are mostly auto-generated.