### PR TITLE
Backport summer 2026 errata to 2.1

### DIFF
--- a/guidelines/relative-luminance.html
+++ b/guidelines/relative-luminance.html
@@ -343,7 +343,7 @@
         
         <div class="note" role="note" id="issue-container-generatedID-130"><div role="heading" class="note-title marker" id="h-note-130" aria-level="3"><span>Note</span><!---0.410359%--></div><p class="">Almost all systems used today to view web content assume sRGB encoding. Unless it
           is known that another color space will be used to process and display the content,
-          authors should evaluate using sRGB colorspace. If using other color spaces, see <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">Understanding Success Criterion 1.4.3</a>.
+          authors should evaluate using sRGB colorspace. If using other color spaces, see <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum">Understanding Success Criterion 1.4.3 Contrast (Minimum)</a>.
         </p></div>
         
         <div class="note" role="note" id="issue-container-generatedID-131"><div role="heading" class="note-title marker" id="h-note-131" aria-level="3"><span>Note</span><!---0.410359%--></div><p class="">If dithering occurs after delivery, then the source color value is used. For colors

--- a/guidelines/sc/20/non-text-content.html
+++ b/guidelines/sc/20/non-text-content.html
@@ -13,7 +13,7 @@
       
       <dd>
          
-         <p>If non-text content is a control or accepts user input, then it has a <a>name</a> that describes its purpose. (Refer to <a href="#name-role-value">Success Criterion 4.1.2</a> for additional requirements for controls and content that accepts user input.)
+         <p>If non-text content is a control or accepts user input, then it has a <a>name</a> that describes its purpose. (Refer to <a href="#name-role-value">Success Criterion 4.1.2 Name, Role, Value</a> for additional requirements for controls and content that accepts user input.)
          </p>
          
       </dd>

--- a/guidelines/sc/20/section-headings.html
+++ b/guidelines/sc/20/section-headings.html
@@ -11,7 +11,7 @@
       heading to different types of content.
    </p>
    
-   <p class="note">This success criterion covers sections within writing, not <a>user interface components</a>. User interface components are covered under <a href="#name-role-value">Success Criterion 4.1.2</a>.
+   <p class="note">This success criterion covers sections within writing, not <a>user interface components</a>. User interface components are covered under <a href="#name-role-value">Success Criterion 4.1.2 Name, Role, Value</a>.
    </p>
    
 </section>

--- a/guidelines/sc/20/timing-adjustable.html
+++ b/guidelines/sc/20/timing-adjustable.html
@@ -68,7 +68,7 @@
    
    <p class="note">This success criterion helps ensure that users can complete tasks without unexpected
       changes in content or context that are a result of a time limit. This success criterion
-      should be considered in conjunction with <a href="#on-focus">Success Criterion 3.2.1</a>, which puts limits on changes of content or context as a result of user action.
+      should be considered in conjunction with <a href="#on-focus">Success Criterion 3.2.1 On Focus</a>, which puts limits on changes of content or context as a result of user action.
    </p>
    
 </section>

--- a/guidelines/sc/21/content-on-hover-or-focus.html
+++ b/guidelines/sc/21/content-on-hover-or-focus.html
@@ -19,9 +19,9 @@
 
   </dl>
     	
-    	<p>Exception: The visual presentation of the additional content is controlled by the <a>user agent</a> and is not modified by the author.</p>
+    	<p>Exception: The visual presentation of the additional content is determined by the <a>user agent</a> and is not modified by the author.</p>
 
-    	<p class="note">Examples of additional content controlled by the user agent include browser tooltips created through use of the HTML <a href="https://www.w3.org/TR/html/dom.html#the-title-attribute"><code>title</code> attribute</a>.</p>
+    	<p class="note">Examples of additional content where the visual presentation is determined by the user agent include browser tooltips created through use of the HTML <a href="https://www.w3.org/TR/html/dom.html#the-title-attribute"><code>title</code> attribute</a>.</p>
      <p class="note">Custom tooltips, sub-menus, and other nonmodal popups that display on hover and focus are examples of additional content covered by this criterion.</p>
 
   </section>

--- a/guidelines/terms/20/contrast-ratio.html
+++ b/guidelines/terms/20/contrast-ratio.html
@@ -20,9 +20,9 @@
       evaluated with anti-aliasing turned off.
    </p>
    
-   <p class="note">For the purpose of Success Criteria 1.4.3 and 1.4.6, contrast is measured with respect
-      to the specified background over which the text is rendered in normal usage. If no
-      background color is specified, then white is assumed.
+   <p class="note">For the purpose of Success Criteria 1.4.3 Contrast (Minimum) and 1.4.6 Contrast (Enhanced),
+      contrast is measured with respect to the specified background over which the text is rendered in normal usage.
+      If no background color is specified, then white is assumed.
    </p>
    
    <p class="note">Background color is the specified color of content over which the text is to be rendered

--- a/guidelines/terms/20/process.html
+++ b/guidelines/terms/20/process.html
@@ -3,13 +3,15 @@
    
    <p>series of user actions where each action is required in order to complete an activity</p>
    
-   <aside class="example"><p>Successful use of a series of web pages on a shopping site requires users to view
+   <aside class="example">
+      <p>Successful use of a series of web pages on a shopping site requires users to view
       alternative products, prices and offers, select products, submit an order, provide
-      shipping information and provide payment information.
-   </p></aside>
+      shipping information and provide payment information.</p>
+   </aside>
    
-   <aside class="example"><p>An account registration page requires successful completion of a <a href="https://www.w3.org/TR/turingtest/">Turing test</a> before
-      the registration form can be accessed.
-   </p></aside>
+   <aside class="example">
+      <p>After filling in a login/authentication form, the user has to successfully complete a
+      <a href="https://www.w3.org/TR/turingtest/">Turing test</a> before being logged into the site.</p>
+   </aside>
    
 </dd>

--- a/guidelines/terms/20/relative-luminance.html
+++ b/guidelines/terms/20/relative-luminance.html
@@ -45,7 +45,7 @@
   
    <p class="note">Almost all systems used today to view web content assume sRGB encoding. Unless it
       is known that another color space will be used to process and display the content,
-      authors should evaluate using sRGB colorspace. If using other color spaces, see <a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum">Understanding Success Criterion 1.4.3</a>.
+      authors should evaluate using sRGB colorspace. If using other color spaces, see <a href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum">Understanding Success Criterion 1.4.3 Contrast (Minimum)</a>.
    </p>
    
    <p class="note">If dithering occurs after delivery, then the source color value is used. For colors

--- a/guidelines/terms/21/single-pointer.html
+++ b/guidelines/terms/21/single-pointer.html
@@ -1,6 +1,6 @@
 <dt><dfn id="dfn-single-pointer">single pointer</dfn></dt>
 <dd>
-   <p>an input modality that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touch screen, or stylus</p>
+   <p>an input modality that only targets a single point on the page/screen at a time – such as a mouse, single finger on a touchscreen, or stylus</p>
    <p class="note">Single pointer interactions include clicks, double clicks, taps, dragging motions, and single-finger swipe gestures. In contrast, multipoint interactions involve the use of two or more pointers at the same time, such as two-finger interactions on a touchscreen, or the simultaneous use of a mouse and stylus.</p>
 </dd>
 

--- a/script/wcag.js
+++ b/script/wcag.js
@@ -78,7 +78,8 @@ function termTitles() {
 	// put definitions into title attributes of term references
 	document.querySelectorAll('.internalDFN').forEach(function(node){
 		var dfn = document.querySelector(node.href.substring(node.href.indexOf('#')));
-		if (dfn.parentNode.nodeName == "DT") node.title = dfn.parentNode.nextElementSibling.firstElementChild.textContent.trim().replace(/\s+/g,' ');
+		if (dfn.parentNode.nodeName == "DT")
+      node.title = dfn.parentNode.nextElementSibling.querySelector(":not(.change)").textContent.trim().replace(/\s+/g,' ');
 		else if (dfn.title) node.title=dfn.title;
 	});	
 }


### PR DESCRIPTION
**Reminder:** I plan to rebase-merge this to maintain 1 commit per erratum as well as the cherry-picking breadcrumb trail.

This backports the relevant parts of PRs referenced in #5176 from the latest [CFC for errata](https://lists.w3.org/Archives/Public/w3c-wai-gl/2026JulSep/0043.html), to the 2.1 guidelines.

All backports were performed with `git cherry-pick -x` to include information on the originating commit.

I looked at the original commits to `main` side-by-side with the cherry-picked commits on this branch to confirm their diffs are identical.

Additional notes:

* I have included #4857 in this list of backports for consistency, although it will currently have no visual effect on 2.1 because `class="change"` is never used in the context that this fix affects. As such, it has not been explicitly listed under 2.1 errata in #5176.

[Preview](https://deploy-preview-5317--wcag21.netlify.app/guidelines/)