### PR TITLE
Add clarification to 1.4.11 Non-text contrast understanding about exempt graphical objects acting as user interface components - UIC needs to have *some* sufficiently contrasting aspect

### DIFF
--- a/understanding/21/non-text-contrast.html
+++ b/understanding/21/non-text-contrast.html
@@ -180,7 +180,7 @@
 					</figcaption>
 				</figure>
 
-		        <p>Note that this success criterion does not directly compare the focused and unfocused states of a control - if the focus state relies on a change of color (e.g., changing <em>only</em> the background color of a button), this success criterion does not define any requirement for the difference in contrast between the two states.</p>
+				<p>Note that this success criterion does not directly compare the focused and unfocused states of a control - if the focus state relies on a change of color (e.g., changing <em>only</em> the background color of a button), this success criterion does not define any requirement for the difference in contrast between the two states.</p>
 
 				<figure id="figure-focus-background">
 					{% include "./img/1.4.11-ntc-focus-background.svg" %}
@@ -197,7 +197,7 @@
 				</section>
 
 				<section>
-					<h3>User Interface Component Examples</h3>
+					<h3>User Interface Component examples</h3>
 					<p>For designing focus indicators, selection indicators and user interface components that need to be perceived clearly, the following are examples that have sufficient contrast.</p>
 
 					<h4>Passing User Interface Component Examples</h4>
@@ -410,7 +410,7 @@
 
 					</div>
 
-					<h4>Failing User Interface Component Examples</h4>
+					<h4>Failing User Interface Component examples</h4>
 
 					<p>The following are examples that have insufficient contrast.</p>
 
@@ -639,74 +639,54 @@
 				</figure>
 
 				<section>
-				<h4>Required for Understanding</h4>
+					<h4>Required for understanding</h4>
 
-				<p>The term &quot;required for understanding&quot; is used in the success criterion as many graphics do not need to meet the contrast requirements. If a person needs to perceive a graphic, or part of a graphic (a graphical object) in order to understand the content it should have sufficient contrast. However, that is not a requirement when:</p>
-				<ul>
-					<li>
-						<p>A graphic with text embedded or overlaid conveys the same information, such as labels <em>and</em> values on a chart.</p>
-						<p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
-					</li>
-					<li> The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
-					<li> The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
-					<li> The graphic is part of a logo or brand name (which is considered &quot;essential&quot; to its presentation).</li>
-				</ul>
+					<p>The term &quot;required for understanding&quot; is used in the success criterion as many graphics do not need to meet the contrast requirements. If a person needs to perceive a graphic, or part of a graphic (a graphical object) in order to understand the content it should have sufficient contrast. However, that is not a requirement when:</p>
+					<ul>
+						<li>
+							<p>A graphic with text embedded or overlaid conveys the same information, such as labels <em>and</em> values on a chart.</p>
+							<p class="note">Text within a graphic must meet <a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a>.</p>
+						</li>
+						<li>The graphic is for aesthetic purposes that does not require the user to see or understand it to understand the content or use the functionality.</li>
+						<li>The information is available in another form, such as in a table that follows the graph, which becomes visible when a "Long Description" button is pressed.</li>
+						<li>The graphic's presentation falls under the <a href="#essential-exception">essential exception</a>.</li>
+					</ul>
 				</section>
 
 				<section>
-				<h4>Logos</h4>
+					<h4>Gradients</h4>
 
-				<p>Logos are exempted from contrast requirements, under the assumption that they must comply with stricter color choices mandated
-				by corporate identity or brand guidelines. However, this can be problematic when logos act as <a>user interface components</a>
-				(such as a link or other interactive control). In these cases, as a best practice, authors should consider choosing a variant of
-				the logo that has sufficient contrast, if allowed by the corporate identity or brand guidelines.
-				Alternatively, authors should consider providing an equivalent <a>user interface component</a> which serves the same purpose and meets
-				contrast requirements.</p>
+					<p>Gradients can reduce the apparent contrast between areas, and make it more difficult to test. The general principles is to identify the graphical object(s) required for understanding, and take the central color of that area. If you remove the adjacent color which does not have sufficient contrast, can you still identify and understand the graphical object?</p>
+					<figure id="figure-blue-circle-i-versions">
+						<img src="img/contrast-gradient.png" alt="Two versions of a blue circle with an 'i' indicating information. The first example has a blue gradient background, the second is missing the upper half of the background which obscures the i." width="300">
+					<figcaption>Removing the background which does not have sufficient contrast highlights that the graphical object (the &quot;i&quot;) is not then understandable.</figcaption></figure>
+					</section>
+					<section>
+					<h4>Dynamic examples</h4>
 
-				<p>If logos are presented with an insufficient contrast, but their presentation was an author choice rather than
-				being mandated by corporate identity or brand guidelines, then that particular low contrast presentation is
-				<em>not</em> "essential", and the logo is <em>not</em> exempt from the contrast requirements.</p>
+					<p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, the unfocused default version must already have sufficiently contrasting colors or text. For the area that receives focus, information can then be made available dynamically as pop-up text, or be foregrounded dynamically by increasing the contrast.</p>
 
-				<figure id="figure-low-contrast-logos-author-choice">
-					<img src="img/1.4.11-ntc-author-choice-logos.png" alt="A heading: 'ACME tool is trusted by the world's most innovative companies.'; below the heading, a series of nine company logos, all presented as very dark grey logos on the page's black background, with very low contrast; one logo is hovered with the mouse, and is displayed in white, with high contrast against the page background.">
-					<figcaption>An author chooses to present company logos with low contrast by default, until they are hovered; the fact that these are logos doesn't exempt this scenario from failing the requirements of this success criterion, as the initial low contrast presentation is not "essential"</figcaption>
-				</figure>
-
+					<!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
+					<figure id="figure-pie-slice-hover-data">
+						<img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350">
+						<figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
+					</figure>
 				</section>
 				<section>
-				<h4>Gradients</h4>
+					<h4>Infographics</h4>
 
-				<p>Gradients can reduce the apparent contrast between areas, and make it more difficult to test. The general principles is to identify the graphical object(s) required for understanding, and take the central color of that area. If you remove the adjacent color which does not have sufficient contrast, can you still identify and understand the graphical object?</p>
-				<figure id="figure-blue-circle-i-versions">
-          <img src="img/contrast-gradient.png" alt="Two versions of a blue circle with an 'i' indicating information. The first example has a blue gradient background, the second is missing the upper half of the background which obscures the i." width="300">
-				<figcaption>Removing the background which does not have sufficient contrast highlights that the graphical object (the &quot;i&quot;) is not then understandable.</figcaption></figure>
-				</section>
-				<section>
-				<h4>Dynamic Examples</h4>
+					<p>Infographics can mean any graphic conveying data, such as a chart or diagram. On the web it is often used to indicate a large graphic with lots of statements, pictures, charts or other ways of conveying data. In the context of graphics contrast, each item within such an infographic should be treated as a set of graphical objects, regardless of whether it is in one file or separate files.</p>
 
-				<p>Some graphics may have interactions that either vary the contrast, or display the information as text when you mouseover/tap/focus each graphical object. In order for someone to discern the graphics exist at all, the unfocused default version must already have sufficiently contrasting colors or text. For the area that receives focus, information can then be made available dynamically as pop-up text, or be foregrounded dynamically by increasing the contrast.</p>
+					<p>Infographics often fail to meet several WCAG level AA criteria including:</p>
 
-				<!-- example from http://www.oracle.com/webfolder/technetwork/jet/jetCookbook.html?component=pieChart&demo=default -->
-				<figure id="figure-pie-slice-hover-data">
-					<img alt="A pie chart with one slice highlighted and a box hovering next to it that shows the data and indicates the source in the key." src="img/dynamic-pie-chart.png" width="350">
-					<figcaption>A dynamic chart where the current 'slice' is hovered or focused, which activates the associated text display of the values and highlights the series</figcaption>
-				</figure>
-				</section>
-				<section>
-				<h4>Infographics</h4>
+					<ul>
+						<li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
+						<li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
+						<li><a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a></li>
+						<li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
+					</ul>
 
-				<p>Infographics can mean any graphic conveying data, such as a chart or diagram. On the web it is often used to indicate a large graphic with lots of statements, pictures, charts or other ways of conveying data. In the context of graphics contrast, each item within such an infographic should be treated as a set of graphical objects, regardless of whether it is in one file or separate files.</p>
-
-				<p>Infographics often fail to meet several WCAG level AA criteria including:</p>
-
-				<ul>
-					<li><a href="non-text-content" class="sc">1.1.1 Non-text Content</a></li>
-					<li><a href="use-of-color" class="sc">1.4.1 Use of Color</a></li>
-					<li><a href="contrast-minimum" class="sc">1.4.3 Contrast (Minimum)</a></li>
-					<li><a href="images-of-text" class="sc">1.4.5 Images of Text</a></li>
-				</ul>
-
-				<p>An infographic can use text which meets the other criteria to minimize the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infographic is not relied upon for understanding.</p>
+					<p>An infographic can use text which meets the other criteria to minimize the number of graphical objects required for understanding. For example, using text with sufficient contrast to provide the values in a chart. A long description would also be sufficient because then the infographic is not relied upon for understanding.</p>
 
 				</section>
 
@@ -720,11 +700,11 @@
 				</section>
 
 				<section>
-					<h4>Essential Exception</h4>
+					<h4>Essential exception</h4>
 
-					<p>Graphical objects do not have to meet the contrast requirements when &quot;a particular presentation of graphics is essential to the information being conveyed&quot;. The Essential exception is intended to apply when there is no way of presenting the graphic with sufficient contrast without undermining the meaning. For example:</p>
+					<p>Graphical objects do not have to meet the contrast requirements when &quot;a particular presentation of graphics is essential to the information being conveyed&quot;. The <a>essential</a> exception is intended to apply when there is no way of presenting the graphic with sufficient contrast without undermining the meaning. For example:</p>
 					<ul>
-						<li><strong>Logos and logotypes</strong>: The brand logo of an organization or product is the representation of that organization, and is often
+						<li><strong>Logos and logotypes</strong>: The brand logo of an organization or product is the representation of that organization, and is generally
 							presented in the brand's specific colors; it is therefore exempt.</li>
 						<li><strong>Flags</strong>: Flags may not be identifiable if the colors are changed to have sufficient contrast.</li>
 						<li><strong>Sensory</strong>: There is no requirement to change pictures of real life scenes such as photos of people or scenery.</li>
@@ -736,10 +716,32 @@
 							</ul>
 						</li>
 					</ul>
-				</section>
+
+					<p>However, when these graphical objects act as <a>user interface components</a> (such as links or other interactive controls),
+					authors must nonetheless make sure that there is an aspect of	the user interface components that allows users
+					to identify the components.</p>
+
+					<p>In the case of logos, authors should choose a variant of the logo that has sufficient contrast, if variants are allowed by the
+					relevant corporate identity or brand guidelines. Otherwise, authors should provide an additional visual element with sufficient
+					contrast that helps identify the user interface component – such as additional text, or an outline or border around the component.</p>
+
+					<p>Alternatively, authors may provide an equivalent <a>user interface component</a> which serves the same purpose
+					and meets contrast requirements.</p>
+
+					<h5>Essential exception and author choice</h5>
+
+					<p>If exempted graphical objects (such as logos) are presented with an insufficient contrast, but their low contrast presentation
+					was an author choice, then that particular low contrast	presentation is	<em>not</em> "essential", and the graphical object
+					is <em>not</em> exempt from the contrast requirements.</p>
+
+					<figure id="figure-low-contrast-logos-author-choice">
+						<img src="img/1.4.11-ntc-author-choice-logos.png" alt="A heading: 'ACME tool is trusted by the world's most innovative companies.'; below the heading, a series of nine company logos, all presented as very dark grey logos on the page's black background, with very low contrast; one logo is hovered with the mouse, and is displayed in white, with high contrast against the page background.">
+						<figcaption>An author chooses to present company logos with low contrast by default, until they are hovered; the fact that these are logos doesn't exempt this scenario from failing the requirements of this success criterion, as the initial low contrast presentation is not "essential" (since it's not mandated by corporate identity or brand guidelines)</figcaption>
+					</figure>
+			</section>
 
 			<section id="testing-principles">
-					<h3>Testing Principles</h3>
+					<h3>Testing principles</h3>
 					<p>A summary of the high-level process for finding and assessing non-text content on a web page:</p>
 					<ul>
 						<li>Identify each user-interface component (link, button, form control) on the page and:
@@ -771,14 +773,14 @@
 		</section>
 
 		<section id="examples">
-			<h2>Graphical Object Examples</h2>
+			<h2>Graphical Object examples</h2>
 			<ul>
 				<li>Status icons on an application's dashboard (without associated text) have a 3:1 minimum contrast ratio.</li>
 				<li>A text input has a dark border around the white editable area.</li>
 				<li>A graph uses a light background and ensures that the colors for each line have a 3:1 contrast ratio against the background.</li>
 			</ul>
 			<section class="example">
-				<h3>Pie Charts</h3>
+				<h3>Pie charts</h3>
 				<p>Pie charts make a good case study for the graphical objects part of this success criterion, the following pie charts are intended to convey the proportion of market share each browser has. Please Note: The actual figures are made up, these are not actual market shares. </p>
 				<figure id="figure-failing-pie-chart">
 					<img src="img/graphics-contrast_pie-chart_fail.png" alt="Failing pie chart">
@@ -820,7 +822,7 @@
 
 
 		<section id="resources">
-			<h2>Resources </h2>
+			<h2>Resources</h2>
 			<ul>
 				<li><a href="http://w3c.github.io/low-vision-a11y-tf/requirements.html">Accessibility Requirements for People with Low Vision</a>.</li>
 				<li><a href="https://lists.w3.org/Archives/Public/public-low-vision-a11y-tf/2017May/0007.html">Smith Kettlewell Eye Research Institute</a> -  &quot;If the text is better understood with the graphics, they should be equally visible as the text&quot;.</li>


### PR DESCRIPTION
**For a counter-proposal, see https://github.com/w3c/wcag/pull/5250**

**This is a redo of the previous speculative PRs - cleaned up, and expanded to not only include "logos" but more generally any graphical objects that are exempted, like flags and such**

Supersedes https://github.com/w3c/wcag/pull/5113 (which only focused on logos, but the same rationale needs to apply to any other graphical objects - like flags etc - whose contrast/colours can't be changed, but that also act as UICs)

In addition, this PR moves the "Logos" section directly under/into the "Exception examples", where it more logically belongs, fixes some markup indentation, and lowercases some of the headings.

Copying over the context/rationale from https://github.com/w3c/wcag/pull/5113

> The normative wording for 1.4.11 https://www.w3.org/TR/WCAG22/#non-text-contrast
> 
> > The visual presentation of the following have a contrast ratio of at least 3:1 against adjacent color(s):
> > 
> > **User Interface Components**
> > Visual information required to identify user interface components and states, except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author;
> > **Graphical Objects**
> > Parts of graphics required to understand the content, except when a particular presentation of graphics is essential to the information being conveyed.
> 
> has two distinct aspects/subjects - user interface components (UICs) and graphical objects.
> 
> Logos that have insufficient non-text contrast are exempted when they act as graphical objects, as their (low contrast) colours fall under the "except when a particular presentation of graphics is essential" clause.
> 
> However, when logos are the only content inside a UIC, the logo itself may be exempt, but the UIC around it has no explicit exemption. A button/control only containing a logo with insufficient contrast, and no other sufficiently contrasting visual indicator, would fail the UIC clause of 1.4.11.
> 
> This means that authors would need to either choose a different version of the logo (if it exists) that has sufficient non-text contrast, or make sure there is some other visual indicator on the UIC so that people who can't perceive the low-contrast logo can still understand/see that there is a UIC to begin with.
> 
> The PR also adds a clarification/reminder that if there's an accessible alternative (such as a link/control that serves the same purpose) somewhere on the page that DOES have sufficient contrast, that can also be used to pass this criterion.
> 
> ---
> 
> Follow-up to https://github.com/w3c/wcag/pull/4402 - this PR contains the more controversial aspect that clarifies if a logo is used as a user interface component, then the UIC *does* need to have a sufficiently contrasting element so that users can perceive it.
> 
> > For 1.4.11 there is a wrinkle because the SC distinguishes between user interface controls and graphical objects. Logos on their own count as graphical objects, and if the CI/brand guidelines stipulated non-contrasting colours, then that is "essential". However, the "user interface control" part of a link/button with a logo is still subject to the requirements of the UIC needing to be identifiable.

Closes https://github.com/w3c/wcag/issues/4376, closes https://github.com/w3c/wcag/issues/1275, closes https://github.com/w3c/wcag/issues/1739

x-ref https://github.com/w3c/wcag/issues/902

Preview: https://deploy-preview-5249--wcag2.netlify.app/understanding/non-text-contrast

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FWAI%2FWCAG22%2FUnderstanding%2Fnon-text-contrast.html&doc2=https%3A%2F%2Fdeploy-preview-5249--wcag2.netlify.app%2Funderstanding%2Fnon-text-contrast