### PR TITLE
Update spec-generator URLs for WCAG-2.1 branch

### DIFF
--- a/.github/workflows/21ed-publish.yaml
+++ b/.github/workflows/21ed-publish.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: |
           cp guidelines/guidelines.css guidelines/relative-luminance.html _site/guidelines
-          curl https://labs.w3.org/spec-generator/?type=respec"&"url=https://raw.githack.com/$GITHUB_REPOSITORY/WCAG-2.1/guidelines/index.html -o _site/guidelines/index.html -f  --retry 3
+          curl https://www.w3.org/publications/spec-generator/?type=respec"&"url=https://raw.githubusercontent.com/$GITHUB_REPOSITORY/WCAG-2.1/guidelines/index.html -o _site/guidelines/index.html -f  --retry 3
       - name: Push
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
This effectively ports #4806 and #4956 to the workflow used for updating the 2.1 ED.

I am backporting this as I noticed workflow failures while merging a couple of 2.1-specific errata PRs.

There are other instances of old spec-generator and githack URLs in `build.xml` and `.travis.yml`, but both seem to be in a state that must not have been used in several years, as they also reference the `master` branch (whereas `main` is the default branch now). As such, I am intentionally not touching those files.
