### PR TITLE
Update F74.html

### DIFF
--- a/techniques/failures/F74.html
+++ b/techniques/failures/F74.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html><html lang="en"><head><title>Failure of Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media alternative to text as an alternative</title><link rel="stylesheet" type="text/css" href="../../css/sources.css" class="remove"></head><body><h1>Failure of Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media alternative to text as an alternative</h1><section class="meta"><p class="id">ID: F74</p><p class="technology">Technology: failures</p><p class="type">Type: Failure</p></section><section id="applicability"><h2>When to Use</h2>
       <p>Pages that provide synchronized media alternatives to text.</p>
    </section><section id="description"><h2>Description</h2>
-      <p>The objective of this failure is to avoid situations in which synchronized media alternatives are not labeled with the text for which they are alternatives. Synchronized media alternatives provide enhanced access to users for whom synchronized media is a more effective format than text. Since they are alternatives to text, they do not need themselves to have redundant text alternatives. However, they need to be clearly labeled with the text for which they substitute, so users can find them and so users who normally expect text alternatives to synchronized media know not to look for them.</p>
+      <p>The objective of this failure is to avoid situations in which synchronized media alternatives are not labeled with the text for which they are alternatives. Synchronized media alternatives provide enhanced access to users for whom synchronized media is a more effective format than text. Since they are alternatives to text, they do not need themselves to have redundant text alternatives. However, they need to be clearly labeled so that they reference the part of the text that they substitute. If such a label is missing, users cannot easily find the corresponding text when they need a text alternative to synchronized media.</p>
    </section><section id="examples"><h2>Examples</h2>
       <section class="example">
          <h3>Synchronized media alternatives provided elsewhere on page</h3>
          
-            <p>A page with instructions to complete a tax form provides a prose description of the fields to complete, data to provide, etc. Additionally, a synchronized media alternative provides spoken instructions, with video of a person completing the section being discussed in the audio. Although both versions are provided on the page, the synchronized media version is provided elsewhere on the page and is not clearly labeled with the part of the text for which it is a substitute. This makes it difficult for users encountering the text to find it, and users encountering the video do not know where its text alternative is.</p>
+            <p>A page with a set of text instructions for using a service has one part that describes the registration process, going through the form fields to complete, data to provide, etc. Additionally, a video provided as a synchronized media alternative shows a person completing the registration process and explains its steps in the synchronized audio. Although both text instruction and video are provided on the same page, the synchronized media version is provided after the entire set of text instructions and is not clearly labeled with the part of the text instruction for which it is a substitute (e.g. "Video explainer of the registration process"). This makes it difficult for users encountering the video to locate the text instruction to which it is an alternative.</p>
          
       </section>
    </section><section id="tests"><h2>Tests</h2>
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check pages that provide synchronized media alternatives to text.</li>
-            <li>Check that synchronized media is clearly labeled with the text for which it is an alternative.</li>
+            <li>Check that synchronized media has a text label that clearly indicates the part of the text for which it is an alternative.</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>

--- a/techniques/failures/F74.html
+++ b/techniques/failures/F74.html
@@ -13,7 +13,7 @@
       <section class="procedure"><h3>Procedure</h3>
          <ol>
             <li>Check pages that provide synchronized media alternatives to text.</li>
-            <li>Check that synchronized media has a text label that clearly indicates the part of the text for which it is an alternative.</li>
+            <li>Check that synchronized media in its default state has an adjacent text label that clearly indicates the part of the text for which it is an alternative.</li>
          </ol>
       </section>
       <section class="results"><h3>Expected Results</h3>


### PR DESCRIPTION
* Tried to give an idea of what is meant by a clear label (= one that clearly references the corresponding text section)
* Changed the tax form example to a registration form instruction as part of a larger set of service instructions (so that the difficulty of associating the synchronized media alternative for that one part is made more obvious when the video is at the bottom of the entire set of instructions)