### PR TITLE
CI: Stop building requirements doc in publish workflow

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -33,7 +33,6 @@ jobs:
           npm run build
           cp guidelines/guidelines.css guidelines/relative-luminance.html _site/guidelines/22
           curl https://www.w3.org/publications/spec-generator/?type=respec"&"url=https://raw.githubusercontent.com/$GITHUB_REPOSITORY/refs/heads/main/guidelines/index.html -o _site/guidelines/22/index.html -f  --retry 3
-          curl https://www.w3.org/publications/spec-generator/?type=respec"&"url=https://raw.githubusercontent.com/$GITHUB_REPOSITORY/refs/heads/main/requirements/22/index.html -o _site/requirements/22/index.html -f  --retry 3
       - name: Push
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
This removes the line that regenerates the WCAG 2 Requirements document, to allow gh-pages pushes to succeed.

This has been failing for the past couple of weeks, presumably coinciding with the release of ReSpec 37. The WCAG 2 Requirements document references the long-deprecated `w3c-respec-common` URL, which depends on ReSpec 25.

Given that the Requirements document has not been meaningfully changed in many years, and if we ever had the intention to republish it, we'd likely need to update it to work with `w3c-respec` using the latest ReSpec version, it seems like we should be fine skipping this step.