### PR TITLE
Build: Upgrade slugify and specify transliterate: false to save 2s

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -651,7 +651,7 @@ export class CustomLiquid extends Liquid {
     }
 
     const slugify = slugifyWithCounter();
-    const slugifyOptions: SlugifyOptions = { decamelize: false };
+    const slugifyOptions: SlugifyOptions = { decamelize: false, transliterate: false };
 
     // Allow autogenerating missing top-level section IDs in understanding docs,
     // but don't pick up incorrectly-nested sections in some techniques pages (e.g. H91)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "W3C",
       "dependencies": {
         "@11ty/eleventy": "^3.1.5",
-        "@sindresorhus/slugify": "^2.2.1",
+        "@sindresorhus/slugify": "^3.0.0",
         "cheerio": "^1.0.0",
         "glob": "^13.0.6",
         "gray-matter": "^4.0.3",
@@ -159,6 +159,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/@sindresorhus/slugify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^1.0.0",
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/@sindresorhus/transliterate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@11ty/lodash-custom": {
@@ -1250,31 +1281,28 @@
       }
     },
     "node_modules/@sindresorhus/slugify": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
-      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-3.0.0.tgz",
+      "integrity": "sha512-SCrKh1zS96q+CuH5GumHcyQEVPsM4Ve8oE0E6tw7AAhGq50K8ojbTUOQnX/j9Mhcv/AXiIsbCfquovyGOo5fGw==",
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/transliterate": "^1.0.0",
+        "@sindresorhus/transliterate": "^2.0.0",
         "escape-string-regexp": "^5.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sindresorhus/transliterate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
-      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-2.3.1.tgz",
+      "integrity": "sha512-gVaaGtKYMYAMmI8buULVH3A2TXVJ98QiwGwI7ddrWGuGidGC2uRt4FHs22+8iROJ0QTzju9CuMjlVsrvpqsdhA==",
       "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "W3C",
   "dependencies": {
     "@11ty/eleventy": "^3.1.5",
-    "@sindresorhus/slugify": "^2.2.1",
+    "@sindresorhus/slugify": "^3.0.0",
     "cheerio": "^1.0.0",
     "glob": "^13.0.6",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
I did a bit of performance profiling of the build process this morning, and `node --prof` highlighted that `@sindresorhus/slugify` was occupying a surprising amount of time in a function called `transliterate`.

It turns out that this package released a new major version last September which allows skipping the `transliterate` step. Since we aren't using unicode in any headings that would affect IDs, this has no effect on build output for us, and saves at least 1.5 seconds.