### PR TITLE
Build: Store cheerio results that are repeatedly referenced

### DIFF
--- a/11ty/CustomLiquid.ts
+++ b/11ty/CustomLiquid.ts
@@ -135,6 +135,7 @@ export class CustomLiquid extends Liquid {
       if (!isTechniques && !isUnderstanding) return super.parse(html);
 
       const $ = flattenDom(html, filepath);
+      const $body = $("body");
 
       // Clean out elements to be removed
       // (e.g. editors.css & sources.css, and leftover template paragraphs)
@@ -223,7 +224,7 @@ export class CustomLiquid extends Liquid {
             .each((_, el) => expandTechniqueLink($(el)));
 
           // XSLT orders related and tests last, but they are not last in source files
-          $("body")
+          $body
             .append("\n", $(`body > section#related`))
             .append("\n", $(`body > section#tests`));
 
@@ -302,7 +303,7 @@ export class CustomLiquid extends Liquid {
             throw new Error("Please remove success-criteria section from guideline pages.");
           }
           // success-criteria template only renders content for guideline (not SC) pages
-          $("body").append(generateIncludes("understanding/success-criteria"));
+          $body.append(generateIncludes("understanding/success-criteria"));
 
           // Add intro prose to populated sections
           $("section#resources h2").after(generateIncludes("understanding/intro/resources"));
@@ -311,14 +312,14 @@ export class CustomLiquid extends Liquid {
           $(understandingToTechniqueLinkSelector).each((_, el) => expandTechniqueLink($(el)));
 
           // Add key terms and references by default, to be removed in #parse if not needed
-          $("body").append(generateIncludeWithParams("dl-section", { title: "Key Terms" }));
-          $("body").append(generateIncludeWithParams("dl-section", { title: "References" }));
+          $body.append(generateIncludeWithParams("dl-section", { title: "Key Terms" }));
+          $body.append(generateIncludeWithParams("dl-section", { title: "References" }));
         }
 
         // Remove h2-level sections with no content other than heading
         $("body > section:not(:has(:not(h2)))").remove();
 
-        $("body")
+        $body
           .attr("dir", "ltr") // Already included in index/about pages
           .append(generateIncludes("test-rules", "back-to-top"))
           .wrapInner(`<main id="main" class="standalone-resource__main"></main>`)
@@ -329,7 +330,7 @@ export class CustomLiquid extends Liquid {
           .wrapInner(`<div class="default-grid with-gap leftcol"></div>`);
       }
 
-      $("body")
+      $body
         .prepend(generateIncludes(...prependedIncludes))
         .append(generateIncludes(...appendedIncludes));
 
@@ -373,12 +374,13 @@ export class CustomLiquid extends Liquid {
             `${scope.technique.id}: ${scope.technique.title}${titleSuffix}`
         );
 
-        const aboutBoxSelector = "section#technique .box-i";
+        const $about = $("section#technique .box-i");
+        const $applicability = $("section#applicability");
 
         // Strip applicability paragraphs with metadata IDs (e.g. H99)
-        $("section#applicability").find("p#id, p#technology, p#type").remove();
+        $applicability.find("p#id, p#technology, p#type").remove();
         // Check for custom applicability paragraph before removing the section
-        const customApplicability = $("section#applicability p")
+        const customApplicability = $applicability.find("p")
           .html()
           ?.trim()
           .replace(/^th(e|is) (technique|failure)s? (is )?/i, "")
@@ -391,14 +393,14 @@ export class CustomLiquid extends Liquid {
 
           // Failure pages have no default applicability paragraph, so append one first
           if (scope.technique.technology === "failures")
-            $("section#technique .box-i").append("<p></p>");
+            $about.append("<p></p>");
 
           const noun = scope.technique.technology === "failures" ? "failure" : "technique";
           const appliesMatch = appliesPattern.exec(customApplicability);
           const connector = /^not/.test(customApplicability)
             ? "is"
             : `applies ${appliesMatch?.[1] || "to"}`;
-          $("section#technique .box-i p:last-child").html(
+          $about.find("p:last-child").html(
             `This ${noun} ${connector} ` +
               // Uncapitalize original sentence, except for all-caps abbreviations or titles
               (/^[A-Z]{2,}/.test(rephrasedApplicability) ||
@@ -409,7 +411,7 @@ export class CustomLiquid extends Liquid {
           );
 
           // Append any relevant subsequent paragraphs or lists from applicability section
-          const $additionalApplicability = $("section#applicability").find(
+          const $additionalApplicability = $applicability.find(
             "p:not(:first-of-type), ul, ol"
           );
           const additionalApplicabilityText = $additionalApplicability.text();
@@ -418,9 +420,9 @@ export class CustomLiquid extends Liquid {
             "This technique relates to:", // Redundant of auto-generated content
           ];
           if (excludes.every((exclude) => !additionalApplicabilityText.includes(exclude)))
-            $additionalApplicability.appendTo(aboutBoxSelector);
+            $additionalApplicability.appendTo($about);
         }
-        $("section#applicability").remove();
+        $applicability.remove();
 
         // Remove any effectively-empty techniques/resources sections,
         // due to template boilerplate or obsolete technique removal


### PR DESCRIPTION
I looked over `CustomLiquid.ts` today looking for any obvious room for performance improvement and spotted a couple of queries we could avoid repeating, with no changes to build output.

Judging by measuring combined duration of all `parse` and `render` calls, this could save around 50ms across the entire build, though it's hard to pin down given fluctuations between runs.