### PR TITLE
Two typos in 2.1 Change Log

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -760,7 +760,7 @@
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#robust">4. Robust</a>, repetition of the word "by" has been removed.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#cc2">5.2.2 Full pages</a>, the third note began with "New" which has been removed.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." has been removed.</li>
-					<li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) notes has been changed to be an example of the first note, leaving only two actual notes.</li>
+					<li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second note (of three total) has been changed to be an example of the first note, leaving only two actual notes.</li>
 					<li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-technologies">technology</a>, the third note has been changed to be an example.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" has been changed to "country".</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -753,14 +753,14 @@
         <p>Changes since the <a href="https://www.w3.org/TR/2018/REC-WCAG21-20180605/">W3C Recommendation of 05 June 2018</a>:</p>
         <ul>
 					<li>In the <a href="https://www.w3.org/TR/WCAG21/#sotd">Status of This Document</a> the paragraph beginning "This document has been reviewed by W3C Members..." appears twice. The first instance of this paragraph has been removed.</li>
-					<li>In the <a href="https://www.w3.org/TR/WCAG21/#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" has been changed to "WCAG 2.1".</li>
+					<li>In the <a href="https://www.w3.org/TR/WCAG21/#intro">Introduction</a>, several (but not all) references to "WCAG 2.0" have been changed to "WCAG 2.1".</li>
 					<li>In the <a href="https://www.w3.org/TR/WCAG21/#numbering-in-wcag-2-1">0.5.2 Numbering in WCAG 2.1</a>, the words "critera" and "ccriteria" have been changed to "criteria".</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#reflow">1.4.10 Reflow</a>, the first note had a supernumary "Note" indicator which has been removed.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus">1.4.13 Content on Hover or Focus</a>, the word "dismissable" has been changed to "dismissible".</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#robust">4. Robust</a>, repetition of the word "by" has been removed.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#cc2">5.2.2 Full pages</a>, the third note began with "New" which has been removed.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#conformance-required">5.3.1 Required Components of a Conformance Claim</a> the editorial note "In WCAG 2.0 this was a dated URI, which may need to be adjusted when this becomes a Rec." has been removed.</li>
-					<li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) note has been changed to be an example of the first note, leaving only two actual notes.</li>
+					<li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-keyboard-interface">keyboard interface</a>, the second (of three) notes has been changed to be an example of the first note, leaving only two actual notes.</li>
 					<li>In the definition for <a href="https://www.w3.org/TR/WCAG21/#dfn-technologies">technology</a>, the third note has been changed to be an example.</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#input-purposes">7. Input Purposes for User Interface Components</a>, the word "county" has been changed to "country".</li>
 					<li>In <a href="https://www.w3.org/TR/WCAG21/#orientation">1.3.4 Orientation</a>, the note referencing "binary display orientation" has been clarified to read "content is not necessarily restricted to landscape or portrait display orientation".</li>


### PR DESCRIPTION
Corrects two small typos in Appendix A Change Log (WCAG 2.1 only, not errata, not WCAG 2.2).

Closes https://github.com/w3c/wcag/issues/4915