### PR TITLE
Build: Define more specific typings for advisory/failure associations

### DIFF
--- a/understanding/understanding.11tydata.js
+++ b/understanding/understanding.11tydata.js
@@ -772,7 +772,7 @@ export default function (data) {
             usingQuantity: "two or more",
           },
         ],
-        advisory: ["PDF2","H99"],
+        advisory: ["PDF2", "H99"],
       },
 
       "headings-and-labels": {
@@ -892,8 +892,7 @@ export default function (data) {
 
       "target-size-enhanced": {
         // 2.5.5
-        sufficient: [
-          "C44"],
+        sufficient: ["C44"],
         advisory: ["Ensuring inline links provide sufficiently large activation target"],
         failure: [
           "Failure of Success Criterion 2.5.5 due to target being less than 44 by 44 CSS pixels",

--- a/understanding/understanding.d.ts
+++ b/understanding/understanding.d.ts
@@ -44,7 +44,7 @@ export type UnderstandingAssociatedTechniqueArray = UnderstandingAssociatedTechn
 
 /** An associated technique that has already been run through expandTechniqueToObject */
 export type ResolvedUnderstandingAssociatedTechnique = Exclude<
-  UnderstandingAssociatedTechniqueArray[number],
+  UnderstandingAssociatedTechniqueArrayElement,
   string
 >;
 
@@ -78,8 +78,12 @@ export type UnderstandingAssociatedTechniqueSection =
 
 /** Object defining various types of techniques for a success criterion */
 interface UnderstandingAssociatedTechniques {
-  advisory?: UnderstandingAssociatedTechniqueArray;
-  failure?: UnderstandingAssociatedTechniqueArray;
+  advisory?: (
+    | string
+    | UnderstandingAssociatedTechniqueEntry
+    | UnderstandingAssociatedTechniqueConjunction
+  )[];
+  failure?: (string | UnderstandingAssociatedTechniqueEntry)[];
   sufficient?: UnderstandingAssociatedTechniqueSection[] | UnderstandingAssociatedTechniqueArray;
   sufficientIntro?: string;
   sufficientNote?: string;

--- a/understanding/understanding.d.ts
+++ b/understanding/understanding.d.ts
@@ -16,8 +16,7 @@ interface UnderstandingAssociatedTechniqueUsingMixin {
 }
 
 interface UnderstandingAssociatedTechniqueEntryWithUsing
-  extends UnderstandingAssociatedTechniqueEntry,
-    UnderstandingAssociatedTechniqueUsingMixin {}
+  extends UnderstandingAssociatedTechniqueEntry, UnderstandingAssociatedTechniqueUsingMixin {}
 
 interface UnderstandingAssociatedTechniqueConjunction {
   and: Array<string | UnderstandingAssociatedTechniqueEntry>;
@@ -25,8 +24,7 @@ interface UnderstandingAssociatedTechniqueConjunction {
 }
 
 interface UnderstandingAssociatedTechniqueConjunctionWithUsing
-  extends UnderstandingAssociatedTechniqueConjunction,
-    UnderstandingAssociatedTechniqueUsingMixin {}
+  extends UnderstandingAssociatedTechniqueConjunction, UnderstandingAssociatedTechniqueUsingMixin {}
 
 /** Represents either type of associated technique entry that contains `using` */
 export type UnderstandingAssociatedTechniqueParent =
@@ -52,8 +50,7 @@ interface UnderstandingAssociatedTechniqueSectionBase {
   title: string;
   note?: string;
 }
-interface UnderstandingAssociatedTechniqueSectionWithoutGroups
-  extends UnderstandingAssociatedTechniqueSectionBase {
+interface UnderstandingAssociatedTechniqueSectionWithoutGroups extends UnderstandingAssociatedTechniqueSectionBase {
   techniques: UnderstandingAssociatedTechniqueArray;
   groups?: never; // Needed to form discriminated union between with/without
 }
@@ -62,8 +59,7 @@ export interface UnderstandingAssociatedTechniqueGroup {
   title: string;
   techniques: UnderstandingAssociatedTechniqueArray;
 }
-interface UnderstandingAssociatedTechniqueSectionWithGroups
-  extends UnderstandingAssociatedTechniqueSectionBase {
+interface UnderstandingAssociatedTechniqueSectionWithGroups extends UnderstandingAssociatedTechniqueSectionBase {
   groups: UnderstandingAssociatedTechniqueGroup[];
   // Restrict techniques to types without `using` when paired with `groups`
   techniques: Array<


### PR DESCRIPTION
This updates typings for `advisory` and `failure` technique associations to be more specific, rather than using the same wider type used for `sufficient`.

This does not affect any existing data, but rather encodes the contract the existing data already satisfies. This can potentially be helpful to avoid (or alert us to) any future changes that might alter expectations of anyone consuming `wcag.json`.

I got this idea while working on expanding the WAI website's usage of `wcag.json` (to remove reliance on legacy JSON files in that repo).

Note: The first commit on this branch contains the only actual change to typings; the rest is reformatting.