### PR TITLE
Avoid focus outline "hugging" container

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -537,6 +537,6 @@ pre {
 dfn:focus {
     outline-offset: 0.25em;
 }
-main:focus, aside:focus, section:focus, div:focus {
+:is(main,aside,section,div):focus {
     outline-offset: 0.75em;
 }

--- a/css/base.css
+++ b/css/base.css
@@ -540,3 +540,13 @@ dfn:focus {
 :is(main,aside,section,div):focus {
     outline-offset: 0.75em;
 }
+
+[id][tabindex="-1"]:is(main,aside,section,div) {
+  > :first-child {
+    padding-block-start: 0.5em;
+  }
+
+  > :last-child {
+    padding-block-end: 0.5em;
+  }
+}

--- a/css/base.css
+++ b/css/base.css
@@ -532,3 +532,11 @@ pre {
     padding: 0 0.25em;
     display: inline-block;
 }
+
+/* avoid focus outline "hugging" container */
+dfn:focus {
+    outline-offset: 0.25em;
+}
+main:focus, aside:focus, section:focus, div:focus {
+    outline-offset: 0.75em;
+}

--- a/guidelines/guidelines.css
+++ b/guidelines/guidelines.css
@@ -66,3 +66,11 @@ a.internalDFN[title]:hover, .internalDFN[title]:active, a.internalDFN[title]:foc
 	cursor: help;
 }
 span.screenreader {position: absolute; left: -10000px}
+
+/* avoid focus outline "hugging" container */
+dfn:focus {
+    outline-offset: 0.25em;
+}
+main:focus, aside:focus, section:focus, div:focus {
+    outline-offset: 0.75em;
+}

--- a/understanding/understanding.css
+++ b/understanding/understanding.css
@@ -211,3 +211,11 @@ video {
 .head p:not(.copyright) > a, .head > a:first-child {
 	font-weight: bold;
 }
+
+/* avoid focus outline "hugging" container */
+dfn:focus {
+    outline-offset: 0.25em;
+}
+main:focus, aside:focus, section:focus, div:focus {
+    outline-offset: 0.75em;
+}

--- a/understanding/understanding.css
+++ b/understanding/understanding.css
@@ -211,11 +211,3 @@ video {
 .head p:not(.copyright) > a, .head > a:first-child {
 	font-weight: bold;
 }
-
-/* avoid focus outline "hugging" container */
-dfn:focus {
-    outline-offset: 0.25em;
-}
-main:focus, aside:focus, section:focus, div:focus {
-    outline-offset: 0.75em;
-}


### PR DESCRIPTION
When navigating with the keyboard, jumping to a term (in the main spec) or following a section link (in understanding) shows the focus outline uncomfortably hugging the container, making it look amateurish/like a mistake. This PR adds a bit of breathing space, making it look intentional.

Before (in Chrome/Win):

![a focused glossary term, with the hugging outline](https://github.com/user-attachments/assets/79047ad6-1258-418f-aab1-00bb3bf2e26d)

![a focused understanding section, with the hugging outline](https://github.com/user-attachments/assets/615fa0bd-513a-4d3a-bff2-2b83b54a36dc)


---

After (in Chrome/Win):

![a focused glossary term, with some offset to provide breathing room](https://github.com/user-attachments/assets/80aa7f11-fc0d-47e9-a079-1a6d242de907)

![a focused understanding section, with some offset to provide breathing room](https://github.com/user-attachments/assets/f37f5c06-19d4-4706-93b7-1c8ce636f021)
