### PR TITLE
Fix About Techniques link added in #5002

### DIFF
--- a/_includes/techniques/about.html
+++ b/_includes/techniques/about.html
@@ -33,7 +33,7 @@
 {% endcase %}
 {% endsectionbox %}
 {% if technique.technology == "failures" %}
-  <p>Failure techniques show examples of how content can fail particular WCAG success criteria. However, content may still satisfy those criteria if it includes equivalent/alternative content or functionality that <strong>does</strong> meet the normative requirements. See <a href="about">About WCAG Techniques</a>.</p>
+  <p>Failure techniques show examples of how content can fail particular WCAG success criteria. However, content may still satisfy those criteria if it includes equivalent/alternative content or functionality that <strong>does</strong> meet the normative requirements. See <a href="{{ techniquesUrl }}about">About WCAG Techniques</a>.</p>
 {% else %}
-  <p>Techniques are examples of ways to meet Web Content Accessibility Guidelines (WCAG). They are <strong>not required</strong> to meet WCAG. Content can satisfy the normative requirements of WCAG even if it does not use any of the documented techniques. See <a href="about">About WCAG Techniques</a>.</p>
+  <p>Techniques are examples of ways to meet Web Content Accessibility Guidelines (WCAG). They are <strong>not required</strong> to meet WCAG. Content can satisfy the normative requirements of WCAG even if it does not use any of the documented techniques. See <a href="{{ techniquesUrl }}about">About WCAG Techniques</a>.</p>
 {% endif %}


### PR DESCRIPTION
The link to About WCAG Techniques added in #5002 assumes `about` is available directly relative to where this include is used, but this include is used one level deeper in individual technique pages.

Prepending with `../` would currently work as well, but I've opted to use the same variable that the header ultimately references to be consistent with that and hopefully be more future-proof if this include's usage were to ever change.