### PR TITLE
Move link to Understanding to its own DD

### DIFF
--- a/guidelines/terms/20/conforming-alternate-version.html
+++ b/guidelines/terms/20/conforming-alternate-version.html
@@ -63,7 +63,7 @@
       acceptable mechanism for reaching another version as long as the method used to set
       the preferences is accessibility supported.
    </p>
-   
+<dd>   
    <p>See <a href="https://www.w3.org/WAI/WCAG22/Understanding/conformance#conforming-alt-versions">Understanding Conforming Alternate Versions</a></p>
-   
+</dd>
 </dd>


### PR DESCRIPTION
Understanding [Conforming Alternate Versions](https://www.w3.org/WAI/WCAG22/Understanding/conformance.html#conforming-alt-versions) section of [Understanding Conformance](https://www.w3.org/WAI/WCAG22/Understanding/conformance.html) links to itself.  This is an attempt to correct that.