### PR TITLE
Add pointerevents alias to biblio.ts

### DIFF
--- a/11ty/biblio.ts
+++ b/11ty/biblio.ts
@@ -12,6 +12,7 @@ export const biblioPattern = /\[\[\??([\w-]+)\]\]/g;
 // Resolve necessary aliases locally rather than requiring an extra round trip to specref
 const aliases = {
   "css3-values": "css-values-3",
+  pointerevents: "pointerevents4",
 };
 
 /** Compiles URLs from local biblio + specref for linking in Understanding documents. */


### PR DESCRIPTION
Fixes #5004

We rely on a local alias map to avoid incurring multiple requests to specref on every build. Last month, pointerevents was updated in specref (https://github.com/tobie/specref/pull/906) to be an alias, which means our map requires updating as well.