### PR TITLE
Commit updates to techniques change log

### DIFF
--- a/techniques/changelog.11tydata.json
+++ b/techniques/changelog.11tydata.json
@@ -3,6 +3,46 @@
   "changelog": {
     "21": [
       {
+        "date": "2026-05-11T07:05:28.000Z",
+        "hash": "7d72cb56a",
+        "techniques": [
+          "ARIA27"
+        ],
+        "type": "added"
+      },
+      {
+        "date": "2026-03-23T17:21:01.000Z",
+        "hash": "6336cd892",
+        "techniques": [
+          "G200"
+        ],
+        "type": "removed"
+      },
+      {
+        "date": "2026-03-09T16:57:10.000Z",
+        "hash": "4e4d2e752",
+        "techniques": [
+          "ARIA26"
+        ],
+        "type": "added"
+      },
+      {
+        "date": "2026-03-09T16:48:09.000Z",
+        "hash": "81d691942",
+        "techniques": [
+          "ARIA25"
+        ],
+        "type": "added"
+      },
+      {
+        "date": "2025-12-02T21:09:11.000Z",
+        "hash": "a6b8babf2",
+        "techniques": [
+          "C44"
+        ],
+        "type": "added"
+      },
+      {
         "date": "2025-08-25T20:11:16.000Z",
         "hash": "6e22d07cb",
         "techniques": [
@@ -507,6 +547,46 @@
       }
     ],
     "22": [
+      {
+        "date": "2026-05-11T07:05:28.000Z",
+        "hash": "7d72cb56a",
+        "techniques": [
+          "ARIA27"
+        ],
+        "type": "added"
+      },
+      {
+        "date": "2026-03-23T17:21:01.000Z",
+        "hash": "6336cd892",
+        "techniques": [
+          "G200"
+        ],
+        "type": "removed"
+      },
+      {
+        "date": "2026-03-09T16:57:10.000Z",
+        "hash": "4e4d2e752",
+        "techniques": [
+          "ARIA26"
+        ],
+        "type": "added"
+      },
+      {
+        "date": "2026-03-09T16:48:09.000Z",
+        "hash": "81d691942",
+        "techniques": [
+          "ARIA25"
+        ],
+        "type": "added"
+      },
+      {
+        "date": "2025-12-02T21:09:11.000Z",
+        "hash": "a6b8babf2",
+        "techniques": [
+          "C44"
+        ],
+        "type": "added"
+      },
       {
         "date": "2025-08-25T20:11:16.000Z",
         "hash": "6e22d07cb",


### PR DESCRIPTION
This commits updates performed by the build when preparing to publish informative docs to the WAI website. (These updates are already reflected at https://www.w3.org/WAI/WCAG22/Techniques/changelog.html but have not been committed back to the repo.)