### PR TITLE
Understanding techniques: change "Numbered list" to just "List" and simplify

### DIFF
--- a/understanding/understanding-techniques.html
+++ b/understanding/understanding-techniques.html
@@ -46,8 +46,8 @@
 			</ul>
 			<p>There may be other ways to meet success criteria besides the sufficient techniques in W3C's <a href="../Techniques/">Techniques for WCAG {{ versionDecimal }}</a> document, as explained in <a href="#other-techniques">Other Techniques</a> below. <em>(See also <a href="#techniques-are-informative">Techniques are Informative</a> above.)</em></p>
 			<section>
-				<h3>Numbered Lists, "AND"</h3>
-				<p> The W3C-documented sufficient techniques are provided in a numbered list where each list item provides a technique or combination of techniques that can be used to meet the success criterion. Where there are multiple techniques on a numbered list item connected by "AND" then all of the techniques must be used to be sufficient. For example, <a href="info-and-relationships#techniques">Sufficient Techniques for 1.3.1 Info and Relationships</a> has: "G115: Using semantic elements to mark up structure AND H49: Using semantic markup to mark emphasized or special text (HTML)".</p>
+				<h3>Bullet lists, "AND"</h3>
+				<p>The W3C-documented sufficient techniques are provided in bullet list where each list item provides a technique or combination of techniques that can be used to meet the success criterion. Where there are multiple techniques on a list item connected by "AND" then all of the techniques must be used to be sufficient. For example, <a href="info-and-relationships#techniques">Sufficient Techniques for 1.3.1 Info and Relationships</a> has: "G115: Using semantic elements to mark up structure AND H49: Using semantic markup to mark emphasized or special text (HTML)".</p>
 			</section>
 		</section>
 		<section>

--- a/understanding/understanding-techniques.html
+++ b/understanding/understanding-techniques.html
@@ -46,8 +46,8 @@
 			</ul>
 			<p>There may be other ways to meet success criteria besides the sufficient techniques in W3C's <a href="../Techniques/">Techniques for WCAG {{ versionDecimal }}</a> document, as explained in <a href="#other-techniques">Other Techniques</a> below. <em>(See also <a href="#techniques-are-informative">Techniques are Informative</a> above.)</em></p>
 			<section>
-				<h3>Bullet lists, "AND"</h3>
-				<p>The W3C-documented sufficient techniques are provided in bullet list where each list item provides a technique or combination of techniques that can be used to meet the success criterion. Where there are multiple techniques on a list item connected by "AND" then all of the techniques must be used to be sufficient. For example, <a href="info-and-relationships#techniques">Sufficient Techniques for 1.3.1 Info and Relationships</a> has: "G115: Using semantic elements to mark up structure AND H49: Using semantic markup to mark emphasized or special text (HTML)".</p>
+				<h3>Lists, "AND"</h3>
+				<p>The W3C-documented sufficient techniques are provided in a list where each item provides a technique or combination of techniques that can be used to meet the success criterion. Where there are multiple techniques connected by "AND" then all of the techniques must be used to be sufficient. For example, <a href="info-and-relationships#techniques">Sufficient Techniques for 1.3.1 Info and Relationships</a> has: "G115: Using semantic elements to mark up structure AND H49: Using semantic markup to mark emphasized or special text (HTML)".</p>
 			</section>
 		</section>
 		<section>


### PR DESCRIPTION
The reference to numbered lists seems to be very outdated, as none of the techniques get listed in numbered lists. See https://github.com/w3c/wcag/discussions/5199