### PR TITLE
Remove unused include (flagged by Adam Page)

### DIFF
--- a/_includes/understanding/intro/techniques.html
+++ b/_includes/understanding/intro/techniques.html
@@ -1,8 +1,0 @@
-<p>
-  Each numbered item in this section represents a technique or combination of techniques
-  that the Accessibility Guidelines Working Group deems sufficient for meeting this success criterion.
-  A technique may go beyond the minimum requirement of the criterion. There may be other ways of meeting the criterion not covered by these techniques.
-  For information on using other techniques, see
-  <a href="understanding-techniques">Understanding Techniques for WCAG Success Criteria</a>,
-  particularly the "Other Techniques" section.
-</p>


### PR DESCRIPTION
This removes a file under `_includes` that Adam noticed was seemingly unused. I suspect I forgot to remove it in #4509.

(I delayed on sending this PR until #4900 was merged to avoid causing conflicts in that PR... and then forgot to actually send this PR.)

I verified that this does not cause any changes or issues in the build.