### PR TITLE
Clarify scope of 11ty build system

### DIFF
--- a/11ty/README.md
+++ b/11ty/README.md
@@ -1,7 +1,11 @@
 # Eleventy Infrastructure for WCAG Techniques and Understanding
 
-This subdirectory contains ES Modules re-implementing pieces of the
-XSLT-based build process using Eleventy.
+This subdirectory contains ES Modules implementing the build process for the
+informative documents (Techniques and Understanding).
+It uses Eleventy, LiquidJS, and Cheerio to reimplement the previous XSLT-based build process.
+
+Note that the content under the `guidelines` folder does _not_ depend on this subdirectory
+or any of the commands listed here.
 
 ## Usage
 


### PR DESCRIPTION
This aims to avoid confusion for anyone interested specifically in working with the guidelines, which do not require interacting with `node` or `npm` at all.