### PR TITLE
Ensure img/video/svg inside figure doesn't grow wider than the figure parent container

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -407,6 +407,7 @@ figure img,
 figure video,
 figure svg {
 	border: 1px solid var(--line-grey);
+	box-sizing: border-box;
 }
 
 main table svg[role*="image"],


### PR DESCRIPTION
Currently, due to the additional `1px` border, wide images/videos/svgs inside a figure can end up 2 pixels wider than the parent `<figure>` container. This is not normally a problem, but results in an unsightly "bump" in focus outline when navigating with a keyboard and jumping to a section that contains one of these wide figures.

Example: https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast#examples (make sure to navigate to it using the keyboard, to enable the focus outline)

> ![example of a wide image - focus outline around the section has a "bump"](https://github.com/user-attachments/assets/6258f595-3ac3-4842-b387-1d3dfc38f50f)

> ![closeup showing the bump and the margin/padding for the figure - the image itself juts out by two pixels to the right](https://github.com/user-attachments/assets/c8cb4e64-5b11-4b2e-a7dd-52be88fd05fc)

Forcing the box-sizing to take into account the border fixes this.

Preview: https://deploy-preview-5315--wcag2.netlify.app/understanding/non-text-contrast#examples

> ![the same example of a wide image - focus outline around the section now doesn't have a bump](https://github.com/user-attachments/assets/00075ff4-e47a-4e41-a91a-57fd562a0134)

> ![closeup showing that the image is now only as wide as the figure parent](https://github.com/user-attachments/assets/813a5890-43c7-4f53-a9c3-06b01a1ce771)
