### PR TITLE
Restore token configuration for deploy workflow

### DIFF
--- a/.github/workflows/11ty-publish.yaml
+++ b/.github/workflows/11ty-publish.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           ref: gh-pages
           path: _site
+          token: ${{ secrets.W3CGRUNTBOT_TOKEN }}
       - name: Install Node.js and dependencies
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
This restores the token configuration I had removed in #5173. I had mistakenly thought it would not be required based on testing on my fork, but the actual push upon merging that PR failed.