### PR TITLE
Define explicit permissions for publish workflow

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -11,6 +11,8 @@ jobs:
   main:
     name: deploy (11ty)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v6
@@ -19,7 +21,6 @@ jobs:
         with:
           ref: gh-pages
           path: _site
-          token: ${{ secrets.W3CGRUNTBOT_TOKEN }}
       - name: Install Node.js and dependencies
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
This removes the dependency on `W3CGRUNTBOT_TOKEN` (which I suspect may have already been unnecessary) and defines explicit permissions so that we can update this repo's workflow permissions settings to be more restrictive by default.

I tested this on my fork first, with the workflow permissions setting already changed:
- [Run](https://github.com/kfranqueiro/wcag/actions/runs/27850852002/job/82429451100)
- [gh-pages commit pushed by run](https://github.com/kfranqueiro/wcag/commit/0e966c60988328c6a0a3fbe5b7e6174cd2a5c193) (ignore the amount of changes, which is due to building for a different base URL)