### PR TITLE
Add figure caption numbering to techniques

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -279,7 +279,9 @@ export class CustomLiquid extends Liquid {
               .first()
               .prepend(`<span>Figure ${i + 1}.</span> `);
           });
+        }
 
+        if (isUnderstanding) {
           // Remove spurious copy-pasted content in 2.5.3 that doesn't belong there
           if ($("section#benefits").length > 1) $("section#benefits").first().remove();
           // Prevent pages from nesting Benefits inside Intent (old issue that has been fixed)

--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -267,7 +267,9 @@ export class CustomLiquid extends Liquid {
               $el.prepend(`<h3>${exampleText}</h3>`);
             }
           });
-        } else if (isUnderstanding) {
+        }
+        
+        if (isUnderstanding || isTechniques) {
           // Add numbers to figcaptions
           $("figcaption").each((i, el) => {
             const $el = $(el);


### PR DESCRIPTION
Noticed as part of the work on https://github.com/w3c/wcag/pull/4832

This adds the "Figure X..." part to all figure captions in techniques (this currently only happens in understanding pages)

Closes https://github.com/w3c/wcag/issues/5061

Preview example: https://deploy-preview-5062--wcag2.netlify.app/techniques/failures/f69 (compare to https://www.w3.org/WAI/WCAG22/Techniques/failures/F69)